### PR TITLE
docs: add guid export data from record of processing activities

### DIFF
--- a/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.en.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.en.mdx
@@ -1,0 +1,18 @@
+---
+title: Export data from the Records of processing aktivities
+description: How to transfer data from the Records of processing aktivities to your organization.
+
+---
+
+<Ingress>
+This guide provides instructions on how to log in to the Records of processing aktivities in the National Data Catalog and transfer data from the Records of processing aktivities to your organization.
+</Ingress>
+
+<Alert size='sm'>
+    The guide is only available in Norwegian.
+</Alert>
+
+
+
+
+

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.en.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.en.mdx
@@ -4,9 +4,13 @@ description: How to transfer data from the Records of processing aktivities to y
 
 ---
 
+# Export data from the Records of processing aktivities
+
 <Ingress>
 This guide provides instructions on how to log in to the Records of processing aktivities in the National Data Catalog and transfer data from the Records of processing aktivities to your organization.
 </Ingress>
+
+&nbsp;
 
 <Alert size='sm'>
     The guide is only available in Norwegian.

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.en.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.en.mdx
@@ -7,7 +7,7 @@ description: How to export data from the Records of processing aktivities to you
 # How to export your data from the Records of processing aktivities
 
 <Ingress>
-This guide provides instructions on how to log in to the Records of processing aktivities in the National Data Catalog and export data from the Records of processing aktivities to your organization.
+This guide provides instructions on how to export data from the Records of processing aktivities to your organization.
 </Ingress>
 
 &nbsp;

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.en.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.en.mdx
@@ -1,13 +1,13 @@
 ---
-title: Export data from the Records of processing aktivities
-description: How to transfer data from the Records of processing aktivities to your organization.
+title: How to export your data from the Records of processing aktivities
+description: How to export data from the Records of processing aktivities to your organization.
 
 ---
 
-# Export data from the Records of processing aktivities
+# How to export your data from the Records of processing aktivities
 
 <Ingress>
-This guide provides instructions on how to log in to the Records of processing aktivities in the National Data Catalog and transfer data from the Records of processing aktivities to your organization.
+This guide provides instructions on how to log in to the Records of processing aktivities in the National Data Catalog and export data from the Records of processing aktivities to your organization.
 </Ingress>
 
 &nbsp;

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.nb.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.nb.mdx
@@ -4,12 +4,15 @@ description: Hvordan overføre data fra Behandlingsoversikt til din egen virksom
 
 ---
 
+# Ta ut data fra Behandlingsoversikt
+
 <Ingress>
 Her får du veiledning i hvordan du logger deg inn i Felles datakatalog sin Behandlingsoversikt og hvordan du kan overføre data fra Behandlingsoversikt til din virksomhet.
 </Ingress>
 
+&nbsp;
 
-# Tilgang til Behandlingsoversikt
+## Tilgang til Behandlingsoversikt
 
 Løsningen Behandlingsoversikt ligger inne i registreringsløsningen til Felles datakatalog. For å kunne overføre data fra Behandlingsoversikt til egen virksomhet må du derfor ha tilgang til registreringsløsningen. Les mer på nettsiden [Ta i bruk Felles datakatalog](https://samarbeid.digdir.no/felles-datakatalog/ta-i-bruk-felles-datakatalog/1619) om hvordan du får tilgang til registreringsløsningen. 
  
@@ -32,12 +35,12 @@ Når du har logget inn i registreringsløsningen, klikker du på valget «Behand
 Du kommer da inn i Behandlingsoversikten for din virksomhet. 
 
 
-# Om Behandlingsaktiviteter i Behandlingsoversikt 
+## Om Behandlingsaktiviteter i Behandlingsoversikt 
 
 Alle data som din virksomhet har registrert i Behandlingsoversikt kan enkelt tas ut av løsningen og overføres til din virksomhet som rapporter. Rapporter kan genereres i HTML-format eller som CSV-filer (Comma-Separated-Values). HTML-format er tilpasset visning i nettleser og kan skrives ut eller lagres som PDF-filer. CSV-format er egnet til videre bruk i databaser eller i regneark. 
 
 
-# Slik går du fram for å generere rapporter
+## Slik går du fram for å generere rapporter
 
 Klikk på «Generer rapport»:
 
@@ -50,29 +53,29 @@ Du kan da velge mellom fire rapporter; Behandlingsoversikt, Behandlingsoversikt 
 ![Bilde som viser at knappen «Generer rapport» er valgt og at under denne er det fire rapporttyper.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_valg_generer_rapport_e74b90fefc.png)
 
 
-## Rapport «Behandlingsoversikt» og «Behandlingsoversikt CSV»
+### Rapport «Behandlingsoversikt» og «Behandlingsoversikt CSV»
 
 Rapportene «Behandlingsoversikt» og «Behandlingsoversikt CSV» inneholder alt din virksomhet har registrert i Behandlingsoversikt. Rapport «Behandlingsoversikt» genererer en HTML-side som vises i din nettleser. Rapport «Behandlingsoversikt CSV» har samme innhold som «Behandlingsoversikt», men genererer en CSV-fil som lastes ned til din PC og som deretter kan importeres til en database eller åpnes i et regneark og oppdateres videre der. Vi anbefaler å generere en eller begge disse rapportene for å sikre at all informasjon som er registrert i Behandlingsoversikt blir overført til din virksomhet.
 
 
-## Rapport «Prokoll» og «Protokoll CSV»
+### Rapport «Prokoll» og «Protokoll CSV»
 
 Rapport «Protokoll» og «Protokoll CSV» inneholder kun godkjente behandlingsprotokoller. Disse rapportene er videre avgrenset til å kun inneholde de tema som dekkes av artikkel 30  «Protokoll over behandlingsaktiviteter» i Personopplysningsloven. Rapport protokoll genererer en HTML-side som vises i din nettleser. Rapport «Protokoll CSV» har samme innhold som rapport «Protokoll», men genererer en CSV-fil som lastes ned til din PC og som deretter kan importeres til en database eller åpnes i et regneark og oppdateres videre der.
 
 
-# Generelt om tema som kan registreres i Behandlingsoversikt – og som det kan tas ut rapporter om
+## Generelt om tema som kan registreres i Behandlingsoversikt – og som det kan tas ut rapporter om
 
 Digdir har ved utvikling av Behandlingsoversikt tatt utgangspunkt i Datatilsynet sin «[Mal for behandlingsansvarliges protokoll](https://www.datatilsynet.no/rettigheter-og-plikter/virksomhetenes-plikter/protokoll-over-behandlingsaktiviteter/)». Behandlingsoversikt dekker derfor en rekke tema som er nevnt i personopplysningsloven og i Datatilsynet sin mal. Løsningen gir muligheter for å registrere kontaktopplysninger for Behandlingsansvarlig og Personvernombud, samt at den oppfyller de øvrige kravene til hva som skal registreres i henhold til artikkel 30 «Protokoller over behandlingsaktiviteter» i Personopplysningsloven. Man kan også registrere andre tema som kan være nyttig å ha registrert i tilknytning til behandlingsaktiviteter, for eksempel informasjon som er nevnt i Artikkel 6 «Behandlingens lovlighet» og artikkel 9 «Behandling av særlige kategorier av personopplysninger. I tillegg har vi lagt inn muligheter i Behandlingsoversikt for å kople behandlingsaktiviteter til virksomhetens datasettbeskrivelser i Felles datakatalog (valgfritt felt). 
 
 På de følgende sidene følger en beskrivelse av ulike rapporter som kan tas ut fra Behandlingsoversikt, samt en beskrivelse av hva rapportene inneholder. De følgende forklaringer av utskrift og lagring er basert på bruk av nettleseren Chrome Versjon 119.0.6045.200 (Offisiell delversjon) (64-bit). Vi tar derfor forbehold om at menyvalg for slik funksjonalitet kan variere mellom ulike nettlesere og ulike versjoner av Chrome.
 
 
-# Beskrivelse av rapportenes innhold
+## Beskrivelse av rapportenes innhold
 
 Her følger en mer detaljert beskrivelse av rapportenes innhold.
 
 
-## Rapport «Behandlingsoversikt»
+### Rapport «Behandlingsoversikt»
 
 Dette er det første alternativet i rapport-menyen:
 
@@ -95,7 +98,7 @@ For tema som det ikke er utfylt noe i, vises allikevel overskriften. Dette gjeld
 Rapport «Behandlingsoversikt» kan skrives ut ved å velge «Skriv ut» i din nettleser. Den kan også lagres som PDF-fil. Dette gjør du ved å velge «Skriv ut» i nettleser og deretter velge «Destinasjon» - «Lagre som PDF».
 
 
-## Rapport «Behandlingsoversikt CSV»
+### Rapport «Behandlingsoversikt CSV»
 
 Dette er det andre valget i rapport-menyen:
 
@@ -128,7 +131,7 @@ Som det fremgår her, brukes et separatortegn dersom det er oppgitt flere regist
 Filen kan behandles videre i for eksempel et regneark. Man kan da for eksempel legge inn flere navn på «Daglig behandlingsansvarlig» og skille navnene med «separatortegnet» som ofte finnes opp til venstre på tastaturet, gjerne på samme tast som paragraf-tegnet ligger på.
 
 
-## Rapport «Protokoll» og «Protokoll CSV»
+### Rapport «Protokoll» og «Protokoll CSV»
 
 Rapport Prokoll og rapport Protokoll CSV inneholder kun godkjente behandlingsaktiviteter. Rapporten er videre avgrenset til å kun gjelde tema som inngår i artikkel 30.
 
@@ -151,14 +154,14 @@ Dersom registeringsfeltene under «Kontaktinformasjon» og «Personvernombud» <
 Når registeringsfeltene under «Kontaktinformasjon» og «Personvernombud» er utfylt, kan man starte generering av rapport «Prokoll» og «Protokoll CSV».  Merk at i tillegg til at rapportene inneholder kun godkjente behandlingsaktiviteter, er innholdet i hver behandlingsaktivitet videre avgrenset til å kun omhandle de tema som er merket som «Obligatorisk» i registreringsløsningen. Det vil si at rapportene inneholder kun artikkel 30-temaene (protokoll-kravene) samt navn på behandlingsaktiviteten. «Protokoll CSV» viser i tillegg organisasjonsnummeret til virksomheten. Valgfrie tema i registeringsløsningen vises derfor ikke i disse rapportene.
 
 
-### Rapport «Protokoll»
+#### Rapport «Protokoll»
 
 For at en behandlingsaktivitet skal få status godkjent, og derved kunne vises i rapport «Protokoll», må alle obligatoriske tema i behandlingsaktiviteten være utfylt, samt at behandlingsaktiviteten må ha status som «Godkjent». Godkjenning foregår ved å klikke på Godkjenn-knappen nederst inne i registreringsvinduet for den enkelte behandlingsaktivitet. Her er eksempel fra rapport Protokoll:
 
 ![Bilde av et eksempel på rapport «Protokoll» som HTML.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_protokoll_html_6e789eaad5.png)
 
 
-### Rapport «Protokoll CSV»
+#### Rapport «Protokoll CSV»
 
 Rapport «Protokoll CSV» har samme innhold som HTML-rapport «Protokoll». I tillegg inneholder den virksomhetens organisasjonsnummer. Den åpnes på samme måte som rapport «Behandlingsoversikt CSV». Her er eksempel fra rapport «Protokoll CSV», åpnet i MS Excel:
 

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.nb.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.nb.mdx
@@ -7,37 +7,8 @@ description: Veiledning i hvordan hente ut data fra Behandlingsoversikt til din 
 # Hvordan hente ut dine data fra Behandlingsoversikt
 
 <Ingress>
-Her får du veiledning i hvordan du logger deg inn i Felles datakatalog sin Behandlingsoversikt og hvordan du kan hente ut data fra Behandlingsoversikt til din virksomhet.
+Alle data som din virksomhet har registrert i Behandlingsoversikt kan enkelt tas ut av løsningen og overføres til din virksomhet som rapporter. Rapporter kan genereres i HTML-format eller som CSV-filer (Comma-Separated-Values). HTML-format er tilpasset visning i nettleser og kan skrives ut eller lagres som PDF-filer. CSV-format er egnet til videre bruk i databaser eller i regneark.
 </Ingress>
-
-&nbsp;
-
-## Tilgang til Behandlingsoversikt
-
-Løsningen Behandlingsoversikt ligger inne i registreringsløsningen til Felles datakatalog. For å kunne hente ut data fra Behandlingsoversikt til egen virksomhet må du derfor ha tilgang til registreringsløsningen. Les mer på nettsiden [Ta i bruk Felles datakatalog](https://samarbeid.digdir.no/felles-datakatalog/ta-i-bruk-felles-datakatalog/1619) om hvordan du får tilgang til registreringsløsningen. 
- 
-Når du har fått tilgang, åpner du nettsiden [Publisere i Felles datakatalog](https://data.norge.no/publishing) og klikker på lenken «Logg inn for å registrere» til venstre i skjermbildet:
-
-![Bilde som viser hvor man trykker for å logge inn på registreringsløsningen.](https://cms.fellesdatakatalog.digdir.no/uploads/Innlogging_registrering_c38f43d43a.png)
-
-&nbsp;
-
-Deretter velger du “Logg inn via ID-porten" til venstre i skjermbildet. Du kan eventuelt velge “Logg inn via Felles brukerhåndtering” dersom du tidligere har fått tilgang til å logge inn via denne løsningen. Ansatte i Brønnøysundregistrene og Skatteetaten kan eventuelt logge inn via egne innloggingsløsninger.
-
-![Bilde som viser de forskjellige innloggingsalternativene.](https://cms.fellesdatakatalog.digdir.no/uploads/Innlogging_alternativer_62081aab4d.png)
-
-&nbsp;
-
-Når du har logget inn i registreringsløsningen, klikker du på valget «Behandlingsoversikt».
-
-![Bilde som viser oversikt over hvilke kataloger som finnes for en virksomhet](https://cms.fellesdatakatalog.digdir.no/uploads/Registreringslosning_alle_kataloger_Behandlingsoversikt_d3c4c63095.png)
-
-Du kommer da inn i Behandlingsoversikten for din virksomhet. 
-
-
-## Om Behandlingsaktiviteter i Behandlingsoversikt 
-
-Alle data som din virksomhet har registrert i Behandlingsoversikt kan enkelt tas ut av løsningen og overføres til din virksomhet som rapporter. Rapporter kan genereres i HTML-format eller som CSV-filer (Comma-Separated-Values). HTML-format er tilpasset visning i nettleser og kan skrives ut eller lagres som PDF-filer. CSV-format er egnet til videre bruk i databaser eller i regneark. 
 
 
 ## Slik går du fram for å generere rapporter
@@ -52,46 +23,21 @@ Du kan da velge mellom fire rapporter; Behandlingsoversikt, Behandlingsoversikt 
 
 ![Bilde som viser at knappen «Generer rapport» er valgt og at under denne er det fire rapporttyper.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_valg_generer_rapport_e74b90fefc.png)
 
-
-### Rapport «Behandlingsoversikt» og «Behandlingsoversikt CSV»
-
-Rapportene «Behandlingsoversikt» og «Behandlingsoversikt CSV» inneholder alt din virksomhet har registrert i Behandlingsoversikt. Rapport «Behandlingsoversikt» genererer en HTML-side som vises i din nettleser. Rapport «Behandlingsoversikt CSV» har samme innhold som «Behandlingsoversikt», men genererer en CSV-fil som lastes ned til din PC og som deretter kan importeres til en database eller åpnes i et regneark og oppdateres videre der. Vi anbefaler å generere en eller begge disse rapportene for å sikre at all informasjon som er registrert i Behandlingsoversikt blir overført til din virksomhet.
-
-
-### Rapport «Prokoll» og «Protokoll CSV»
-
-Rapport «Protokoll» og «Protokoll CSV» inneholder kun godkjente behandlingsprotokoller. Disse rapportene er videre avgrenset til å kun inneholde de tema som dekkes av artikkel 30  «Protokoll over behandlingsaktiviteter» i Personopplysningsloven. Rapport protokoll genererer en HTML-side som vises i din nettleser. Rapport «Protokoll CSV» har samme innhold som rapport «Protokoll», men genererer en CSV-fil som lastes ned til din PC og som deretter kan importeres til en database eller åpnes i et regneark og oppdateres videre der.
-
-
-## Generelt om tema som kan registreres i Behandlingsoversikt – og som det kan tas ut rapporter om
-
-Digdir har ved utvikling av Behandlingsoversikt tatt utgangspunkt i Datatilsynet sin «[Mal for behandlingsansvarliges protokoll](https://www.datatilsynet.no/rettigheter-og-plikter/virksomhetenes-plikter/protokoll-over-behandlingsaktiviteter/)». Behandlingsoversikt dekker derfor en rekke tema som er nevnt i personopplysningsloven og i Datatilsynet sin mal. Løsningen gir muligheter for å registrere kontaktopplysninger for Behandlingsansvarlig og Personvernombud, samt at den oppfyller de øvrige kravene til hva som skal registreres i henhold til artikkel 30 «Protokoller over behandlingsaktiviteter» i Personopplysningsloven. Man kan også registrere andre tema som kan være nyttig å ha registrert i tilknytning til behandlingsaktiviteter, for eksempel informasjon som er nevnt i Artikkel 6 «Behandlingens lovlighet» og artikkel 9 «Behandling av særlige kategorier av personopplysninger. I tillegg har vi lagt inn muligheter i Behandlingsoversikt for å kople behandlingsaktiviteter til virksomhetens datasettbeskrivelser i Felles datakatalog (valgfritt felt). 
-
-På de følgende sidene følger en beskrivelse av ulike rapporter som kan tas ut fra Behandlingsoversikt, samt en beskrivelse av hva rapportene inneholder. De følgende forklaringer av utskrift og lagring er basert på bruk av nettleseren Chrome Versjon 119.0.6045.200 (Offisiell delversjon) (64-bit). Vi tar derfor forbehold om at menyvalg for slik funksjonalitet kan variere mellom ulike nettlesere og ulike versjoner av Chrome.
-
-
-## Beskrivelse av rapportenes innhold
-
-Her følger en mer detaljert beskrivelse av rapportenes innhold.
-
+&nbsp;
 
 ### Rapport «Behandlingsoversikt»
 
-Dette er det første alternativet i rapport-menyen:
+Rapportvalget genererer en HTML-rapport som inkluderer alt virksomheten har registrert under «Kontaktinformasjon» og «Personvernombud», samt all informasjon knyttet til behandlingsaktiviteter. Rapporten dekker både behandlingsaktiviteter med status «Godkjent» og de som er merket som «Utkast».
 
-![Bilde som viser de fire rapporttypene under knappen «Generer rapport».](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapportalternativer_877d5421ad.png)
+Rapporten begynner med å vise innholdet fra seksjonene «Kontaktinformasjon» og «Personvernombud». Deretter presenteres hver behandlingsaktivitet fortløpende, med tilhørende registreringsfelt.
 
-Rapportvalget genererer en HTML-rapport som inneholder alt din virksomhet har registrert i bolkene «Kontaktinformasjon» og «Personvernombud», samt alt som er registrert i samtlige behandlingsaktiviteter. Rapporten inneholder derfor både behandlingsaktiviteter med status «Godkjent» og behandlingsaktiviteter som har status «Utkast».
-
-Rapporten starter med å vise alt som er registret i bolkene «Kontaktinformasjon» og «Personvernombud». Deretter vises en og en behandlingsaktivitet i rekkefølge, med hver sine respektive registeringsfelter per behandlingsaktivitet.
-
-I det følgende eksempelet fremgår det at rapporten starter med å vise navn på virksomheten. Videre viser den hva som er registrert under «Kontaktinformasjon» og «Personvernombud» og deretter ser man starten på informasjonen tilknyttet behandlingsaktiviteten «Ansettelser»:
+I eksempelet nedenfor starter rapporten med virksomhetens navn, etterfulgt av registreringene under «Kontaktinformasjon» og «Personvernombud», før den viser informasjonen for behandlingsaktiviteten «Ansettelser».
 
 ![Bilde av et eksempel på rapport «Behandlingsoversikt» som HTML.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_html_b319cdf7da.png)
 
-Tema som omhandler artikkel 30 «Protokoller over behandlingsaktiviteter» i Personopplysningsloven er merket «Obligatorisk» i rapporten. Alle obligatoriske felt i en behandlingsaktivitet må fylles ut før man kan godkjenne behandlingsaktiviteten. Under overskriften «Ansettelser» fremgår det at denne rapporten er godkjent.
+Tema knyttet til artikkel 30 «Protokoller over behandlingsaktiviteter» i Personopplysningsloven er markert som «Obligatorisk» i rapporten. Alle obligatoriske felt i en behandlingsaktivitet må være utfylt før godkjenning kan skje. Under overskriften «Ansettelser» vises det at denne rapporten er godkjent.
 
-For tema som det ikke er utfylt noe i, vises allikevel overskriften. Dette gjelder både for behandlingsaktiviteter som står med status «Godkjent» og de som står med status «Utkast». Nedenfor er et eksempel fra rapport hvor det vises utdrag fra behandlingsaktiviteten «Lønn». I overskriften fremgår det at behandlingsaktiviteten står med status «Utkast». Videre ser man at det ikke er fylt ut noe i de valgfrie feltene «Daglig behandlingsansvar» og «Databehandlere og databehandler», og at det er angitt «Nei» i det obligatoriske feltet «Felles behandlingsansvar».
+Selv om enkelte temaer ikke er utfylt, vil overskriften fortsatt vises. Dette gjelder for både godkjente behandlingsaktiviteter og de som har status «Utkast». Nedenfor vises et eksempel fra rapporten med utdrag fra behandlingsaktiviteten «Lønn». Her fremgår det at statusen til behandlingsaktiviteten er «Utkast». Det er tydelig at de valgfrie feltene «Daglig behandlingsansvar» og «Databehandlere og databehandler» ikke er fylt ut, og at det obligatoriske feltet «Felles behandlingsansvar» er angitt med «Nei».
 
 ![Bilde av et eksempel på rapport «Behandlingsoversikt» som HTML og uten innhold.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_html_tema_uten_innhold_97c2aba9fe.png)
 
@@ -100,74 +46,41 @@ Rapport «Behandlingsoversikt» kan skrives ut ved å velge «Skriv ut» i din n
 
 ### Rapport «Behandlingsoversikt CSV»
 
-Dette er det andre valget i rapport-menyen:
-
-![Bilde som viser de fire rapporttypene under knappen «Generer rapport».](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapportalternativer_877d5421ad.png)
-
-Rapporten genererer en CSV-fil som kan importeres i database eller i regneark. All informasjon som er registrert i Behandlingsoversikt vises i rader og kolonner i filen.
-
-Filen blir automatisk lastet ned til din PC når du klikker på «Behandlingsoversikt CSV». Sjekk i logg over nylige nedlastinger eller i mappen «Nedlastinger» om den er lagt der. Her er eksempel fra på hvordan det fremgår at filen er generert:
-
-![Bilde som viser at filen «behandlingsoversikt.csv» ligger i loggen over nylige nedlastinger.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_CSV_nedlasting_060b603946.png)
-
-&nbsp;
-
-Rapporten dekker samme innhold som rapport «Behandlingsoversikt, men inneholder i tillegg virksomhetens organisasjonsnummer. Her er et eksempel på rapport «Behandlingsoversikt CSV» åpnet i MS Excel: 
+Rapporten «Behandlingsoversikt CSV» genererer en CSV-fil som inneholder det samme som HTML-rapporten, med tillegg av virksomhetens organisasjonsnummer. Filen lastes automatisk ned til PC-en din. Sjekk loggen over nylige nedlastinger eller mappen «Nedlastinger» for å finne filen. Deretter kan filen importeres til en database eller åpnes i et regneark for videre bearbeiding. Nedenfor er et eksempel på rapport «Behandlingsoversikt CSV» åpnet i MS Excel: 
 
 ![Bilde som viser eksempel på rapport «Behandlingsoversikt CSV» åpnet i MS Excel.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_CSV_eksempel1_127c7da850.png)
 
-Hver rad representerer en behandlingsaktivitet. Tema i kolonnene følger i hovedsak samme rekkefølge som tema i registreringsløsningen. Først kommer Navn på virksomheten, så organisasjonsnummer, informasjon fra de ulike feltene under «Kontaktinformasjon» og «Personvernombud» og til slutt temaene i de ulike feltene knyttet til hver behandlingsaktivitet. Navn på behandlingsaktiviteten ligger for eksempel i kolonne P. Merk at «Organisasjonsnummer» vises kun i CSV-rapportene.
+Hver rad representerer en behandlingsaktivitet. Tema i kolonnene følger i hovedsak samme rekkefølge som tema i registreringsløsningen. Navn på behandlingsaktiviteten ligger i kolonne P.
 
-Tema som kan gjentas med flere registreringer blir separert i kolonnene. Nedenfor følger er eksempel fra registeringsløsningen, og deretter med visning av tilsvarende felter og data i CSV-fil. I dette eksempelet er det registrert to navn med tilhørende telefon og epost under «Daglig behandlingsansvarlig i behandlingsaktiviteten «Lønn» i registeringsløsningen:
+Temaer med flere registreringer blir adskilt i kolonnene ved hjelp av separatoren «|». Nedenfor vises et eksempel på en CSV-fil hvor tre personer er registrert som «Daglig behandlingsansvarlig» i behandlingsaktiviteten «Lønn».
 
-![Bilde som viser at det er registrert to personer med daglig behandlingsansvar for en behandlingsaktivitet.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_behandlingsaktivitet_daglig_behandlingsansvar_4f84aa1572.png)
-
-I CSV-filen «Behandlingsoversikt CSV» vises samme informasjon fra behandlingsaktiviteten «Lønn»:
-
-![Bilde som viser eksempel på rapport Behandlingsoversikt CSV» åpnet i MC Excel der det er registrert to personer med daglig behandlingsansvar for en behandlingsaktivitet.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_CSV_eksempel_Lonn_52c0a151a2.png)
-
-Som det fremgår her, brukes et separatortegn dersom det er oppgitt flere registeringer innen et tema. I eksempelet fremgår det i kolonne R at det i behandlingsaktiviteten «Lønn» er tre «Daglig behandlingsansvarlige».  I kolonne S vises telefonnummer i samme rekkefølge som navnene. Det betyr at Jan Jansen har telefon 22334455 og Nils Nilsen har telefon 33445566. For Tor Torsen er det ikke registrert noe telefonnummer.
-
-Filen kan behandles videre i for eksempel et regneark. Man kan da for eksempel legge inn flere navn på «Daglig behandlingsansvarlig» og skille navnene med «separatortegnet» som ofte finnes opp til venstre på tastaturet, gjerne på samme tast som paragraf-tegnet ligger på.
-
-
-### Rapport «Protokoll» og «Protokoll CSV»
-
-Rapport Prokoll og rapport Protokoll CSV inneholder kun godkjente behandlingsaktiviteter. Rapporten er videre avgrenset til å kun gjelde tema som inngår i artikkel 30.
-
-Rapport “Protokoll” er en HTML-rapport og er det 3. valget i rapportmenyen:
-
-![Bilde som viser de fire rapporttypene under knappen «Generer rapport».](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapportalternativer_877d5421ad.png)
+![Bilde som viser eksempel på rapport Behandlingsoversikt CSV» åpnet i MC Excel der det er registrert tre personer med daglig behandlingsansvar for en behandlingsaktivitet.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_CSV_eksempel_Lonn_52c0a151a2.png)
 
 &nbsp;
 
-For å kunne generere rapportene «Protokoll» og «Protokoll CSV», må de obligatoriske feltene under temaene «Kontaktinformasjon» og «Personvernombud» være utfylt:
+### Rapport «Protokoll»
+
+Rapportvalget genererer en HTML-rapport som kun inkluderer godkjente behandlingsaktiviteter, avgrenset til temaene som omfattes av artikkel 30. For å kunne opprette denne rapporten, må alle obligatoriske felter under «Kontaktinformasjon» og «Personvernombud» være utfylt.
 
 ![Bilde som viser temaene «Kontaktinformasjon» og «Personvernombud» i Behandlingsoversikt.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_kontakt_og_personvern_1b17c54e27.png)
 
 &nbsp;
 
-Dersom registeringsfeltene under «Kontaktinformasjon» og «Personvernombud» <u>ikke</u> er fylt ut, blir rapportvalgene «Protokoll» og «Protokoll CSV» vist med grå tekst i menyen hvor man velger rapport. Det betyr at det ikke er mulig å generere rapportene:
+Dersom feltene under «Kontaktinformasjon» og «Personvernombud» ikke er utfylt, vil rapportvalgene «Protokoll» og «Protokoll CSV» vises som grået ut i rapportmenyen.
 
-![Bilde som viser at rapporttypene «Protokoll» og «Protokoll CSV» er deaktivert under knappen «Generer rapport».](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapportalternativer_manglende_utfylling_722200b988.png)
-
-Når registeringsfeltene under «Kontaktinformasjon» og «Personvernombud» er utfylt, kan man starte generering av rapport «Prokoll» og «Protokoll CSV».  Merk at i tillegg til at rapportene inneholder kun godkjente behandlingsaktiviteter, er innholdet i hver behandlingsaktivitet videre avgrenset til å kun omhandle de tema som er merket som «Obligatorisk» i registreringsløsningen. Det vil si at rapportene inneholder kun artikkel 30-temaene (protokoll-kravene) samt navn på behandlingsaktiviteten. «Protokoll CSV» viser i tillegg organisasjonsnummeret til virksomheten. Valgfrie tema i registeringsløsningen vises derfor ikke i disse rapportene.
-
-
-#### Rapport «Protokoll»
-
-For at en behandlingsaktivitet skal få status godkjent, og derved kunne vises i rapport «Protokoll», må alle obligatoriske tema i behandlingsaktiviteten være utfylt, samt at behandlingsaktiviteten må ha status som «Godkjent». Godkjenning foregår ved å klikke på Godkjenn-knappen nederst inne i registreringsvinduet for den enkelte behandlingsaktivitet. Her er eksempel fra rapport Protokoll:
+For at en behandlingsaktivitet skal vises i rapporten «Protokoll», må alle obligatoriske temaer i aktiviteten være fylt ut, og aktiviteten må ha status «Godkjent». Godkjenning gjøres ved å klikke på Godkjenn-knappen nederst i registreringsvinduet for den aktuelle behandlingsaktiviteten. Her er et eksempel fra rapporten «Protokoll»:
 
 ![Bilde av et eksempel på rapport «Protokoll» som HTML.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_protokoll_html_6e789eaad5.png)
 
+&nbsp;
 
-#### Rapport «Protokoll CSV»
+### Rapport «Protokoll CSV»
 
-Rapport «Protokoll CSV» har samme innhold som HTML-rapport «Protokoll». I tillegg inneholder den virksomhetens organisasjonsnummer. Den åpnes på samme måte som rapport «Behandlingsoversikt CSV». Her er eksempel fra rapport «Protokoll CSV», åpnet i MS Excel:
+Rapporten «Protokoll CSV» genererer en CSV-fil med samme innhold som HTML-rapporten, men med virksomhetens organisasjonsnummer som tillegg. Den åpnes på samme måte som rapporten «Behandlingsoversikt CSV». Nedenfor er et eksempel på rapporten «Protokoll CSV», åpnet i MS Excel:
 
 ![Bilde som viser et eksempel på rapport «Protokoll CSV» åpnet i MS Excel.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_protokoll_CSV_eksempel_eba15ff1ec.png)
 
 &nbsp;
 
-Om du har spørsmål til bruk av Behandlingsoversikt, eller trenger hjelp med generering av rapporter, kan du ta kontakt med oss på epost-adresse [fellesdatakatalog@digdir.no](mailto:fellesdatakatalog@digdir.no)
+Har du spørsmål om bruk av Behandlingsoversikt eller trenger hjelp med rapportgenerering, kan du kontakte oss på e-post: [fellesdatakatalog@digdir.no](mailto:fellesdatakatalog@digdir.no)
 

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.nb.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.nb.mdx
@@ -1,0 +1,170 @@
+---
+title: Ta ut data fra Behandlingsoversikt
+description: Hvordan overføre data fra Behandlingsoversikt til din egen virksomhet. 
+
+---
+
+<Ingress>
+Her får du veiledning i hvordan du logger deg inn i Felles datakatalog sin Behandlingsoversikt og hvordan du kan overføre data fra Behandlingsoversikt til din virksomhet.
+</Ingress>
+
+
+# Tilgang til Behandlingsoversikt
+
+Løsningen Behandlingsoversikt ligger inne i registreringsløsningen til Felles datakatalog. For å kunne overføre data fra Behandlingsoversikt til egen virksomhet må du derfor ha tilgang til registreringsløsningen. Les mer på nettsiden [Ta i bruk Felles datakatalog](https://samarbeid.digdir.no/felles-datakatalog/ta-i-bruk-felles-datakatalog/1619) om hvordan du får tilgang til registreringsløsningen. 
+ 
+Når du har fått tilgang, åpner du nettsiden [Publisere i Felles datakatalog](https://data.norge.no/publishing) og klikker på lenken «Logg inn for å registrere» til venstre i skjermbildet:
+
+![Bilde som viser hvor man trykker for å logge inn på registreringsløsningen.](https://cms.fellesdatakatalog.digdir.no/uploads/Innlogging_registrering_c38f43d43a.png)
+
+&nbsp;
+
+Deretter velger du “Logg inn via ID-porten" til venstre i skjermbildet. Du kan eventuelt velge “Logg inn via Felles brukerhåndtering” dersom du tidligere har fått tilgang til å logge inn via denne løsningen. Ansatte i Brønnøysundregistrene og Skatteetaten kan eventuelt logge inn via egne innloggingsløsninger.
+
+![Bilde som viser de forskjellige innloggingsalternativene.](https://cms.fellesdatakatalog.digdir.no/uploads/Innlogging_alternativer_62081aab4d.png)
+
+&nbsp;
+
+Når du har logget inn i registreringsløsningen, klikker du på valget «Behandlingsoversikt».
+
+![Bilde som viser oversikt over hvilke kataloger som finnes for en virksomhet](https://cms.fellesdatakatalog.digdir.no/uploads/Registreringslosning_alle_kataloger_Behandlingsoversikt_d3c4c63095.png)
+
+Du kommer da inn i Behandlingsoversikten for din virksomhet. 
+
+
+# Om Behandlingsaktiviteter i Behandlingsoversikt 
+
+Alle data som din virksomhet har registrert i Behandlingsoversikt kan enkelt tas ut av løsningen og overføres til din virksomhet som rapporter. Rapporter kan genereres i HTML-format eller som CSV-filer (Comma-Separated-Values). HTML-format er tilpasset visning i nettleser og kan skrives ut eller lagres som PDF-filer. CSV-format er egnet til videre bruk i databaser eller i regneark. 
+
+
+# Slik går du fram for å generere rapporter
+
+Klikk på «Generer rapport»:
+
+![Bilde som viser hvor knappen «Generer rapport» er på behandlingsoversiktsiden.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_knapp_generer_rapport_5dc8ab6b63.png)
+
+&nbsp;
+
+Du kan da velge mellom fire rapporter; Behandlingsoversikt, Behandlingsoversikt CSV, Protokoll og Protokoll CSV:
+
+![Bilde som viser at knappen «Generer rapport» er valgt og at under denne er det fire rapporttyper.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_valg_generer_rapport_e74b90fefc.png)
+
+
+## Rapport «Behandlingsoversikt» og «Behandlingsoversikt CSV»
+
+Rapportene «Behandlingsoversikt» og «Behandlingsoversikt CSV» inneholder alt din virksomhet har registrert i Behandlingsoversikt. Rapport «Behandlingsoversikt» genererer en HTML-side som vises i din nettleser. Rapport «Behandlingsoversikt CSV» har samme innhold som «Behandlingsoversikt», men genererer en CSV-fil som lastes ned til din PC og som deretter kan importeres til en database eller åpnes i et regneark og oppdateres videre der. Vi anbefaler å generere en eller begge disse rapportene for å sikre at all informasjon som er registrert i Behandlingsoversikt blir overført til din virksomhet.
+
+
+## Rapport «Prokoll» og «Protokoll CSV»
+
+Rapport «Protokoll» og «Protokoll CSV» inneholder kun godkjente behandlingsprotokoller. Disse rapportene er videre avgrenset til å kun inneholde de tema som dekkes av artikkel 30  «Protokoll over behandlingsaktiviteter» i Personopplysningsloven. Rapport protokoll genererer en HTML-side som vises i din nettleser. Rapport «Protokoll CSV» har samme innhold som rapport «Protokoll», men genererer en CSV-fil som lastes ned til din PC og som deretter kan importeres til en database eller åpnes i et regneark og oppdateres videre der.
+
+
+# Generelt om tema som kan registreres i Behandlingsoversikt – og som det kan tas ut rapporter om
+
+Digdir har ved utvikling av Behandlingsoversikt tatt utgangspunkt i Datatilsynet sin «[Mal for behandlingsansvarliges protokoll](https://www.datatilsynet.no/rettigheter-og-plikter/virksomhetenes-plikter/protokoll-over-behandlingsaktiviteter/)». Behandlingsoversikt dekker derfor en rekke tema som er nevnt i personopplysningsloven og i Datatilsynet sin mal. Løsningen gir muligheter for å registrere kontaktopplysninger for Behandlingsansvarlig og Personvernombud, samt at den oppfyller de øvrige kravene til hva som skal registreres i henhold til artikkel 30 «Protokoller over behandlingsaktiviteter» i Personopplysningsloven. Man kan også registrere andre tema som kan være nyttig å ha registrert i tilknytning til behandlingsaktiviteter, for eksempel informasjon som er nevnt i Artikkel 6 «Behandlingens lovlighet» og artikkel 9 «Behandling av særlige kategorier av personopplysninger. I tillegg har vi lagt inn muligheter i Behandlingsoversikt for å kople behandlingsaktiviteter til virksomhetens datasettbeskrivelser i Felles datakatalog (valgfritt felt). 
+
+På de følgende sidene følger en beskrivelse av ulike rapporter som kan tas ut fra Behandlingsoversikt, samt en beskrivelse av hva rapportene inneholder. De følgende forklaringer av utskrift og lagring er basert på bruk av nettleseren Chrome Versjon 119.0.6045.200 (Offisiell delversjon) (64-bit). Vi tar derfor forbehold om at menyvalg for slik funksjonalitet kan variere mellom ulike nettlesere og ulike versjoner av Chrome.
+
+
+# Beskrivelse av rapportenes innhold
+
+Her følger en mer detaljert beskrivelse av rapportenes innhold.
+
+
+## Rapport «Behandlingsoversikt»
+
+Dette er det første alternativet i rapport-menyen:
+
+![Bilde som viser de fire rapporttypene under knappen «Generer rapport».](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapportalternativer_877d5421ad.png)
+
+Rapportvalget genererer en HTML-rapport som inneholder alt din virksomhet har registrert i bolkene «Kontaktinformasjon» og «Personvernombud», samt alt som er registrert i samtlige behandlingsaktiviteter. Rapporten inneholder derfor både behandlingsaktiviteter med status «Godkjent» og behandlingsaktiviteter som har status «Utkast».
+
+Rapporten starter med å vise alt som er registret i bolkene «Kontaktinformasjon» og «Personvernombud». Deretter vises en og en behandlingsaktivitet i rekkefølge, med hver sine respektive registeringsfelter per behandlingsaktivitet.
+
+I det følgende eksempelet fremgår det at rapporten starter med å vise navn på virksomheten. Videre viser den hva som er registrert under «Kontaktinformasjon» og «Personvernombud» og deretter ser man starten på informasjonen tilknyttet behandlingsaktiviteten «Ansettelser»:
+
+![Bilde av et eksempel på rapport «Behandlingsoversikt» som HTML.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_html_b319cdf7da.png)
+
+Tema som omhandler artikkel 30 «Protokoller over behandlingsaktiviteter» i Personopplysningsloven er merket «Obligatorisk» i rapporten. Alle obligatoriske felt i en behandlingsaktivitet må fylles ut før man kan godkjenne behandlingsaktiviteten. Under overskriften «Ansettelser» fremgår det at denne rapporten er godkjent.
+
+For tema som det ikke er utfylt noe i, vises allikevel overskriften. Dette gjelder både for behandlingsaktiviteter som står med status «Godkjent» og de som står med status «Utkast». Nedenfor er et eksempel fra rapport hvor det vises utdrag fra behandlingsaktiviteten «Lønn». I overskriften fremgår det at behandlingsaktiviteten står med status «Utkast». Videre ser man at det ikke er fylt ut noe i de valgfrie feltene «Daglig behandlingsansvar» og «Databehandlere og databehandler», og at det er angitt «Nei» i det obligatoriske feltet «Felles behandlingsansvar».
+
+![Bilde av et eksempel på rapport «Behandlingsoversikt» som HTML og uten innhold.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_html_tema_uten_innhold_97c2aba9fe.png)
+
+Rapport «Behandlingsoversikt» kan skrives ut ved å velge «Skriv ut» i din nettleser. Den kan også lagres som PDF-fil. Dette gjør du ved å velge «Skriv ut» i nettleser og deretter velge «Destinasjon» - «Lagre som PDF».
+
+
+## Rapport «Behandlingsoversikt CSV»
+
+Dette er det andre valget i rapport-menyen:
+
+![Bilde som viser de fire rapporttypene under knappen «Generer rapport».](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapportalternativer_877d5421ad.png)
+
+Rapporten genererer en CSV-fil som kan importeres i database eller i regneark. All informasjon som er registrert i Behandlingsoversikt vises i rader og kolonner i filen.
+
+Filen blir automatisk lastet ned til din PC når du klikker på «Behandlingsoversikt CSV». Sjekk i logg over nylige nedlastinger eller i mappen «Nedlastinger» om den er lagt der. Her er eksempel fra på hvordan det fremgår at filen er generert:
+
+![Bilde som viser at filen «behandlingsoversikt.csv» ligger i loggen over nylige nedlastinger.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_CSV_nedlasting_060b603946.png)
+
+&nbsp;
+
+Rapporten dekker samme innhold som rapport «Behandlingsoversikt, men inneholder i tillegg virksomhetens organisasjonsnummer. Her er et eksempel på rapport «Behandlingsoversikt CSV» åpnet i MS Excel: 
+
+![Bilde som viser eksempel på rapport «Behandlingsoversikt CSV» åpnet i MS Excel.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_CSV_eksempel1_127c7da850.png)
+
+Hver rad representerer en behandlingsaktivitet. Tema i kolonnene følger i hovedsak samme rekkefølge som tema i registreringsløsningen. Først kommer Navn på virksomheten, så organisasjonsnummer, informasjon fra de ulike feltene under «Kontaktinformasjon» og «Personvernombud» og til slutt temaene i de ulike feltene knyttet til hver behandlingsaktivitet. Navn på behandlingsaktiviteten ligger for eksempel i kolonne P. Merk at «Organisasjonsnummer» vises kun i CSV-rapportene.
+
+Tema som kan gjentas med flere registreringer blir separert i kolonnene. Nedenfor følger er eksempel fra registeringsløsningen, og deretter med visning av tilsvarende felter og data i CSV-fil. I dette eksempelet er det registrert to navn med tilhørende telefon og epost under «Daglig behandlingsansvarlig i behandlingsaktiviteten «Lønn» i registeringsløsningen:
+
+![Bilde som viser at det er registrert to personer med daglig behandlingsansvar for en behandlingsaktivitet.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_behandlingsaktivitet_daglig_behandlingsansvar_4f84aa1572.png)
+
+I CSV-filen «Behandlingsoversikt CSV» vises samme informasjon fra behandlingsaktiviteten «Lønn»:
+
+![Bilde som viser eksempel på rapport Behandlingsoversikt CSV» åpnet i MC Excel der det er registrert to personer med daglig behandlingsansvar for en behandlingsaktivitet.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_CSV_eksempel_Lonn_52c0a151a2.png)
+
+Som det fremgår her, brukes et separatortegn dersom det er oppgitt flere registeringer innen et tema. I eksempelet fremgår det i kolonne R at det i behandlingsaktiviteten «Lønn» er tre «Daglig behandlingsansvarlige».  I kolonne S vises telefonnummer i samme rekkefølge som navnene. Det betyr at Jan Jansen har telefon 22334455 og Nils Nilsen har telefon 33445566. For Tor Torsen er det ikke registrert noe telefonnummer.
+
+Filen kan behandles videre i for eksempel et regneark. Man kan da for eksempel legge inn flere navn på «Daglig behandlingsansvarlig» og skille navnene med «separatortegnet» som ofte finnes opp til venstre på tastaturet, gjerne på samme tast som paragraf-tegnet ligger på.
+
+
+## Rapport «Protokoll» og «Protokoll CSV»
+
+Rapport Prokoll og rapport Protokoll CSV inneholder kun godkjente behandlingsaktiviteter. Rapporten er videre avgrenset til å kun gjelde tema som inngår i artikkel 30.
+
+Rapport “Protokoll” er en HTML-rapport og er det 3. valget i rapportmenyen:
+
+![Bilde som viser de fire rapporttypene under knappen «Generer rapport».](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapportalternativer_877d5421ad.png)
+
+&nbsp;
+
+For å kunne generere rapportene «Protokoll» og «Protokoll CSV», må de obligatoriske feltene under temaene «Kontaktinformasjon» og «Personvernombud» være utfylt:
+
+![Bilde som viser temaene «Kontaktinformasjon» og «Personvernombud» i Behandlingsoversikt.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_kontakt_og_personvern_1b17c54e27.png)
+
+&nbsp;
+
+Dersom registeringsfeltene under «Kontaktinformasjon» og «Personvernombud» <u>ikke</u> er fylt ut, blir rapportvalgene «Protokoll» og «Protokoll CSV» vist med grå tekst i menyen hvor man velger rapport. Det betyr at det ikke er mulig å generere rapportene:
+
+![Bilde som viser at rapporttypene «Protokoll» og «Protokoll CSV» er deaktivert under knappen «Generer rapport».](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapportalternativer_manglende_utfylling_722200b988.png)
+
+Når registeringsfeltene under «Kontaktinformasjon» og «Personvernombud» er utfylt, kan man starte generering av rapport «Prokoll» og «Protokoll CSV».  Merk at i tillegg til at rapportene inneholder kun godkjente behandlingsaktiviteter, er innholdet i hver behandlingsaktivitet videre avgrenset til å kun omhandle de tema som er merket som «Obligatorisk» i registreringsløsningen. Det vil si at rapportene inneholder kun artikkel 30-temaene (protokoll-kravene) samt navn på behandlingsaktiviteten. «Protokoll CSV» viser i tillegg organisasjonsnummeret til virksomheten. Valgfrie tema i registeringsløsningen vises derfor ikke i disse rapportene.
+
+
+### Rapport «Protokoll»
+
+For at en behandlingsaktivitet skal få status godkjent, og derved kunne vises i rapport «Protokoll», må alle obligatoriske tema i behandlingsaktiviteten være utfylt, samt at behandlingsaktiviteten må ha status som «Godkjent». Godkjenning foregår ved å klikke på Godkjenn-knappen nederst inne i registreringsvinduet for den enkelte behandlingsaktivitet. Her er eksempel fra rapport Protokoll:
+
+![Bilde av et eksempel på rapport «Protokoll» som HTML.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_protokoll_html_6e789eaad5.png)
+
+
+### Rapport «Protokoll CSV»
+
+Rapport «Protokoll CSV» har samme innhold som HTML-rapport «Protokoll». I tillegg inneholder den virksomhetens organisasjonsnummer. Den åpnes på samme måte som rapport «Behandlingsoversikt CSV». Her er eksempel fra rapport «Protokoll CSV», åpnet i MS Excel:
+
+![Bilde som viser et eksempel på rapport «Protokoll CSV» åpnet i MS Excel.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_protokoll_CSV_eksempel_eba15ff1ec.png)
+
+&nbsp;
+
+Om du har spørsmål til bruk av Behandlingsoversikt, eller trenger hjelp med generering av rapporter, kan du ta kontakt med oss på epost-adresse [fellesdatakatalog@digdir.no](mailto:fellesdatakatalog@digdir.no)
+

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.nb.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.nb.mdx
@@ -25,6 +25,8 @@ Du kan da velge mellom fire rapporter; Behandlingsoversikt, Behandlingsoversikt 
 
 &nbsp;
 
+Nedenfor følger beskrivelser av de forskjellige rapporttypene.
+
 ### Rapport «Behandlingsoversikt»
 
 Rapportvalget genererer en HTML-rapport som inkluderer alt virksomheten har registrert under «Kontaktinformasjon» og «Personvernombud», samt all informasjon knyttet til behandlingsaktiviteter. Rapporten dekker både behandlingsaktiviteter med status «Godkjent» og de som er merket som «Utkast».

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.nb.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.nb.mdx
@@ -1,20 +1,20 @@
 ---
-title: Ta ut data fra Behandlingsoversikt
-description: Hvordan overføre data fra Behandlingsoversikt til din egen virksomhet. 
+title: Hvordan hente ut dine data fra Behandlingsoversikt
+description: Veiledning i hvordan hente ut data fra Behandlingsoversikt til din egen virksomhet. 
 
 ---
 
-# Ta ut data fra Behandlingsoversikt
+# Hvordan hente ut dine data fra Behandlingsoversikt
 
 <Ingress>
-Her får du veiledning i hvordan du logger deg inn i Felles datakatalog sin Behandlingsoversikt og hvordan du kan overføre data fra Behandlingsoversikt til din virksomhet.
+Her får du veiledning i hvordan du logger deg inn i Felles datakatalog sin Behandlingsoversikt og hvordan du kan hente ut data fra Behandlingsoversikt til din virksomhet.
 </Ingress>
 
 &nbsp;
 
 ## Tilgang til Behandlingsoversikt
 
-Løsningen Behandlingsoversikt ligger inne i registreringsløsningen til Felles datakatalog. For å kunne overføre data fra Behandlingsoversikt til egen virksomhet må du derfor ha tilgang til registreringsløsningen. Les mer på nettsiden [Ta i bruk Felles datakatalog](https://samarbeid.digdir.no/felles-datakatalog/ta-i-bruk-felles-datakatalog/1619) om hvordan du får tilgang til registreringsløsningen. 
+Løsningen Behandlingsoversikt ligger inne i registreringsløsningen til Felles datakatalog. For å kunne hente ut data fra Behandlingsoversikt til egen virksomhet må du derfor ha tilgang til registreringsløsningen. Les mer på nettsiden [Ta i bruk Felles datakatalog](https://samarbeid.digdir.no/felles-datakatalog/ta-i-bruk-felles-datakatalog/1619) om hvordan du får tilgang til registreringsløsningen. 
  
 Når du har fått tilgang, åpner du nettsiden [Publisere i Felles datakatalog](https://data.norge.no/publishing) og klikker på lenken «Logg inn for å registrere» til venstre i skjermbildet:
 

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.nn.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.nn.mdx
@@ -4,12 +4,15 @@ description: Korleis overføre data frå Behandlingsoversikt til din eigen verks
 
 ---
 
+# Ta ut data frå Behandlingsoversikt
+
 <Ingress>
 Her får du rettleiing i korleis du loggar deg inn i Felles datakatalog sin Behandlingsoversikt og korleis du kan overføre data frå Behandlingsoversikt til din verksemd.
 </Ingress>
 
+&nbsp;
 
-# Tilgang til Behandlingsoversikt
+## Tilgang til Behandlingsoversikt
 
 Løysinga Behandlingsoversikt ligg i registreringsløysinga til Felles datakatalog. For å kunne overføre data frå Behandlingsoversikt til eigen verksemd, må du derfor ha tilgang til registreringsløysinga. Les meir på nettsida [Ta i bruk Felles datakatalog](https://samarbeid.digdir.no/felles-datakatalog/ta-i-bruk-felles-datakatalog/1619) om korleis du får tilgang til registreringsløysinga.
 
@@ -32,12 +35,12 @@ Når du har logga inn i registreringsløysinga, klikkar du på valet «Behandlin
 Du kjem då inn i Behandlingsoversikten for din verksemd.
 
 
-# Om Behandlingsaktivitetar i Behandlingsoversikt
+## Om Behandlingsaktivitetar i Behandlingsoversikt
 
 Alle data som verksemda di har registrert i Behandlingsoversikt kan enkelt takast ut av løysinga og overførast til verksemda som rapportar. Rapportar kan genererast i HTML-format eller som CSV-filer (komma-separerte verdiar). HTML-formatet er tilpassa visning i nettlesar og kan skrivast ut eller lagrast som PDF-filer. CSV-formatet er egna til vidare bruk i databasar eller i rekneark.
 
 
-# Framgangsmåte for å generere rapportar
+## Framgangsmåte for å generere rapportar
 
 Klikk på «Generer rapport»:
 
@@ -50,29 +53,29 @@ Du kan då velje mellom fire rapportar; Behandlingsoversikt, Behandlingsoversikt
 ![Bilete som viser at knappen «Generer rapport» er vald, og at under denne er det fire rapporttypar.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_valg_generer_rapport_e74b90fefc.png)
 
 
-## Rapport «Behandlingsoversikt» og «Behandlingsoversikt CSV»
+### Rapport «Behandlingsoversikt» og «Behandlingsoversikt CSV»
 
 Rapportane «Behandlingsoversikt» og «Behandlingsoversikt CSV» inneheld alt din verksemd har registrert i Behandlingsoversikt. Rapport «Behandlingsoversikt» genererer ei HTML-side som blir vist i nettlesaren din. Rapport «Behandlingsoversikt CSV» har same innhald som «Behandlingsoversikt», men genererer ei CSV-fil som blir lasta ned til PC-en din, og som deretter kan importerast til ei database eller opnast i eit rekneark for vidare oppdatering. Vi tilrår å generere ein eller begge desse rapportane for å sikre at all informasjon registrert i Behandlingsoversikt blir overført til verksemda di.
 
 
-## Rapport «Protokoll» og «Protokoll CSV»
+### Rapport «Protokoll» og «Protokoll CSV»
 
 Rapportane «Protokoll» og «Protokoll CSV» inneheld berre godkjende behandlingsprotokollar. Desse rapportane er vidare avgrensa til å berre innehalde dei tema som dekkast av artikkel 30 «Protokoll over behandlingsaktivitetar» i Personopplysningslova. Rapport «Protokoll» genererer ei HTML-side som blir vist i nettlesaren din. Rapport «Protokoll CSV» har same innhald som rapport «Protokoll», men genererer ei CSV-fil som blir lasta ned til PC-en din, og som kan importerast til ei database eller opnast i eit rekneark for vidare oppdatering.
 
 
-# Generelt om tema som kan registrerast i Behandlingsoversikt – og som det kan takast ut rapportar om
+## Generelt om tema som kan registrerast i Behandlingsoversikt – og som det kan takast ut rapportar om
 
 Digdir har ved utviklinga av Behandlingsoversikt teke utgangspunkt i Datatilsynet sin «[Mal for behandlingsansvarleg si protokoll](https://www.datatilsynet.no/rettigheter-og-plikter/virksomhetenes-plikter/protokoll-over-behandlingsaktiviteter/)». Behandlingsoversikt dekkjer derfor ei rekkje tema som er nemnt i personopplysningslova og i Datatilsynet sin mal. Løysinga gir moglegheiter for å registrere kontaktopplysningar for Behandlingsansvarleg og Personvernombod, og oppfyller elles krava til kva som skal registrerast i samsvar med artikkel 30 «Protokoll over behandlingsaktivitetar» i Personopplysningslova. Ein kan òg registrere andre tema som kan vere nyttige å ha knytt til behandlingsaktivitetar, som informasjon nemnt i artikkel 6 «Behandlingas lovlegheit» og artikkel 9 «Behandling av særskilde kategoriar av personopplysningar». I tillegg har vi lagt inn moglegheiter i Behandlingsoversikt for å knyte behandlingsaktivitetar til verksemda sine datasettbeskrivingar i Felles datakatalog (valfritt felt).
 
 På dei neste sidene følgjer ei skildring av ulike rapportar som kan takast ut frå Behandlingsoversikt, samt ei skildring av kva rapportane inneheld. Følgjande forklaringar av utskrift og lagring er basert på bruk av nettlesaren Chrome Versjon 119.0.6045.200 (Offisiell delversjon) (64-bit). Vi tek derfor atterhald om at menyval for slik funksjonalitet kan variere mellom ulike nettlesarar og versjonar av Chrome.
 
 
-# Skildring av rapportane sitt innhald
+## Skildring av rapportane sitt innhald
 
 Her følgjer ei meir detaljert skildring av innhaldet i rapportane.
 
 
-## Rapport «Behandlingsoversikt»
+### Rapport «Behandlingsoversikt»
 
 Dette er det første alternativet i rapportmenyen:
 
@@ -95,7 +98,7 @@ For tema som ikkje er utfylt, visast likevel overskrifta. Dette gjeld både for 
 Rapport «Behandlingsoversikt» kan skrivast ut ved å velje «Skriv ut» i nettlesaren din. Den kan òg lagrast som PDF-fil. Dette gjer du ved å velje «Skriv ut» i nettlesaren og deretter velje «Destinasjon» - «Lagre som PDF».
 
 
-## Rapport «Behandlingsoversikt CSV»
+### Rapport «Behandlingsoversikt CSV»
 
 Dette er det andre valet i rapportmenyen:
 
@@ -128,7 +131,7 @@ Som det går fram her, blir eit skiljeteikn brukt dersom det er oppgitt fleire r
 Fila kan behandlast vidare i for eksempel eit rekneark. Ein kan då til dømes leggje inn fleire namn på «Dagleg behandlingsansvarleg» og skilje namna med «skiljeteiknet» som ofte finst oppe til venstre på tastaturet, gjerne på same tast som paragraf-teiknet ligg på.
 
 
-## Rapport «Protokoll» og «Protokoll CSV»
+### Rapport «Protokoll» og «Protokoll CSV»
 
 Rapport Protokoll og rapport Protokoll CSV inneheld berre godkjende behandlingsaktivitetar. Rapporten er vidare avgrensa til å berre gjelde tema som inngår i artikkel 30.
 
@@ -151,14 +154,14 @@ Dersom registreringsfelta under «Kontaktinformasjon» og «Personvernombod» <u
 Når registreringsfelta under «Kontaktinformasjon» og «Personvernombod» er utfylte, kan ein starte generering av rapport «Protokoll» og «Protokoll CSV». Merk at i tillegg til at rapportane inneheld berre godkjende behandlingsaktivitetar, er innhaldet i kvar behandlingsaktivitet vidare avgrensa til berre å omhandle dei tema som er merkte som «Obligatorisk» i registreringsløysinga. Det vil seie at rapportane berre inneheld artikkel 30-temaene (protokoll-krava) samt namn på behandlingsaktiviteten. «Protokoll CSV» viser i tillegg organisasjonsnummeret til verksemda. Valfrie tema i registreringsløysinga blir difor ikkje viste i desse rapportane.
 
 
-### Rapport «Protokoll»
+#### Rapport «Protokoll»
 
 For at ein behandlingsaktivitet skal få status som godkjent, og dermed kunne visast i rapport «Protokoll», må alle obligatoriske tema i behandlingsaktiviteten vere utfylte, samt at behandlingsaktiviteten må ha status som «Godkjent». Godkjenning skjer ved å klikke på Godkjenn-knappen nedst inne i registreringsvindauget for den enkelte behandlingsaktiviteten. Her er eit døme frå rapport Protokoll:
 
 ![Bilete av eit eksempel på rapport «Protokoll» som HTML.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_protokoll_html_6e789eaad5.png)
 
 
-### Rapport «Protokoll CSV»
+#### Rapport «Protokoll CSV»
 
 Rapport «Protokoll CSV» har same innhald som HTML-rapporten «Protokoll». I tillegg inneheld den verksemda sitt organisasjonsnummer. Den blir opna på same måte som rapport «Behandlingsoversikt CSV». Her er eit døme frå rapport «Protokoll CSV», opna i MS Excel:
 

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.nn.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.nn.mdx
@@ -1,0 +1,170 @@
+---
+title: Ta ut data frå Behandlingsoversikt
+description: Korleis overføre data frå Behandlingsoversikt til din eigen verksemd.
+
+---
+
+<Ingress>
+Her får du rettleiing i korleis du loggar deg inn i Felles datakatalog sin Behandlingsoversikt og korleis du kan overføre data frå Behandlingsoversikt til din verksemd.
+</Ingress>
+
+
+# Tilgang til Behandlingsoversikt
+
+Løysinga Behandlingsoversikt ligg i registreringsløysinga til Felles datakatalog. For å kunne overføre data frå Behandlingsoversikt til eigen verksemd, må du derfor ha tilgang til registreringsløysinga. Les meir på nettsida [Ta i bruk Felles datakatalog](https://samarbeid.digdir.no/felles-datakatalog/ta-i-bruk-felles-datakatalog/1619) om korleis du får tilgang til registreringsløysinga.
+
+Når du har fått tilgang, opnar du nettsida [Publisere i Felles datakatalog](https://data.norge.no/publishing) og klikkar på lenkja «Logg inn for å registrere» til venstre i skjermbildet:
+
+![Bilete som viser kvar ein trykkjer for å logge inn i registreringsløysinga.](https://cms.fellesdatakatalog.digdir.no/uploads/Innlogging_registrering_c38f43d43a.png)
+
+&nbsp;
+
+Deretter vel du “Logg inn via ID-porten” til venstre i skjermbildet. Du kan eventuelt velje “Logg inn via Felles brukarhandsaming” dersom du tidlegare har fått tilgang til å logge inn via denne løysinga. Tilsette i Brønnøysundregistera og Skatteetaten kan også logge inn via eigne innloggingsløysingar.
+
+![Bilete som viser dei forskjellige innloggingsalternativa.](https://cms.fellesdatakatalog.digdir.no/uploads/Innlogging_alternativer_62081aab4d.png)
+
+&nbsp;
+
+Når du har logga inn i registreringsløysinga, klikkar du på valet «Behandlingsoversikt».
+
+![Bilete som viser oversikt over kva katalogar som finst for ei verksemd.](https://cms.fellesdatakatalog.digdir.no/uploads/Registreringslosning_alle_kataloger_Behandlingsoversikt_d3c4c63095.png)
+
+Du kjem då inn i Behandlingsoversikten for din verksemd.
+
+
+# Om Behandlingsaktivitetar i Behandlingsoversikt
+
+Alle data som verksemda di har registrert i Behandlingsoversikt kan enkelt takast ut av løysinga og overførast til verksemda som rapportar. Rapportar kan genererast i HTML-format eller som CSV-filer (komma-separerte verdiar). HTML-formatet er tilpassa visning i nettlesar og kan skrivast ut eller lagrast som PDF-filer. CSV-formatet er egna til vidare bruk i databasar eller i rekneark.
+
+
+# Framgangsmåte for å generere rapportar
+
+Klikk på «Generer rapport»:
+
+![Bilete som viser kvar knappen «Generer rapport» er på behandlingsoversiktsida.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_knapp_generer_rapport_5dc8ab6b63.png)
+
+&nbsp;
+
+Du kan då velje mellom fire rapportar; Behandlingsoversikt, Behandlingsoversikt CSV, Protokoll og Protokoll CSV:
+
+![Bilete som viser at knappen «Generer rapport» er vald, og at under denne er det fire rapporttypar.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_valg_generer_rapport_e74b90fefc.png)
+
+
+## Rapport «Behandlingsoversikt» og «Behandlingsoversikt CSV»
+
+Rapportane «Behandlingsoversikt» og «Behandlingsoversikt CSV» inneheld alt din verksemd har registrert i Behandlingsoversikt. Rapport «Behandlingsoversikt» genererer ei HTML-side som blir vist i nettlesaren din. Rapport «Behandlingsoversikt CSV» har same innhald som «Behandlingsoversikt», men genererer ei CSV-fil som blir lasta ned til PC-en din, og som deretter kan importerast til ei database eller opnast i eit rekneark for vidare oppdatering. Vi tilrår å generere ein eller begge desse rapportane for å sikre at all informasjon registrert i Behandlingsoversikt blir overført til verksemda di.
+
+
+## Rapport «Protokoll» og «Protokoll CSV»
+
+Rapportane «Protokoll» og «Protokoll CSV» inneheld berre godkjende behandlingsprotokollar. Desse rapportane er vidare avgrensa til å berre innehalde dei tema som dekkast av artikkel 30 «Protokoll over behandlingsaktivitetar» i Personopplysningslova. Rapport «Protokoll» genererer ei HTML-side som blir vist i nettlesaren din. Rapport «Protokoll CSV» har same innhald som rapport «Protokoll», men genererer ei CSV-fil som blir lasta ned til PC-en din, og som kan importerast til ei database eller opnast i eit rekneark for vidare oppdatering.
+
+
+# Generelt om tema som kan registrerast i Behandlingsoversikt – og som det kan takast ut rapportar om
+
+Digdir har ved utviklinga av Behandlingsoversikt teke utgangspunkt i Datatilsynet sin «[Mal for behandlingsansvarleg si protokoll](https://www.datatilsynet.no/rettigheter-og-plikter/virksomhetenes-plikter/protokoll-over-behandlingsaktiviteter/)». Behandlingsoversikt dekkjer derfor ei rekkje tema som er nemnt i personopplysningslova og i Datatilsynet sin mal. Løysinga gir moglegheiter for å registrere kontaktopplysningar for Behandlingsansvarleg og Personvernombod, og oppfyller elles krava til kva som skal registrerast i samsvar med artikkel 30 «Protokoll over behandlingsaktivitetar» i Personopplysningslova. Ein kan òg registrere andre tema som kan vere nyttige å ha knytt til behandlingsaktivitetar, som informasjon nemnt i artikkel 6 «Behandlingas lovlegheit» og artikkel 9 «Behandling av særskilde kategoriar av personopplysningar». I tillegg har vi lagt inn moglegheiter i Behandlingsoversikt for å knyte behandlingsaktivitetar til verksemda sine datasettbeskrivingar i Felles datakatalog (valfritt felt).
+
+På dei neste sidene følgjer ei skildring av ulike rapportar som kan takast ut frå Behandlingsoversikt, samt ei skildring av kva rapportane inneheld. Følgjande forklaringar av utskrift og lagring er basert på bruk av nettlesaren Chrome Versjon 119.0.6045.200 (Offisiell delversjon) (64-bit). Vi tek derfor atterhald om at menyval for slik funksjonalitet kan variere mellom ulike nettlesarar og versjonar av Chrome.
+
+
+# Skildring av rapportane sitt innhald
+
+Her følgjer ei meir detaljert skildring av innhaldet i rapportane.
+
+
+## Rapport «Behandlingsoversikt»
+
+Dette er det første alternativet i rapportmenyen:
+
+![Bilete som viser dei fire rapporttypane under knappen «Generer rapport»».](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapportalternativer_877d5421ad.png)
+
+Rapportvalet genererer ein HTML-rapport som inneheld alt din verksemd har registrert i bolkane «Kontaktinformasjon» og «Personvernombod», samt alt som er registrert i alle behandlingsaktivitetar. Rapporten inneheld derfor både behandlingsaktivitetar med status «Godkjent» og behandlingsaktivitetar med status «Utkast».
+
+Rapporten startar med å vise alt som er registrert i bolkane «Kontaktinformasjon» og «Personvernombod». Deretter blir kvar behandlingsaktivitet vist etter tur, med kvart sitt registreringsfelt per behandlingsaktivitet.
+
+I følgjande eksempel ser vi at rapporten startar med å vise namnet på verksemda. Vidare viser den kva som er registrert under «Kontaktinformasjon» og «Personvernombod», og deretter ser ein starten på informasjonen knytt til behandlingsaktiviteten «Ansettelser»:
+
+![Bilete av eit eksempel på rapport «Behandlingsoversikt» som HTML.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_html_b319cdf7da.png)
+
+Tema som omhandlar artikkel 30 «Protokollar over behandlingsaktivitetar» i Personopplysningslova er merka «Obligatorisk» i rapporten. Alle obligatoriske felt i ein behandlingsaktivitet må fyllast ut før ein kan godkjenne behandlingsaktiviteten. Under overskrifta «Ansettelser» går det fram at denne rapporten er godkjent.
+
+For tema som ikkje er utfylt, visast likevel overskrifta. Dette gjeld både for behandlingsaktivitetar som står med status «Godkjent» og dei som står med status «Utkast». Nedanfor er eit eksempel frå rapporten der det er vist utdrag frå behandlingsaktiviteten «Lønn». I overskrifta går det fram at behandlingsaktiviteten står med status «Utkast». Vidare ser ein at det ikkje er fylt ut noko i dei valfrie felta «Dagleg behandlingsansvar» og «Databehandlarar og databehandlar», og at det er oppgitt «Nei» i det obligatoriske feltet «Felles behandlingsansvar».
+
+![Bilete av eit eksempel på rapport «Behandlingsoversikt» som HTML og utan innhald.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_html_tema_uten_innhold_97c2aba9fe.png)
+
+Rapport «Behandlingsoversikt» kan skrivast ut ved å velje «Skriv ut» i nettlesaren din. Den kan òg lagrast som PDF-fil. Dette gjer du ved å velje «Skriv ut» i nettlesaren og deretter velje «Destinasjon» - «Lagre som PDF».
+
+
+## Rapport «Behandlingsoversikt CSV»
+
+Dette er det andre valet i rapportmenyen:
+
+![Bilete som viser dei fire rapporttypane under knappen «Generer rapport»».](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapportalternativer_877d5421ad.png)
+
+Rapporten genererer ei CSV-fil som kan importerast til ei database eller i eit rekneark. All informasjon som er registrert i Behandlingsoversikt visast i rader og kolonnar i fila.
+
+Fila blir automatisk lasta ned til PC-en din når du klikkar på «Behandlingsoversikt CSV». Sjekk loggen over nylege nedlastingar eller mappa «Nedlastingar» om den har blitt lagra der. Her er eit eksempel på at fila er generert:
+
+![Bilete som viser at fila «behandlingsoversikt.csv» ligg i loggen over nylege nedlastingar.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_CSV_nedlasting_060b603946.png)
+
+&nbsp;
+
+Rapporten dekkjer same innhald som rapport «Behandlingsoversikt, men inneheld i tillegg verksemda sitt organisasjonsnummer. Her er eit eksempel på rapport «Behandlingsoversikt CSV» opna i MS Excel:
+
+[Bilete som viser døme på rapport «Behandlingsoversikt CSV» opna i MS Excel.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_CSV_eksempel1_127c7da850.png)
+
+Kvar rad representerer ein behandlingsaktivitet. Tema i kolonnane følgjer stort sett same rekkefølgje som tema i registreringsløysinga. Først kjem Namn på verksemda, så organisasjonsnummer, informasjon frå dei ulike felta under «Kontaktinformasjon» og «Personvernombod», og til slutt tema i dei ulike felta knytt til kvar behandlingsaktivitet. Namn på behandlingsaktiviteten ligg til dømes i kolonne P. Merk at «Organisasjonsnummer» visast berre i CSV-rapportane.
+
+Tema som kan gjentakast med fleire registreringar, blir separert i kolonnane. Nedanfor følgjer eit døme frå registreringsløysinga, og deretter ei vising av tilsvarande felt og data i ei CSV-fil. I dette dømet er det registrert to namn med tilhøyrande telefonnummer og e-post under «Dagleg behandlingsansvarleg i behandlingsaktiviteten «Lønn» i registreringsløysinga:
+
+![Bilete som viser at det er registrert to personar med dagleg behandlingsansvar for ein behandlingsaktivitet.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_behandlingsaktivitet_daglig_behandlingsansvar_4f84aa1572.png)
+
+I CSV-fila «Behandlingsoversikt CSV» blir same informasjon frå behandlingsaktiviteten «Lønn» vist:
+
+![Bilete som viser døme på rapport Behandlingsoversikt CSV» opna i MC Excel der det er registrert to personar med dagleg behandlingsansvar for ein behandlingsaktivitet.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_CSV_eksempel_Lonn_52c0a151a2.png)
+
+Som det går fram her, blir eit skiljeteikn brukt dersom det er oppgitt fleire registreringar innanfor eit tema. I dømet kjem det fram i kolonne R at det i behandlingsaktiviteten «Lønn» er tre «Dagleg behandlingsansvarlege». I kolonne S er telefonnummera viste i same rekkefølgje som namna. Det betyr at Jan Jansen har telefon 22334455, og Nils Nilsen har telefon 33445566. For Tor Torsen er det ikkje registrert noko telefonnummer.
+
+Fila kan behandlast vidare i for eksempel eit rekneark. Ein kan då til dømes leggje inn fleire namn på «Dagleg behandlingsansvarleg» og skilje namna med «skiljeteiknet» som ofte finst oppe til venstre på tastaturet, gjerne på same tast som paragraf-teiknet ligg på.
+
+
+## Rapport «Protokoll» og «Protokoll CSV»
+
+Rapport Protokoll og rapport Protokoll CSV inneheld berre godkjende behandlingsaktivitetar. Rapporten er vidare avgrensa til å berre gjelde tema som inngår i artikkel 30.
+
+Rapport “Protokoll” er ein HTML-rapport og er det 3. valet i rapportmenyen:
+
+![Bilete som viser dei fire rapporttypane under knappen «Generer rapport»».](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapportalternativer_877d5421ad.png)
+
+&nbsp;
+
+For å kunne generere rapportane «Protokoll» og «Protokoll CSV», må dei obligatoriske felta under temaene «Kontaktinformasjon» og «Personvernombod» vere utfylte:
+
+![Bilete som viser temaene «Kontaktinformasjon» og «Personvernombod» i Behandlingsoversikt.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_kontakt_og_personvern_1b17c54e27.png)
+
+&nbsp;
+
+Dersom registreringsfelta under «Kontaktinformasjon» og «Personvernombod» <u>ikkje</u> er utfylte, blir rapportvala «Protokoll» og «Protokoll CSV» viste med grå tekst i menyen der ein vel rapport. Dette betyr at det ikkje er mogleg å generere rapportane:
+
+![Bilete som viser at rapporttypane «Protokoll» og «Protokoll CSV» er deaktiverte under knappen «Generer rapport».](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapportalternativer_manglende_utfylling_722200b988.png)
+
+Når registreringsfelta under «Kontaktinformasjon» og «Personvernombod» er utfylte, kan ein starte generering av rapport «Protokoll» og «Protokoll CSV». Merk at i tillegg til at rapportane inneheld berre godkjende behandlingsaktivitetar, er innhaldet i kvar behandlingsaktivitet vidare avgrensa til berre å omhandle dei tema som er merkte som «Obligatorisk» i registreringsløysinga. Det vil seie at rapportane berre inneheld artikkel 30-temaene (protokoll-krava) samt namn på behandlingsaktiviteten. «Protokoll CSV» viser i tillegg organisasjonsnummeret til verksemda. Valfrie tema i registreringsløysinga blir difor ikkje viste i desse rapportane.
+
+
+### Rapport «Protokoll»
+
+For at ein behandlingsaktivitet skal få status som godkjent, og dermed kunne visast i rapport «Protokoll», må alle obligatoriske tema i behandlingsaktiviteten vere utfylte, samt at behandlingsaktiviteten må ha status som «Godkjent». Godkjenning skjer ved å klikke på Godkjenn-knappen nedst inne i registreringsvindauget for den enkelte behandlingsaktiviteten. Her er eit døme frå rapport Protokoll:
+
+![Bilete av eit eksempel på rapport «Protokoll» som HTML.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_protokoll_html_6e789eaad5.png)
+
+
+### Rapport «Protokoll CSV»
+
+Rapport «Protokoll CSV» har same innhald som HTML-rapporten «Protokoll». I tillegg inneheld den verksemda sitt organisasjonsnummer. Den blir opna på same måte som rapport «Behandlingsoversikt CSV». Her er eit døme frå rapport «Protokoll CSV», opna i MS Excel:
+
+![Bilete som viser døme på rapport «Protokoll CSV» opna i MS Excel.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_protokoll_CSV_eksempel_eba15ff1ec.png)
+
+&nbsp;
+
+Om du har spørsmål til bruk av Behandlingsoversikt, eller treng hjelp med generering av rapportar, kan du ta kontakt med oss på e-postadressa [fellesdatakatalog@digdir.no](mailto:fellesdatakatalog@digdir.no)
+

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.nn.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.nn.mdx
@@ -25,6 +25,8 @@ Du kan då velje mellom fire rapportar; Behandlingsoversikt, Behandlingsoversikt
 
 &nbsp;
 
+Nedanfor følgjer skildringar av dei forskjellige rapporttypane.
+
 ### Rapport «Behandlingsoversikt»
 
 Rapportvalet genererer ein HTML-rapport som inkluderer alt verksemda har registrert under «Kontaktinformasjon» og «Personvernombod», samt all informasjon knytt til behandlingsaktivitetar. Rapporten dekkjer både behandlingsaktivitetar med status «Godkjent» og dei som er merkte som «Utkast».

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.nn.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.nn.mdx
@@ -1,20 +1,20 @@
 ---
-title: Ta ut data frå Behandlingsoversikt
-description: Korleis overføre data frå Behandlingsoversikt til din eigen verksemd.
+title: Korleis hente ut dine data frå Behandlingsoversikt
+description: Rettleiing i korleis hente ut data frå Behandlingsoversikt til din eigen verksemd.
 
 ---
 
-# Ta ut data frå Behandlingsoversikt
+# Korleis hente ut dine data frå Behandlingsoversikt
 
 <Ingress>
-Her får du rettleiing i korleis du loggar deg inn i Felles datakatalog sin Behandlingsoversikt og korleis du kan overføre data frå Behandlingsoversikt til din verksemd.
+Her får du rettleiing i korleis du loggar deg inn i Felles datakatalog sin Behandlingsoversikt og korleis du kan hente ut data frå Behandlingsoversikt til din verksemd.
 </Ingress>
 
 &nbsp;
 
 ## Tilgang til Behandlingsoversikt
 
-Løysinga Behandlingsoversikt ligg i registreringsløysinga til Felles datakatalog. For å kunne overføre data frå Behandlingsoversikt til eigen verksemd, må du derfor ha tilgang til registreringsløysinga. Les meir på nettsida [Ta i bruk Felles datakatalog](https://samarbeid.digdir.no/felles-datakatalog/ta-i-bruk-felles-datakatalog/1619) om korleis du får tilgang til registreringsløysinga.
+Løysinga Behandlingsoversikt ligg i registreringsløysinga til Felles datakatalog. For å kunne hente ut data frå Behandlingsoversikt til eigen verksemd, må du derfor ha tilgang til registreringsløysinga. Les meir på nettsida [Ta i bruk Felles datakatalog](https://samarbeid.digdir.no/felles-datakatalog/ta-i-bruk-felles-datakatalog/1619) om korleis du får tilgang til registreringsløysinga.
 
 Når du har fått tilgang, opnar du nettsida [Publisere i Felles datakatalog](https://data.norge.no/publishing) og klikkar på lenkja «Logg inn for å registrere» til venstre i skjermbildet:
 

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.nn.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-export-data/how-to-export-data.nn.mdx
@@ -1,173 +1,85 @@
 ---
-title: Korleis hente ut dine data frå Behandlingsoversikt
-description: Rettleiing i korleis hente ut data frå Behandlingsoversikt til din eigen verksemd.
+title: Korleis hente ut data frå Behandlingsoversikt
+description: Rettleiing for korleis hente ut data frå Behandlingsoversikt til din eigen verksemd.
 
 ---
 
-# Korleis hente ut dine data frå Behandlingsoversikt
+# Korleis hente ut data frå Behandlingsoversikt
 
 <Ingress>
-Her får du rettleiing i korleis du loggar deg inn i Felles datakatalog sin Behandlingsoversikt og korleis du kan hente ut data frå Behandlingsoversikt til din verksemd.
+Alle data som din verksemd har registrert i Behandlingsoversikt kan enkelt hentast ut av løysinga og overførast til din verksemd som rapportar. Rapportar kan genererast i HTML-format eller som CSV-filer (Comma-Separated-Values). HTML-formatet er tilpassa vising i nettlesar og kan skrivast ut eller lagrast som PDF-filer. CSV-formatet er eigna for vidare bruk i databasar eller i rekneark.
 </Ingress>
 
-&nbsp;
 
-## Tilgang til Behandlingsoversikt
-
-Løysinga Behandlingsoversikt ligg i registreringsløysinga til Felles datakatalog. For å kunne hente ut data frå Behandlingsoversikt til eigen verksemd, må du derfor ha tilgang til registreringsløysinga. Les meir på nettsida [Ta i bruk Felles datakatalog](https://samarbeid.digdir.no/felles-datakatalog/ta-i-bruk-felles-datakatalog/1619) om korleis du får tilgang til registreringsløysinga.
-
-Når du har fått tilgang, opnar du nettsida [Publisere i Felles datakatalog](https://data.norge.no/publishing) og klikkar på lenkja «Logg inn for å registrere» til venstre i skjermbildet:
-
-![Bilete som viser kvar ein trykkjer for å logge inn i registreringsløysinga.](https://cms.fellesdatakatalog.digdir.no/uploads/Innlogging_registrering_c38f43d43a.png)
-
-&nbsp;
-
-Deretter vel du “Logg inn via ID-porten” til venstre i skjermbildet. Du kan eventuelt velje “Logg inn via Felles brukarhandsaming” dersom du tidlegare har fått tilgang til å logge inn via denne løysinga. Tilsette i Brønnøysundregistera og Skatteetaten kan også logge inn via eigne innloggingsløysingar.
-
-![Bilete som viser dei forskjellige innloggingsalternativa.](https://cms.fellesdatakatalog.digdir.no/uploads/Innlogging_alternativer_62081aab4d.png)
-
-&nbsp;
-
-Når du har logga inn i registreringsløysinga, klikkar du på valet «Behandlingsoversikt».
-
-![Bilete som viser oversikt over kva katalogar som finst for ei verksemd.](https://cms.fellesdatakatalog.digdir.no/uploads/Registreringslosning_alle_kataloger_Behandlingsoversikt_d3c4c63095.png)
-
-Du kjem då inn i Behandlingsoversikten for din verksemd.
-
-
-## Om Behandlingsaktivitetar i Behandlingsoversikt
-
-Alle data som verksemda di har registrert i Behandlingsoversikt kan enkelt takast ut av løysinga og overførast til verksemda som rapportar. Rapportar kan genererast i HTML-format eller som CSV-filer (komma-separerte verdiar). HTML-formatet er tilpassa visning i nettlesar og kan skrivast ut eller lagrast som PDF-filer. CSV-formatet er egna til vidare bruk i databasar eller i rekneark.
-
-
-## Framgangsmåte for å generere rapportar
+## Slik går du fram for å generere rapportar
 
 Klikk på «Generer rapport»:
 
-![Bilete som viser kvar knappen «Generer rapport» er på behandlingsoversiktsida.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_knapp_generer_rapport_5dc8ab6b63.png)
+![Bilete som viser kor knappen «Generer rapport» er på behandlingsoversikt-sida.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_knapp_generer_rapport_5dc8ab6b63.png)
 
 &nbsp;
 
 Du kan då velje mellom fire rapportar; Behandlingsoversikt, Behandlingsoversikt CSV, Protokoll og Protokoll CSV:
 
-![Bilete som viser at knappen «Generer rapport» er vald, og at under denne er det fire rapporttypar.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_valg_generer_rapport_e74b90fefc.png)
+![Bilete som viser at knappen «Generer rapport» er valt, og at det er fire rapporttypar under denne.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_valg_generer_rapport_e74b90fefc.png)
 
-
-### Rapport «Behandlingsoversikt» og «Behandlingsoversikt CSV»
-
-Rapportane «Behandlingsoversikt» og «Behandlingsoversikt CSV» inneheld alt din verksemd har registrert i Behandlingsoversikt. Rapport «Behandlingsoversikt» genererer ei HTML-side som blir vist i nettlesaren din. Rapport «Behandlingsoversikt CSV» har same innhald som «Behandlingsoversikt», men genererer ei CSV-fil som blir lasta ned til PC-en din, og som deretter kan importerast til ei database eller opnast i eit rekneark for vidare oppdatering. Vi tilrår å generere ein eller begge desse rapportane for å sikre at all informasjon registrert i Behandlingsoversikt blir overført til verksemda di.
-
-
-### Rapport «Protokoll» og «Protokoll CSV»
-
-Rapportane «Protokoll» og «Protokoll CSV» inneheld berre godkjende behandlingsprotokollar. Desse rapportane er vidare avgrensa til å berre innehalde dei tema som dekkast av artikkel 30 «Protokoll over behandlingsaktivitetar» i Personopplysningslova. Rapport «Protokoll» genererer ei HTML-side som blir vist i nettlesaren din. Rapport «Protokoll CSV» har same innhald som rapport «Protokoll», men genererer ei CSV-fil som blir lasta ned til PC-en din, og som kan importerast til ei database eller opnast i eit rekneark for vidare oppdatering.
-
-
-## Generelt om tema som kan registrerast i Behandlingsoversikt – og som det kan takast ut rapportar om
-
-Digdir har ved utviklinga av Behandlingsoversikt teke utgangspunkt i Datatilsynet sin «[Mal for behandlingsansvarleg si protokoll](https://www.datatilsynet.no/rettigheter-og-plikter/virksomhetenes-plikter/protokoll-over-behandlingsaktiviteter/)». Behandlingsoversikt dekkjer derfor ei rekkje tema som er nemnt i personopplysningslova og i Datatilsynet sin mal. Løysinga gir moglegheiter for å registrere kontaktopplysningar for Behandlingsansvarleg og Personvernombod, og oppfyller elles krava til kva som skal registrerast i samsvar med artikkel 30 «Protokoll over behandlingsaktivitetar» i Personopplysningslova. Ein kan òg registrere andre tema som kan vere nyttige å ha knytt til behandlingsaktivitetar, som informasjon nemnt i artikkel 6 «Behandlingas lovlegheit» og artikkel 9 «Behandling av særskilde kategoriar av personopplysningar». I tillegg har vi lagt inn moglegheiter i Behandlingsoversikt for å knyte behandlingsaktivitetar til verksemda sine datasettbeskrivingar i Felles datakatalog (valfritt felt).
-
-På dei neste sidene følgjer ei skildring av ulike rapportar som kan takast ut frå Behandlingsoversikt, samt ei skildring av kva rapportane inneheld. Følgjande forklaringar av utskrift og lagring er basert på bruk av nettlesaren Chrome Versjon 119.0.6045.200 (Offisiell delversjon) (64-bit). Vi tek derfor atterhald om at menyval for slik funksjonalitet kan variere mellom ulike nettlesarar og versjonar av Chrome.
-
-
-## Skildring av rapportane sitt innhald
-
-Her følgjer ei meir detaljert skildring av innhaldet i rapportane.
-
+&nbsp;
 
 ### Rapport «Behandlingsoversikt»
 
-Dette er det første alternativet i rapportmenyen:
+Rapportvalet genererer ein HTML-rapport som inkluderer alt verksemda har registrert under «Kontaktinformasjon» og «Personvernombod», samt all informasjon knytt til behandlingsaktivitetar. Rapporten dekkjer både behandlingsaktivitetar med status «Godkjent» og dei som er merkte som «Utkast».
 
-![Bilete som viser dei fire rapporttypane under knappen «Generer rapport»».](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapportalternativer_877d5421ad.png)
+Rapporten byrjar med å vise innhaldet frå seksjonane «Kontaktinformasjon» og «Personvernombod». Deretter presenterer ho kvar behandlingsaktivitet løpande, med tilhøyrande registreringsfelt.
 
-Rapportvalet genererer ein HTML-rapport som inneheld alt din verksemd har registrert i bolkane «Kontaktinformasjon» og «Personvernombod», samt alt som er registrert i alle behandlingsaktivitetar. Rapporten inneheld derfor både behandlingsaktivitetar med status «Godkjent» og behandlingsaktivitetar med status «Utkast».
-
-Rapporten startar med å vise alt som er registrert i bolkane «Kontaktinformasjon» og «Personvernombod». Deretter blir kvar behandlingsaktivitet vist etter tur, med kvart sitt registreringsfelt per behandlingsaktivitet.
-
-I følgjande eksempel ser vi at rapporten startar med å vise namnet på verksemda. Vidare viser den kva som er registrert under «Kontaktinformasjon» og «Personvernombod», og deretter ser ein starten på informasjonen knytt til behandlingsaktiviteten «Ansettelser»:
+I dømet nedanfor startar rapporten med verksemda sitt namn, etterfølgd av registreringane under «Kontaktinformasjon» og «Personvernombod», før ho viser informasjonen for behandlingsaktiviteten «Ansettelser».
 
 ![Bilete av eit eksempel på rapport «Behandlingsoversikt» som HTML.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_html_b319cdf7da.png)
 
-Tema som omhandlar artikkel 30 «Protokollar over behandlingsaktivitetar» i Personopplysningslova er merka «Obligatorisk» i rapporten. Alle obligatoriske felt i ein behandlingsaktivitet må fyllast ut før ein kan godkjenne behandlingsaktiviteten. Under overskrifta «Ansettelser» går det fram at denne rapporten er godkjent.
+Tema knytt til artikkel 30 «Protokollar over behandlingsaktivitetar» i Personopplysningslova er markert som «Obligatorisk» i rapporten. Alle obligatoriske felt i ein behandlingsaktivitet må vere utfylte før godkjenning kan skje. Under overskrifta «Ansettelser» visast det at denne rapporten er godkjend.
 
-For tema som ikkje er utfylt, visast likevel overskrifta. Dette gjeld både for behandlingsaktivitetar som står med status «Godkjent» og dei som står med status «Utkast». Nedanfor er eit eksempel frå rapporten der det er vist utdrag frå behandlingsaktiviteten «Lønn». I overskrifta går det fram at behandlingsaktiviteten står med status «Utkast». Vidare ser ein at det ikkje er fylt ut noko i dei valfrie felta «Dagleg behandlingsansvar» og «Databehandlarar og databehandlar», og at det er oppgitt «Nei» i det obligatoriske feltet «Felles behandlingsansvar».
+Sjølv om enkelte tema ikkje er utfylte, vil overskrifta framleis visast. Dette gjeld for både godkjende behandlingsaktivitetar og dei som har status «Utkast». Nedanfor visast eit eksempel frå rapporten med utdrag frå behandlingsaktiviteten «Lønn». Her kjem det fram at statusen til behandlingsaktiviteten er «Utkast». Det er tydeleg at dei valfrie felta «Dagleg behandlingsansvar» og «Databehandlarar og databehandlar» ikkje er utfylte, og at det obligatoriske feltet «Felles behandlingsansvar» er angitt med «Nei».
 
 ![Bilete av eit eksempel på rapport «Behandlingsoversikt» som HTML og utan innhald.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_html_tema_uten_innhold_97c2aba9fe.png)
 
-Rapport «Behandlingsoversikt» kan skrivast ut ved å velje «Skriv ut» i nettlesaren din. Den kan òg lagrast som PDF-fil. Dette gjer du ved å velje «Skriv ut» i nettlesaren og deretter velje «Destinasjon» - «Lagre som PDF».
+Rapport «Behandlingsoversikt» kan skrivast ut ved å velje «Skriv ut» i nettlesaren din. Ho kan også lagrast som PDF-fil. Dette gjer du ved å velje «Skriv ut» i nettlesaren og deretter velje «Destinasjon» - «Lagre som PDF».
 
 
 ### Rapport «Behandlingsoversikt CSV»
 
-Dette er det andre valet i rapportmenyen:
+Rapporten «Behandlingsoversikt CSV» genererer ei CSV-fil som inneheld det same som HTML-rapporten, med tillegg av verksemda sitt organisasjonsnummer. Filen blir automatisk lasta ned til PC-en din. Sjekk loggen over nylege nedlastingar eller mappa «Nedlastingar» for å finne filen. Deretter kan filen importerast til ein database eller opnast i eit rekneark for vidare bearbeiding. Nedanfor er eit eksempel på rapport «Behandlingsoversikt CSV» opna i MS Excel:
 
-![Bilete som viser dei fire rapporttypane under knappen «Generer rapport»».](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapportalternativer_877d5421ad.png)
+![Bilete som viser eksempel på rapport «Behandlingsoversikt CSV» opna i MS Excel.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_CSV_eksempel1_127c7da850.png)
 
-Rapporten genererer ei CSV-fil som kan importerast til ei database eller i eit rekneark. All informasjon som er registrert i Behandlingsoversikt visast i rader og kolonnar i fila.
+Kvar rad representerer ein behandlingsaktivitet. Tema i kolonnene følgjer i hovudsak same rekkjefølgje som tema i registreringsløysinga. Namnet på behandlingsaktiviteten ligg i kolonne P.
 
-Fila blir automatisk lasta ned til PC-en din når du klikkar på «Behandlingsoversikt CSV». Sjekk loggen over nylege nedlastingar eller mappa «Nedlastingar» om den har blitt lagra der. Her er eit eksempel på at fila er generert:
+Tema med fleire registreringar blir skilde i kolonnene ved hjelp av separatoren «|». Nedanfor visast eit eksempel på ei CSV-fil der tre personar er registrerte som «Dagleg behandlingsansvarleg» i behandlingsaktiviteten «Lønn».
 
-![Bilete som viser at fila «behandlingsoversikt.csv» ligg i loggen over nylege nedlastingar.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_CSV_nedlasting_060b603946.png)
-
-&nbsp;
-
-Rapporten dekkjer same innhald som rapport «Behandlingsoversikt, men inneheld i tillegg verksemda sitt organisasjonsnummer. Her er eit eksempel på rapport «Behandlingsoversikt CSV» opna i MS Excel:
-
-[Bilete som viser døme på rapport «Behandlingsoversikt CSV» opna i MS Excel.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_CSV_eksempel1_127c7da850.png)
-
-Kvar rad representerer ein behandlingsaktivitet. Tema i kolonnane følgjer stort sett same rekkefølgje som tema i registreringsløysinga. Først kjem Namn på verksemda, så organisasjonsnummer, informasjon frå dei ulike felta under «Kontaktinformasjon» og «Personvernombod», og til slutt tema i dei ulike felta knytt til kvar behandlingsaktivitet. Namn på behandlingsaktiviteten ligg til dømes i kolonne P. Merk at «Organisasjonsnummer» visast berre i CSV-rapportane.
-
-Tema som kan gjentakast med fleire registreringar, blir separert i kolonnane. Nedanfor følgjer eit døme frå registreringsløysinga, og deretter ei vising av tilsvarande felt og data i ei CSV-fil. I dette dømet er det registrert to namn med tilhøyrande telefonnummer og e-post under «Dagleg behandlingsansvarleg i behandlingsaktiviteten «Lønn» i registreringsløysinga:
-
-![Bilete som viser at det er registrert to personar med dagleg behandlingsansvar for ein behandlingsaktivitet.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_behandlingsaktivitet_daglig_behandlingsansvar_4f84aa1572.png)
-
-I CSV-fila «Behandlingsoversikt CSV» blir same informasjon frå behandlingsaktiviteten «Lønn» vist:
-
-![Bilete som viser døme på rapport Behandlingsoversikt CSV» opna i MC Excel der det er registrert to personar med dagleg behandlingsansvar for ein behandlingsaktivitet.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_CSV_eksempel_Lonn_52c0a151a2.png)
-
-Som det går fram her, blir eit skiljeteikn brukt dersom det er oppgitt fleire registreringar innanfor eit tema. I dømet kjem det fram i kolonne R at det i behandlingsaktiviteten «Lønn» er tre «Dagleg behandlingsansvarlege». I kolonne S er telefonnummera viste i same rekkefølgje som namna. Det betyr at Jan Jansen har telefon 22334455, og Nils Nilsen har telefon 33445566. For Tor Torsen er det ikkje registrert noko telefonnummer.
-
-Fila kan behandlast vidare i for eksempel eit rekneark. Ein kan då til dømes leggje inn fleire namn på «Dagleg behandlingsansvarleg» og skilje namna med «skiljeteiknet» som ofte finst oppe til venstre på tastaturet, gjerne på same tast som paragraf-teiknet ligg på.
-
-
-### Rapport «Protokoll» og «Protokoll CSV»
-
-Rapport Protokoll og rapport Protokoll CSV inneheld berre godkjende behandlingsaktivitetar. Rapporten er vidare avgrensa til å berre gjelde tema som inngår i artikkel 30.
-
-Rapport “Protokoll” er ein HTML-rapport og er det 3. valet i rapportmenyen:
-
-![Bilete som viser dei fire rapporttypane under knappen «Generer rapport»».](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapportalternativer_877d5421ad.png)
+![Bilete som viser eksempel på rapport «Behandlingsoversikt CSV» opna i MS Excel der det er registrert tre personar med dagleg behandlingsansvar for ein behandlingsaktivitet](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_CSV_eksempel_Lonn_52c0a151a2.png)
 
 &nbsp;
 
-For å kunne generere rapportane «Protokoll» og «Protokoll CSV», må dei obligatoriske felta under temaene «Kontaktinformasjon» og «Personvernombod» vere utfylte:
+### Rapport «Protokoll»
+
+Rapportvalet genererer ein HTML-rapport som berre inkluderer godkjende behandlingsaktivitetar, avgrensa til tema som omfattast av artikkel 30. For å kunne opprette denne rapporten, må alle obligatoriske felt under «Kontaktinformasjon» og «Personvernombod» vere utfylte.
 
 ![Bilete som viser temaene «Kontaktinformasjon» og «Personvernombod» i Behandlingsoversikt.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_kontakt_og_personvern_1b17c54e27.png)
 
 &nbsp;
 
-Dersom registreringsfelta under «Kontaktinformasjon» og «Personvernombod» <u>ikkje</u> er utfylte, blir rapportvala «Protokoll» og «Protokoll CSV» viste med grå tekst i menyen der ein vel rapport. Dette betyr at det ikkje er mogleg å generere rapportane:
+Dersom felta under «Kontaktinformasjon» og «Personvernombod» ikkje er utfylte, vil rapportvala «Protokoll» og «Protokoll CSV» visast som gråa ut i rapportmenyen
 
-![Bilete som viser at rapporttypane «Protokoll» og «Protokoll CSV» er deaktiverte under knappen «Generer rapport».](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapportalternativer_manglende_utfylling_722200b988.png)
-
-Når registreringsfelta under «Kontaktinformasjon» og «Personvernombod» er utfylte, kan ein starte generering av rapport «Protokoll» og «Protokoll CSV». Merk at i tillegg til at rapportane inneheld berre godkjende behandlingsaktivitetar, er innhaldet i kvar behandlingsaktivitet vidare avgrensa til berre å omhandle dei tema som er merkte som «Obligatorisk» i registreringsløysinga. Det vil seie at rapportane berre inneheld artikkel 30-temaene (protokoll-krava) samt namn på behandlingsaktiviteten. «Protokoll CSV» viser i tillegg organisasjonsnummeret til verksemda. Valfrie tema i registreringsløysinga blir difor ikkje viste i desse rapportane.
-
-
-#### Rapport «Protokoll»
-
-For at ein behandlingsaktivitet skal få status som godkjent, og dermed kunne visast i rapport «Protokoll», må alle obligatoriske tema i behandlingsaktiviteten vere utfylte, samt at behandlingsaktiviteten må ha status som «Godkjent». Godkjenning skjer ved å klikke på Godkjenn-knappen nedst inne i registreringsvindauget for den enkelte behandlingsaktiviteten. Her er eit døme frå rapport Protokoll:
+For at ein behandlingsaktivitet skal visast i rapporten «Protokoll», må alle obligatoriske tema i aktiviteten vere utfylte, og aktiviteten må ha status «Godkjend». Godkjenning blir gjort ved å klikke på Godkjenn-knappen nederst i registreringsvindauget for den aktuelle behandlingsaktiviteten. Her er eit eksempel frå rapporten «Protokoll»:
 
 ![Bilete av eit eksempel på rapport «Protokoll» som HTML.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_protokoll_html_6e789eaad5.png)
 
+&nbsp;
 
-#### Rapport «Protokoll CSV»
+### Rapport «Protokoll CSV»
 
-Rapport «Protokoll CSV» har same innhald som HTML-rapporten «Protokoll». I tillegg inneheld den verksemda sitt organisasjonsnummer. Den blir opna på same måte som rapport «Behandlingsoversikt CSV». Her er eit døme frå rapport «Protokoll CSV», opna i MS Excel:
+Rapporten «Protokoll CSV» genererer ei CSV-fil med same innhald som HTML-rapporten, men med verksemda sitt organisasjonsnummer som tillegg. Ho blir opna på same måte som rapporten «Behandlingsoversikt CSV». Nedanfor er eit eksempel på rapporten «Protokoll CSV» opna i MS Excel:
 
-![Bilete som viser døme på rapport «Protokoll CSV» opna i MS Excel.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_protokoll_CSV_eksempel_eba15ff1ec.png)
+![Bilete som viser eit eksempel på rapport «Protokoll CSV» opna i MS Excel.](https://cms.fellesdatakatalog.digdir.no/uploads/Behandlingsoversikt_rapport_protokoll_CSV_eksempel_eba15ff1ec.png)
 
 &nbsp;
 
-Om du har spørsmål til bruk av Behandlingsoversikt, eller treng hjelp med generering av rapportar, kan du ta kontakt med oss på e-postadressa [fellesdatakatalog@digdir.no](mailto:fellesdatakatalog@digdir.no)
-
+Har du spørsmål om bruk av Behandlingsoversikt eller treng hjelp med rapportgenerering, kan du kontakte oss på e-post: [fellesdatakatalog@digdir.no](mailto:fellesdatakatalog@digdir.no)

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-login/how-to-login.en.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-login/how-to-login.en.mdx
@@ -1,0 +1,13 @@
+---
+title: How to log in to Records of processing activities
+description: A guide on how to log in to the Records of processing activities. 
+
+---
+
+# How to log in to Records of processing activities
+
+&nbsp;
+
+<Alert size='sm'>
+    The guide is only available in Norwegian.
+</Alert>

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-login/how-to-login.nb.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-login/how-to-login.nb.mdx
@@ -1,0 +1,34 @@
+---
+title: Hvordan logge inn på Behandlingsoversikt
+description: Veiledning i hvordan du logger deg på Behandlingsoversikt. 
+
+---
+
+# Hvordan logge inn på Behandlingsoversikt
+
+<Alert size='sm'>
+    For å kunne logge inn på Behandlingsoversikt til egen virksomhet må du ha tilgang
+    til registreringsløsningen i Felles datakatalog. Les mer på nettsiden [Ta i bruk 
+    Felles datakatalog](https://samarbeid.digdir.no/felles-datakatalog/ta-i-bruk-felles-datakatalog/1619) 
+    om hvordan du får tilgang til registreringsløsningen.
+</Alert>
+
+&nbsp;
+ 
+Åpen nettsiden [Publisere i Felles datakatalog](https://data.norge.no/publishing) og klikk på lenken «Logg inn for å registrere» til venstre i skjermbildet:
+
+![Bilde som viser hvor man trykker for å logge inn på registreringsløsningen.](https://cms.fellesdatakatalog.digdir.no/uploads/Innlogging_registrering_c38f43d43a.png)
+
+&nbsp;
+
+Deretter velger du “Logg inn via ID-porten" til venstre i skjermbildet. Du kan eventuelt velge “Logg inn via Felles brukerhåndtering” dersom du tidligere har fått tilgang til å logge inn via denne løsningen. Ansatte i Brønnøysundregistrene og Skatteetaten kan eventuelt logge inn via egne innloggingsløsninger.
+
+![Bilde som viser de forskjellige innloggingsalternativene.](https://cms.fellesdatakatalog.digdir.no/uploads/Innlogging_alternativer_62081aab4d.png)
+
+&nbsp;
+
+Når du har logget inn i registreringsløsningen, klikker du på valget «Behandlingsoversikt».
+
+![Bilde som viser oversikt over hvilke kataloger som finnes for en virksomhet](https://cms.fellesdatakatalog.digdir.no/uploads/Registreringslosning_alle_kataloger_Behandlingsoversikt_d3c4c63095.png)
+
+Du kommer da inn i Behandlingsoversikten for din virksomhet. 

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-login/how-to-login.nn.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/how-to-login/how-to-login.nn.mdx
@@ -1,0 +1,34 @@
+---
+title: Korleis logge inn på Behandlingsoversikt
+description: Rettleiing for korleis du loggar deg inn på Behandlingsoversikt.
+
+---
+
+# Korleis logge inn på Behandlingsoversikt
+
+<Alert size='sm'>
+    For å kunne logge inn på Behandlingsoversikt for din verksemd må du ha tilgang til
+    registreringsløysinga i Felles datakatalog. Les meir på nettsida [Ta i bruk 
+    Felles datakatalog](https://samarbeid.digdir.no/felles-datakatalog/ta-i-bruk-felles-datakatalog/1619) 
+    om korleis du får tilgang til registreringsløysinga.
+</Alert>
+
+&nbsp;
+ 
+Opna nettsida [Publisere i Felles datakatalog](https://data.norge.no/publishing) og klikk på lenkja «Logg inn for å registrere» til venstre i skjermbiletet:
+
+![Bilete som viser kor ein trykkjer for å logge inn på registreringsløysinga.](https://cms.fellesdatakatalog.digdir.no/uploads/Innlogging_registrering_c38f43d43a.png)
+
+&nbsp;
+
+Deretter vel du «Logg inn via ID-porten» til venstre i skjermbiletet. Du kan eventuelt velje “Logg inn via Felles brukerhåndtering” dersom du tidlegare har fått tilgang til å logge inn via denne løysinga. Tilsette i Brønnøysundregistrene og Skatteetaten kan eventuelt logge inn via eigne innloggingsløysingar.
+
+![Bilete som viser dei ulike innloggingsalternativa.](https://cms.fellesdatakatalog.digdir.no/uploads/Innlogging_alternativer_62081aab4d.png)
+
+&nbsp;
+
+Når du har logga inn i registreringsløysinga, klikkar du på valet «Behandlingsoversikt».
+
+![Bilete som viser oversikt over kva for katalogar som finst for ei verksemd.](https://cms.fellesdatakatalog.digdir.no/uploads/Registreringslosning_alle_kataloger_Behandlingsoversikt_d3c4c63095.png)
+
+Du kjem då inn i Behandlingsoversikten for din verksemd.

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/records-of-processing-activities.en.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/records-of-processing-activities.en.mdx
@@ -1,0 +1,16 @@
+---
+title: Records of processing activities
+description: Records of processing activities is a solution where public organizations can register the data controller's protocol in accordance with the Personal Data Act (GDPR).
+
+---
+
+<Ingress>
+Records of processing activities is a solution where public organizations can register the data controller's protocol in accordance with the Personal Data Act (GDPR). Records of processing activities is part of the registration solution within the National Data Catalog.
+</Ingress>
+
+<Alert
+    severity='warning'
+    size='sm'
+>
+    The Norwegian Digitalisation Agency (Digdir) has decided to discontinue the solution as of 31.03.2025.
+</Alert>

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/records-of-processing-activities.en.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/records-of-processing-activities.en.mdx
@@ -1,14 +1,18 @@
 ---
 title: Records of processing activities
-description: Records of processing activities is a solution where public organizations can register the data controller's protocol in accordance with the Personal Data Act (GDPR).
+description: Records of processing activities is a solution where public organizations can register the data controller's protocol in accordance with the General Data Protection Regulation (GDPR).
 
 ---
 
 # Records of processing activities
 
-<Ingress>
-Records of processing activities is a solution where public organizations can register the data controller's protocol in accordance with the Personal Data Act (GDPR). Records of processing activities is part of the registration solution within the National Data Catalog.
-</Ingress>
+
+Records of processing activities is a solution where public organizations can register the data controller's protocol in accordance with the General Data Protection Regulation (GDPR). 
+
+The solution allows for the registration of contact information for the Data Controller and Data Protection Officer and meets the other requirements for what must be recorded in accordance with Article 30 "Records of processing activities" of the General Data Protection Regulation. It is also possible to register other relevant topics connected to Records of processing activities, such as information mentioned in Article 6 "Lawfulness of Processing" and Article 9 "Processing of Special Categories of Personal Data". The solution was developed based on the Norwegian Data Protection Authority’s "[Template for the Data Controller’s Protocol](https://www.datatilsynet.no/rettigheter-og-plikter/virksomhetenes-plikter/protokoll-over-behandlingsaktiviteter/)". Additionally, we have included options in the Records of processing activities to link processing activities to the organization’s dataset descriptions in the National Data Catalog (optional field).
+
+Records of processing activities is part of the registration solution within the National Data Catalog.
+
 
 &nbsp;
 

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/records-of-processing-activities.en.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/records-of-processing-activities.en.mdx
@@ -4,9 +4,13 @@ description: Records of processing activities is a solution where public organiz
 
 ---
 
+# Records of processing activities
+
 <Ingress>
 Records of processing activities is a solution where public organizations can register the data controller's protocol in accordance with the Personal Data Act (GDPR). Records of processing activities is part of the registration solution within the National Data Catalog.
 </Ingress>
+
+&nbsp;
 
 <Alert
     severity='warning'

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/records-of-processing-activities.nb.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/records-of-processing-activities.nb.mdx
@@ -6,9 +6,11 @@ description: Behandlingsoversikt er en løsning der offentlige virksomheter kan 
 
 # Behandlingsoversikt
 
-<Ingress>
-Behandlingsoversikt er en løsning der offentlige virksomheter kan registrere behandlingsansvarliges protokoll i henhold til Personopplysningsloven (GDPR). Behandlingsoversikt ligger i registeringsløsningen til Felles datakatalog.
-</Ingress>
+Behandlingsoversikt er en løsning der offentlige virksomheter kan registrere behandlingsansvarliges protokoll i henhold til Personopplysningsloven (GDPR).
+
+Løsningen gir muligheter for å registrere kontaktopplysninger for Behandlingsansvarlig og Personvernombud, samt at den oppfyller de øvrige kravene til hva som skal registreres i henhold til artikkel 30 «Protokoller over behandlingsaktiviteter» i Personopplysningsloven. Man kan også registrere andre tema som kan være nyttig å ha registrert i tilknytning til behandlingsaktiviteter, for eksempel informasjon som er nevnt i Artikkel 6 «Behandlingens lovlighet» og artikkel 9 «Behandling av særlige kategorier av personopplysninger. Det ble tatt utgangspunkt i Datatilsynet sin «[Mal for behandlingsansvarliges protokoll](https://www.datatilsynet.no/rettigheter-og-plikter/virksomhetenes-plikter/protokoll-over-behandlingsaktiviteter/)» da løsningen ble laget. I tillegg har vi lagt inn muligheter i Behandlingsoversikt for å kople behandlingsaktiviteter til virksomhetens datasettbeskrivelser i Felles datakatalog (valgfritt felt).
+
+Behandlingsoversikt ligger i registeringsløsningen til Felles datakatalog.
 
 &nbsp;
 

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/records-of-processing-activities.nb.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/records-of-processing-activities.nb.mdx
@@ -4,9 +4,13 @@ description: Behandlingsoversikt er en løsning der offentlige virksomheter kan 
 
 ---
 
+# Behandlingsoversikt
+
 <Ingress>
 Behandlingsoversikt er en løsning der offentlige virksomheter kan registrere behandlingsansvarliges protokoll i henhold til Personopplysningsloven (GDPR). Behandlingsoversikt ligger i registeringsløsningen til Felles datakatalog.
 </Ingress>
+
+&nbsp;
 
 <Alert
     severity='warning'

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/records-of-processing-activities.nb.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/records-of-processing-activities.nb.mdx
@@ -1,0 +1,16 @@
+---
+title: Behandlingsoversikt
+description: Behandlingsoversikt er en løsning der offentlige virksomheter kan registrere behandlingsansvarliges protokoll i henhold til Personopplysningsloven (GDPR). 
+
+---
+
+<Ingress>
+Behandlingsoversikt er en løsning der offentlige virksomheter kan registrere behandlingsansvarliges protokoll i henhold til Personopplysningsloven (GDPR). Behandlingsoversikt ligger i registeringsløsningen til Felles datakatalog.
+</Ingress>
+
+<Alert
+    severity='warning'
+    size='sm'
+>
+    Digitaliseringsdirektoratet (Digdir) har besluttet å legge ned løsningen fra 31.03.2025.
+</Alert>

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/records-of-processing-activities.nn.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/records-of-processing-activities.nn.mdx
@@ -1,0 +1,16 @@
+---
+title: Behandlingsoversikt
+description: Behandlingsoversikt er ei løysing der offentlege verksemder kan registrere protokollen til behandlingsansvarlege i samsvar med Personopplysningslova (GDPR).
+
+---
+
+<Ingress>
+Behandlingsoversikt er ei løysing der offentlege verksemder kan registrere protokollen til behandlingsansvarlege i samsvar med Personopplysningslova (GDPR). Behandlingsoversikt ligg i registreringsløysinga til Felles datakatalog.
+</Ingress>
+
+<Alert
+    severity='warning'
+    size='sm'
+>
+    Digitaliseringsdirektoratet (Digdir) har bestemt å leggje ned løysinga frå 31.03.2025.
+</Alert>

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/records-of-processing-activities.nn.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/records-of-processing-activities.nn.mdx
@@ -6,9 +6,11 @@ description: Behandlingsoversikt er ei løysing der offentlege verksemder kan re
 
 # Behandlingsoversikt
 
-<Ingress>
-Behandlingsoversikt er ei løysing der offentlege verksemder kan registrere protokollen til behandlingsansvarlege i samsvar med Personopplysningslova (GDPR). Behandlingsoversikt ligg i registreringsløysinga til Felles datakatalog.
-</Ingress>
+Behandlingsoversikt er ei løysing der offentlege verksemder kan registrere protokollen til behandlingsansvarleg i samsvar med Personopplysningslova (GDPR).
+
+Løysinga gir høve til å registrere kontaktopplysningar for Behandlingsansvarleg og Personvernombod, samt oppfyller dei andre krava til kva som skal registrerast i samsvar med artikkel 30 «Protokollar over behandlingsaktivitetar» i Personopplysningslova. Ein kan òg registrere andre tema som kan vere nyttige å ha i samband med behandlingsaktivitetar, til dømes informasjon omtalt i artikkel 6 «Lovleg grunnlag for behandling» og artikkel 9 «Behandling av særlege kategoriar av personopplysningar». Datatilsynet sin «[Mal for behandlingsansvarleg si protokoll](https://www.datatilsynet.no/rettigheter-og-plikter/virksomhetenes-plikter/protokoll-over-behandlingsaktiviteter/)» vart brukt som utgangspunkt då løysinga blei utvikla. I tillegg har vi lagt til moglegheiter i Behandlingsoversikt for å kople behandlingsaktivitetar til verksemda sine datasettbeskrivingar i Felles datakatalog (valfritt felt).
+
+Behandlingsoversikt er ein del av registreringsløysinga til Felles datakatalog.
 
 &nbsp;
 

--- a/apps/data-norge/public/content/docs/records-of-processing-activities/records-of-processing-activities.nn.mdx
+++ b/apps/data-norge/public/content/docs/records-of-processing-activities/records-of-processing-activities.nn.mdx
@@ -4,9 +4,13 @@ description: Behandlingsoversikt er ei løysing der offentlege verksemder kan re
 
 ---
 
+# Behandlingsoversikt
+
 <Ingress>
 Behandlingsoversikt er ei løysing der offentlege verksemder kan registrere protokollen til behandlingsansvarlege i samsvar med Personopplysningslova (GDPR). Behandlingsoversikt ligg i registreringsløysinga til Felles datakatalog.
 </Ingress>
+
+&nbsp;
 
 <Alert
     severity='warning'

--- a/libs/dictionaries/src/lib/dictionaries/nb/docs.json
+++ b/libs/dictionaries/src/lib/dictionaries/nb/docs.json
@@ -34,7 +34,7 @@
         "/docs/metadata-quality": "Metadatakvalitet",
         "/docs/resources": "Ressurser",
         "/docs/records-of-processing-activities": "Behandlingsoversikt",
-        "/docs/records-of-processing-activities/how-to-export-data": "Ta ut data"
+        "/docs/records-of-processing-activities/how-to-export-data": "Hvordan hente ut dine data"
     },
     "feedbackBanner": {
         "heading": "Finner du det du leter etter?",

--- a/libs/dictionaries/src/lib/dictionaries/nb/docs.json
+++ b/libs/dictionaries/src/lib/dictionaries/nb/docs.json
@@ -32,7 +32,9 @@
         "/docs/sharing-data/rdf/rdf-crash-course": "Kræsjkurs i RDF",
         "/docs/community": "Datalandsbyen",
         "/docs/metadata-quality": "Metadatakvalitet",
-        "/docs/resources": "Ressurser"
+        "/docs/resources": "Ressurser",
+        "/docs/records-of-processing-activities": "Behandlingsoversikt",
+        "/docs/records-of-processing-activities/how-to-export-data": "Ta ut data"
     },
     "feedbackBanner": {
         "heading": "Finner du det du leter etter?",

--- a/libs/dictionaries/src/lib/dictionaries/nb/docs.json
+++ b/libs/dictionaries/src/lib/dictionaries/nb/docs.json
@@ -34,6 +34,7 @@
         "/docs/metadata-quality": "Metadatakvalitet",
         "/docs/resources": "Ressurser",
         "/docs/records-of-processing-activities": "Behandlingsoversikt",
+        "/docs/records-of-processing-activities/how-to-login": "Hvordan logge inn",
         "/docs/records-of-processing-activities/how-to-export-data": "Hvordan hente ut dine data"
     },
     "feedbackBanner": {

--- a/libs/dictionaries/src/lib/dictionaries/nn/docs.json
+++ b/libs/dictionaries/src/lib/dictionaries/nn/docs.json
@@ -32,7 +32,9 @@
         "/docs/sharing-data/rdf/rdf-crash-course": "Kræsjkurs i RDF",
         "/docs/community": "Datalandsbyen",
         "/docs/metadata-quality": "Metadatakvalitet",
-        "/docs/resources": "Ressursar"
+        "/docs/resources": "Ressursar",
+        "/docs/records-of-processing-activities": "Behandlingsoversikt",
+        "/docs/records-of-processing-activities/how-to-export-data": "Ta ut data"
     },
     "feedbackBanner": {
         "heading": "Fann du det du leitte etter?",

--- a/libs/dictionaries/src/lib/dictionaries/nn/docs.json
+++ b/libs/dictionaries/src/lib/dictionaries/nn/docs.json
@@ -34,7 +34,7 @@
         "/docs/metadata-quality": "Metadatakvalitet",
         "/docs/resources": "Ressursar",
         "/docs/records-of-processing-activities": "Behandlingsoversikt",
-        "/docs/records-of-processing-activities/how-to-export-data": "Ta ut data"
+        "/docs/records-of-processing-activities/how-to-export-data": "Korleis hente ut dine data frå Behandlingsoversikt"
     },
     "feedbackBanner": {
         "heading": "Fann du det du leitte etter?",

--- a/libs/dictionaries/src/lib/dictionaries/nn/docs.json
+++ b/libs/dictionaries/src/lib/dictionaries/nn/docs.json
@@ -34,7 +34,8 @@
         "/docs/metadata-quality": "Metadatakvalitet",
         "/docs/resources": "Ressursar",
         "/docs/records-of-processing-activities": "Behandlingsoversikt",
-        "/docs/records-of-processing-activities/how-to-export-data": "Korleis hente ut dine data frå Behandlingsoversikt"
+        "/docs/records-of-processing-activities/how-to-login": "Korleis logge inn",
+        "/docs/records-of-processing-activities/how-to-export-data": "Korleis hente ut dine data"
     },
     "feedbackBanner": {
         "heading": "Fann du det du leitte etter?",


### PR DESCRIPTION
Added a page about the Record of processing activities and a guide for exporting data.

fix: #297 