### PR TITLE
Fix:include whole sentence in link text-en

### DIFF
--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/2-dataset-description/2-dataset-description.en.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/2-dataset-description/2-dataset-description.en.mdx
@@ -11,7 +11,7 @@ Now you are ready to create the description in the correct format so that it can
     **Good to know**: We need to create the description in a structured data format that the data.norge.no system can
     understand. This format is called RDF (Resource Description Framework) and is also used by other European data
     portals and several private companies' data catalogs. RDF can be written in various ways – in the examples below, we
-    use the RDF format called Turtle – but you can choose which format to use. You can [read more about RDF
+    use the RDF format called Turtle – but you can choose which format to use. [You can read more about RDF
     here](/docs/sharing-data/rdf).
 </Alert>
 


### PR DESCRIPTION
Wcag demand 2.2.4, "The purpose of each link can be determined from the link text alone or from the link text together with its programmatically determined link context, except where the purpose of the link would be ambiguous to users in general."

Examples from Uu-tilsynet that can be compared to this, includes the full sentence in the link text. http://uutilsynet.no/veiledning/244-formal-med-lenke-i-kontekst/1251