### PR TITLE
Fix:include whole sentence in link text

### DIFF
--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/2-dataset-description/2-dataset-description.nb.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/2-dataset-description/2-dataset-description.nb.mdx
@@ -11,7 +11,7 @@ Da er du klar til å lage beskrivelsen i riktig format, sånn at det kan publise
     **Nyttig å vite**: Vi må lage beskrivelsen i et strukturert dataformat som data.norge.no sitt system kan forstå.
     Dette formatet heter RDF (Resource Description Framework) og er i bruk også blant andre europeiske dataportaler og i
     flere private virksomheter sine datakataloger. RDF kan skrives på flere ulike måter – i eksemplene under bruker vi
-    RDF-formatet som heter Turtle – men du velger selv hvilket du vil bruke. Du kan [lese mer om RDF
+    RDF-formatet som heter Turtle – men du velger selv hvilket du vil bruke. [Du kan lese mer om RDF
     her](/docs/sharing-data/rdf)
 </Alert>
 
@@ -30,6 +30,8 @@ Aller først må vi angi en unik identifikator for datasettbeskrivelsen, i form 
 For beskrivelsen av KI-prosjekter bruker vi URI-en `https://data.digdir.no/datasets/ai_projects_norwegian_state_dataset`
 
 Denne identifikatoren kan nå brukes av alle systemer overalt for å peke til nøyaktig den samme tingen.
+
+Les mer om URI-er og 
 
 ## Tittel og beskrivelse
 

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/2-dataset-description/2-dataset-description.nb.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/2-dataset-description/2-dataset-description.nb.mdx
@@ -31,8 +31,6 @@ For beskrivelsen av KI-prosjekter bruker vi URI-en `https://data.digdir.no/datas
 
 Denne identifikatoren kan nå brukes av alle systemer overalt for å peke til nøyaktig den samme tingen.
 
-Les mer om URI-er og 
-
 ## Tittel og beskrivelse
 
 Vi vil nå legge til tittelen vi har forberedt, både på bokmål, nynorsk og engelsk. Da bruker vi egenskapen `dct:title`, og kan angi språket for teksten med `@nb` for bokmål, `@nn` for nynorsk og `@en` for engelsk. Resultatet blir slik:


### PR DESCRIPTION
Wcag demand 2.2.4, "The purpose of each link can be determined from the link text alone or from the link text together with its programmatically determined link context, except where the purpose of the link would be ambiguous to users in general."

Examples from Uu-tilsynet that can be compared to this, includes the full sentence in the link text. http://uutilsynet.no/veiledning/244-formal-med-lenke-i-kontekst/1251