### PR TITLE
Fix:include whole sentence in link text-nn

### DIFF
--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/2-dataset-description/2-dataset-description.nn.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/2-dataset-description/2-dataset-description.nn.mdx
@@ -11,7 +11,7 @@ No er du klar til å lage beskrivinga i rett format, slik at ho kan publiserast 
     **Nyttig å vite**: Vi må lage beskrivinga i eit strukturert dataformat som data.norge.no sitt system kan forstå.
     Dette formatet heiter RDF (Resource Description Framework) og er i bruk òg blant andre europeiske dataportalar og i
     fleire private verksemder sine datakatalogar. RDF kan skrivast på fleire ulike måtar – i døma under bruker vi
-    RDF-formatet som heiter Turtle – men du vel sjølv kva for eitt du vil bruke. Du kan [lese meir om RDF
+    RDF-formatet som heiter Turtle – men du vel sjølv kva for eitt du vil bruke. [Du kan lese meir om RDF
     her](/docs/sharing-data/rdf)
 </Alert>
 


### PR DESCRIPTION
Wcag demand 2.2.4, "The purpose of each link can be determined from the link text alone or from the link text together with its programmatically determined link context, except where the purpose of the link would be ambiguous to users in general."

Examples from Uu-tilsynet that can be compared to this, includes the full sentence in the link text. http://uutilsynet.no/veiledning/244-formal-med-lenke-i-kontekst/1251