### PR TITLE
Change:remove skatteetaten from organization-carousel

### DIFF
--- a/apps/data-norge/src/app/components/frontpage/organization-carousel/organizations.json
+++ b/apps/data-norge/src/app/components/frontpage/organization-carousel/organizations.json
@@ -24,7 +24,6 @@
     "Oslo kommune",
     "Registerenheten i Brønnøysund",
     "Riksantikvaren",
-    "Skatteetaten",
     "Sokkeldirektoratet",
     "Statens kartverk",
     "Statens lånekasse for utdanning",


### PR DESCRIPTION
This change removes Skatteetaten from organzation-carousel, as they have removed a dataset and are now below the threshold of 10 datasets, that is needed to be part of the carousel.