### PR TITLE
Add mandatory fields for catalog description in 5-catalog-and-complet…

### DIFF
--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.en.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.en.mdx
@@ -61,8 +61,7 @@ dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_datase
   dcat:contactPoint <https://data.digdir.no/contactpoint/kunstig_intelligens> ;
   dct:keyword "kunstig intelligens"@nb , "kunstig intelligens"@nn , "artificial intelligence"@en,
                 "offentlig sektor"@nb , "offentleg sektor"@nn , "public sector"@en ;
-  dcat:theme <http://publications.europa.eu/resource/authority/data-theme/GOVE>,
-               <http://eurovoc.europa.eu/3030> ;
+  dcat:theme <http://publications.europa.eu/resource/authority/data-theme/GOVE> ;
   dct:spatial <http://publications.europa.eu/resource/authority/country/NOR> ;
   prov:wasGeneratedBy <https://data.norge.no/vocabulary/provenance-activity-type#collecting-from-third-party> ;
   dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.en.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.en.mdx
@@ -27,10 +27,24 @@ The complete description with information on dataset, distribution, and data ser
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://data.digdir.no/catalog/1> a dcat:Catalog ;
-  dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_dataset> ;
+dct:title "Eksempelkatalog for datasett"@nb ,
+  "Eksempelkatalog for datasett"@nn ,
+  "Example catalog for datasets"@en ;
+dct:description 
+  "En eksempelkatalog for datasett som eies av Digitaliseringsdirektoratet, kun for å illustrere et eksempel"@nb , 
+  "Ei eksempelkatalog for datasett som eiges av Digitaliseringsdorektoratet, bare for å illustrera eit eksempel"@nn ,
+  "An example catalog for datasets that are owned by the Norwegian Digitalization Agency, for illustration purposes only."@en ;
+dct:publisher <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/991825827> ;
+dcat:contactPoint <https://data.digdir.no/contactpoint/informasjonsforvaltning> ;
+dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_dataset> ;
   .
 
-_:contactPoint a vcard:Organization ;
+<https://data.digdir.no/contactpoint/informasjonsforvaltning> a vcard:Organization ;
+  vcard:hasEmail "informasjonsforvaltning@digdir.no" ;
+  vcard:fn "Informasjonsforvaltning Digdir" ;
+  .
+
+<https://data.digdir.no/contactpoint/kunstig_intelligens> a vcard:Organization ;
   vcard:hasEmail "kunstigintelligens@digdir.no" ;
   vcard:fn "Kunstig Intelligens Digdir" ;
   .
@@ -43,7 +57,7 @@ _:contactPoint a vcard:Organization ;
                     "Ei oversikt over kunstig intelligens-prosjekt i offentleg sektor. Oversikta er ikkje komplett"@nn ,
                     "An overview of artificial intelligence projects in the public sector. The overview is not complete."@en ;
   dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
-  dcat:contactPoint _:contactPoint ;
+  dcat:contactPoint <https://data.digdir.no/contactpoint/kunstig_intelligens> ;
   dct:keyword "kunstig intelligens"@nb , "kunstig intelligens"@nn , "artificial intelligence"@en,
                 "offentlig sektor"@nb , "offentleg sektor"@nn , "public sector"@en ;
   dcat:theme <http://publications.europa.eu/resource/authority/data-theme/GOVE>,
@@ -64,6 +78,14 @@ _:contactPoint a vcard:Organization ;
   dct:language <http://publications.europa.eu/resource/authority/language/NOB> ;
   .
 
+<https://data.digdir.no/datasets/ai_projects_norwegian_state_api> a dcat:DataService ;
+  dcat:servesDataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_dataset> ;
+  dcat:endpointURL <https://data.digdir.no/api/ai_projects_norwegian_state> ; # fiktiv URL, fungerer ikke!
+  dct:title "API for oversikt over KI-prosjekter i offentlig sektor"@nb ;
+  dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
+  dcat:contactPoint <https://data.digdir.no/contactpoint/kunstig_intelligens> ;
+  .
+```
 <https://data.digdir.no/datasets/ai_projects_norwegian_state_api> a dcat:DataService ;
   dcat:servesDataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_dataset> ;
   dcat:endpointURL <https://data.digdir.no/api/ai_projects_norwegian_state> ; # fictious URL, does not work!

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.en.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.en.mdx
@@ -66,6 +66,7 @@ dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_datase
   prov:wasGeneratedBy <https://data.norge.no/vocabulary/provenance-activity-type#collecting-from-third-party> ;
   dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
   foaf:page <https://data.norge.no/kunstig-intelligens> ;
+  dcat:distribution <https://data.digdir.no/datasets/ai_projects_norwegian_state_distribution> ;
   .
 
 <https://data.digdir.no/datasets/ai_projects_norwegian_state_distribution> a dcat:Distribution ;

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.en.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.en.mdx
@@ -15,7 +15,7 @@ Finally, we need to link the dataset we have described to a catalog; the catalog
 
 In this example, we assume that Digdir has one data catalog (`dcat:Catalog`) that contains all the datasets Digdir has published information about, and that the URI of the catalog is `https://data.digdir.no/catalog/1`.
 
-The complete description with information on dataset, distribution, and data service/API would then look like this:
+The complete description with information on dataset and distribution would then look like this:
 
 ```turtle
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
@@ -72,18 +72,11 @@ dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_datase
 <https://data.digdir.no/datasets/ai_projects_norwegian_state_distribution> a dcat:Distribution ;
   dcat:accessURL <https://github.com/Informasjonsforvaltning/ai-project-service/blob/main/ai_projects_norwegian_state%20-%20Oversatt_v1.csv> ;
   dcat:downloadURL <https://raw.githubusercontent.com/Informasjonsforvaltning/ai-project-service/main/ai_projects_norwegian_state%20-%20Oversatt_v1.csv> ;
+  dcat:accessService <https://data.digdir.no/apis/ai_projects_norwegian_state_api> ;
   dct:description "CSV-fil med oversikt over kunstig intelligens-prosjekter i offentlig sektor"@nb ;
   dct:issued "2023-02-23"^^xsd:date ;
   dct:license <http://publications.europa.eu/resource/authority/licence/CC0> ;
   dct:format <http://publications.europa.eu/resource/authority/file-type/CSV> ;
   dct:language <http://publications.europa.eu/resource/authority/language/NOB> ;
-  .
-
-<https://data.digdir.no/datasets/ai_projects_norwegian_state_api> a dcat:DataService ;
-  dcat:servesDataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_dataset> ;
-  dcat:endpointURL <https://data.digdir.no/api/ai_projects_norwegian_state> ; # fiktiv URL, fungerer ikke!
-  dct:title "API for oversikt over KI-prosjekter i offentlig sektor"@nb ;
-  dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
-  dcat:contactPoint <https://data.digdir.no/contactpoint/kunstig_intelligens> ;
   .
 ```

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.en.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.en.mdx
@@ -40,8 +40,9 @@ dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_datase
   .
 
 <https://data.digdir.no/contactpoint/informasjonsforvaltning> a vcard:Organization ;
-  vcard:hasEmail "informasjonsforvaltning@digdir.no" ;
-  vcard:fn "Informasjonsforvaltning Digdir" ;
+  vcard:hasEmail "mailto:informasjonsforvaltning@digdir.no" ;
+  vcard:hasURL <https://data.norge.no/specification/dcat-ap-no#Kontaktopplysning-kontaktside> ;
+  vcard:fn "Informasjonsforvaltning Digdir"@nb ;
   .
 
 <https://data.digdir.no/contactpoint/kunstig_intelligens> a vcard:Organization ;
@@ -63,7 +64,7 @@ dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_datase
   dcat:theme <http://publications.europa.eu/resource/authority/data-theme/GOVE>,
                <http://eurovoc.europa.eu/3030> ;
   dct:spatial <http://publications.europa.eu/resource/authority/country/NOR> ;
-  prov:wasGeneratedBy provno:collectingFromThirdparty ;
+  prov:wasGeneratedBy <https://data.norge.no/vocabulary/provenance-activity-type#collecting-from-third-party> ;
   dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
   foaf:page <https://data.norge.no/kunstig-intelligens> ;
   .

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.en.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.en.mdx
@@ -62,7 +62,6 @@ dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_datase
   dct:keyword "kunstig intelligens"@nb , "kunstig intelligens"@nn , "artificial intelligence"@en,
                 "offentlig sektor"@nb , "offentleg sektor"@nn , "public sector"@en ;
   dcat:theme <http://publications.europa.eu/resource/authority/data-theme/GOVE> ;
-  dct:spatial <http://publications.europa.eu/resource/authority/country/NOR> ;
   prov:wasGeneratedBy <https://data.norge.no/vocabulary/provenance-activity-type#collecting-from-third-party> ;
   dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
   foaf:page <https://data.norge.no/kunstig-intelligens> ;

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.en.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.en.mdx
@@ -86,11 +86,3 @@ dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_datase
   dcat:contactPoint <https://data.digdir.no/contactpoint/kunstig_intelligens> ;
   .
 ```
-<https://data.digdir.no/datasets/ai_projects_norwegian_state_api> a dcat:DataService ;
-  dcat:servesDataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_dataset> ;
-  dcat:endpointURL <https://data.digdir.no/api/ai_projects_norwegian_state> ; # fictious URL, does not work!
-  dct:title "API for oversikt over KI-prosjekter i offentlig sektor"@nb ;
-  dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
-  dcat:contactPoint _:contactPoint ;
-  .
-```

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nb.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nb.mdx
@@ -61,8 +61,7 @@ dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_datase
   dcat:contactPoint <https://data.digdir.no/contactpoint/kunstig_intelligens> ;
   dct:keyword "kunstig intelligens"@nb , "kunstig intelligens"@nn , "artificial intelligence"@en,
                 "offentlig sektor"@nb , "offentleg sektor"@nn , "public sector"@en ;
-  dcat:theme <http://publications.europa.eu/resource/authority/data-theme/GOVE>,
-               <http://eurovoc.europa.eu/3030> ;
+  dcat:theme <http://publications.europa.eu/resource/authority/data-theme/GOVE> ;
   dct:spatial <http://publications.europa.eu/resource/authority/country/NOR> ;
   prov:wasGeneratedBy <https://data.norge.no/vocabulary/provenance-activity-type#collecting-from-third-party> ;
   dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nb.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nb.mdx
@@ -41,6 +41,7 @@ dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_datase
 
 <https://data.digdir.no/contactpoint/informasjonsforvaltning> a vcard:Organization ;
   vcard:hasEmail "mailto:informasjonsforvaltning@digdir.no" ;
+  vcard:hasURL <https://data.norge.no/specification/dcat-ap-no#Kontaktopplysning-kontaktside> ;
   vcard:fn "Informasjonsforvaltning Digdir"@nb ;
   .
 
@@ -63,7 +64,7 @@ dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_datase
   dcat:theme <http://publications.europa.eu/resource/authority/data-theme/GOVE>,
                <http://eurovoc.europa.eu/3030> ;
   dct:spatial <http://publications.europa.eu/resource/authority/country/NOR> ;
-  prov:wasGeneratedBy provno:collectingFromThirdparty ;
+  prov:wasGeneratedBy <https://data.norge.no/vocabulary/provenance-activity-type#collecting-from-third-party> ;
   dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
   foaf:page <https://data.norge.no/kunstig-intelligens> ;
   .

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nb.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nb.mdx
@@ -66,6 +66,7 @@ dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_datase
   prov:wasGeneratedBy <https://data.norge.no/vocabulary/provenance-activity-type#collecting-from-third-party> ;
   dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
   foaf:page <https://data.norge.no/kunstig-intelligens> ;
+  dcat:distribution <https://data.digdir.no/datasets/ai_projects_norwegian_state_distribution> ;
   .
 
 <https://data.digdir.no/datasets/ai_projects_norwegian_state_distribution> a dcat:Distribution ;

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nb.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nb.mdx
@@ -72,7 +72,7 @@ dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_datase
 <https://data.digdir.no/datasets/ai_projects_norwegian_state_distribution> a dcat:Distribution ;
   dcat:accessURL <https://github.com/Informasjonsforvaltning/ai-project-service/blob/main/ai_projects_norwegian_state%20-%20Oversatt_v1.csv> ;
   dcat:downloadURL <https://raw.githubusercontent.com/Informasjonsforvaltning/ai-project-service/main/ai_projects_norwegian_state%20-%20Oversatt_v1.csv> ;
-  dcat:accessService <https://data.digdir.no/apis/ai_projects_norwegian_state_api>
+  dcat:accessService <https://data.digdir.no/apis/ai_projects_norwegian_state_api> ;
   dct:description "CSV-fil med oversikt over kunstig intelligens-prosjekter i offentlig sektor"@nb ;
   dct:issued "2023-02-23"^^xsd:date ;
   dct:license <http://publications.europa.eu/resource/authority/licence/CC0> ;

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nb.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nb.mdx
@@ -15,7 +15,7 @@ Helt til slutt må vi knytte datasettet vi har beskrevet til en katalog, katalog
 
 I eksemplet her antar vi at Digdir har én datakatalog (`dcat:Catalog`) som inneholder alle datasettene Digdir har publisert informasjon om, og at URI-en til katalogen er `https://data.digdir.no/catalog/1` .
 
-Den komplette beskrivelsen med beskrivelse av datasett, distribusjon og datatjeneste/API ser da slik ut:
+Den komplette beskrivelsen med beskrivelse av datasett og distribusjon ser da slik ut:
 
 ```turtle
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
@@ -72,18 +72,11 @@ dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_datase
 <https://data.digdir.no/datasets/ai_projects_norwegian_state_distribution> a dcat:Distribution ;
   dcat:accessURL <https://github.com/Informasjonsforvaltning/ai-project-service/blob/main/ai_projects_norwegian_state%20-%20Oversatt_v1.csv> ;
   dcat:downloadURL <https://raw.githubusercontent.com/Informasjonsforvaltning/ai-project-service/main/ai_projects_norwegian_state%20-%20Oversatt_v1.csv> ;
+  dcat:accessService <https://data.digdir.no/apis/ai_projects_norwegian_state_api>
   dct:description "CSV-fil med oversikt over kunstig intelligens-prosjekter i offentlig sektor"@nb ;
   dct:issued "2023-02-23"^^xsd:date ;
   dct:license <http://publications.europa.eu/resource/authority/licence/CC0> ;
   dct:format <http://publications.europa.eu/resource/authority/file-type/CSV> ;
   dct:language <http://publications.europa.eu/resource/authority/language/NOB> ;
-  .
-
-<https://data.digdir.no/datasets/ai_projects_norwegian_state_api> a dcat:DataService ;
-  dcat:servesDataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_dataset> ;
-  dcat:endpointURL <https://data.digdir.no/api/ai_projects_norwegian_state> ; # fiktiv URL, fungerer ikke!
-  dct:title "API for oversikt over KI-prosjekter i offentlig sektor"@nb ;
-  dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
-  dcat:contactPoint <https://data.digdir.no/contactpoint/kunstig_intelligens> ;
   .
 ```

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nb.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nb.mdx
@@ -35,19 +35,18 @@ dct:description
   "Ei eksempelkatalog for datasett som eiges av Digitaliseringsdorektoratet, bare for å illustrera eit eksempel"@nn ,
   "An example catalog for datasets that are owned by the Norwegian Digitalization Agency, for illustration purposes only."@en ;
 dct:publisher <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/991825827> ;
-dcat:contactPoint _:contactPoint1
-dcat:dataset 
-  <https://data.digdir.no/datasets/ai_projects_norwegian_state_dataset> ;
+dcat:contactPoint <https://data.digdir.no/contactpoint/informasjonsforvaltning> ;
+dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_dataset> ;
   .
 
-_:contactPoint1 a vcard:Organization ;
-  vcard:hasEmail "informasjonsforvaltning@digdir.no" ;
-  vcard:fn "Informasjonsforvaltning Digdir" ;
+<https://data.digdir.no/contactpoint/informasjonsforvaltning> a vcard:Organization ;
+  vcard:hasEmail "mailto:informasjonsforvaltning@digdir.no" ;
+  vcard:fn "Informasjonsforvaltning Digdir"@nb ;
   .
 
-_:contactPoint2 a vcard:Organization ;
-  vcard:hasEmail "kunstigintelligens@digdir.no" ;
-  vcard:fn "Kunstig Intelligens Digdir" ;
+<https://data.digdir.no/contactpoint/kunstig_intelligens> a vcard:Organization ;
+  vcard:hasEmail "mailto:kunstigintelligens@digdir.no" ;
+  vcard:fn "Kunstig Intelligens Digdir"@nb ;
   .
 
 <https://data.digdir.no/datasets/ai_projects_norwegian_state_dataset> a dcat:Dataset ;
@@ -58,7 +57,7 @@ _:contactPoint2 a vcard:Organization ;
                     "Ei oversikt over kunstig intelligens-prosjekt i offentleg sektor. Oversikta er ikkje komplett"@nn ,
                     "An overview of artificial intelligence projects in the public sector. The overview is not complete."@en ;
   dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
-  dcat:contactPoint _:contactPoint2 ;
+  dcat:contactPoint <https://data.digdir.no/contactpoint/kunstig_intelligens> ;
   dct:keyword "kunstig intelligens"@nb , "kunstig intelligens"@nn , "artificial intelligence"@en,
                 "offentlig sektor"@nb , "offentleg sektor"@nn , "public sector"@en ;
   dcat:theme <http://publications.europa.eu/resource/authority/data-theme/GOVE>,
@@ -84,6 +83,6 @@ _:contactPoint2 a vcard:Organization ;
   dcat:endpointURL <https://data.digdir.no/api/ai_projects_norwegian_state> ; # fiktiv URL, fungerer ikke!
   dct:title "API for oversikt over KI-prosjekter i offentlig sektor"@nb ;
   dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
-  dcat:contactPoint _:contactPoint2 ;
+  dcat:contactPoint <https://data.digdir.no/contactpoint/kunstig_intelligens> ;
   .
 ```

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nb.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nb.mdx
@@ -35,7 +35,7 @@ dct:description
   "Ei eksempelkatalog for datasett som eiges av Digitaliseringsdorektoratet, bare for å illustrera eit eksempel"@nn ,
   "An example catalog for datasets that are owned by the Norwegian Digitalization Agency, for illustration purposes only."@en ;
 dct:publisher <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/991825827> ;
-dcat:contactPoint _:contactPoint
+dcat:contactPoint _:contactPoint1
 dcat:dataset 
   <https://data.digdir.no/datasets/ai_projects_norwegian_state_dataset> ;
   .
@@ -58,7 +58,7 @@ _:contactPoint2 a vcard:Organization ;
                     "Ei oversikt over kunstig intelligens-prosjekt i offentleg sektor. Oversikta er ikkje komplett"@nn ,
                     "An overview of artificial intelligence projects in the public sector. The overview is not complete."@en ;
   dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
-  dcat:contactPoint _:contactPoint ;
+  dcat:contactPoint _:contactPoint2 ;
   dct:keyword "kunstig intelligens"@nb , "kunstig intelligens"@nn , "artificial intelligence"@en,
                 "offentlig sektor"@nb , "offentleg sektor"@nn , "public sector"@en ;
   dcat:theme <http://publications.europa.eu/resource/authority/data-theme/GOVE>,
@@ -84,6 +84,6 @@ _:contactPoint2 a vcard:Organization ;
   dcat:endpointURL <https://data.digdir.no/api/ai_projects_norwegian_state> ; # fiktiv URL, fungerer ikke!
   dct:title "API for oversikt over KI-prosjekter i offentlig sektor"@nb ;
   dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
-  dcat:contactPoint _:contactPoint ;
+  dcat:contactPoint _:contactPoint2 ;
   .
 ```

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nb.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nb.mdx
@@ -27,10 +27,25 @@ Den komplette beskrivelsen med beskrivelse av datasett, distribusjon og datatjen
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://data.digdir.no/catalog/1> a dcat:Catalog ;
-  dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_dataset> ;
+dct:title "Eksempelkatalog for datasett"@nb ,
+  "Eksempelkatalog for datasett"@nn ,
+  "Example catalog for datasets"@en ;
+dct:description 
+  "En eksempelkatalog for datasett som eies av Digitaliseringsdirektoratet, kun for å illustrere et eksempel"@nb , 
+  "Ei eksempelkatalog for datasett som eiges av Digitaliseringsdorektoratet, bare for å illustrera eit eksempel"@nn ,
+  "An example catalog for datasets that are owned by the Norwegian Digitalization Agency, for illustration purposes only."@en ;
+dct:publisher <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/991825827> ;
+dcat:contactPoint _:contactPoint
+dcat:dataset 
+  <https://data.digdir.no/datasets/ai_projects_norwegian_state_dataset> ;
   .
 
-_:contactPoint a vcard:Organization ;
+_:contactPoint1 a vcard:Organization ;
+  vcard:hasEmail "informasjonsforvaltning@digdir.no" ;
+  vcard:fn "Informasjonsforvaltning Digdir" ;
+  .
+
+_:contactPoint2 a vcard:Organization ;
   vcard:hasEmail "kunstigintelligens@digdir.no" ;
   vcard:fn "Kunstig Intelligens Digdir" ;
   .

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nb.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nb.mdx
@@ -62,7 +62,6 @@ dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_datase
   dct:keyword "kunstig intelligens"@nb , "kunstig intelligens"@nn , "artificial intelligence"@en,
                 "offentlig sektor"@nb , "offentleg sektor"@nn , "public sector"@en ;
   dcat:theme <http://publications.europa.eu/resource/authority/data-theme/GOVE> ;
-  dct:spatial <http://publications.europa.eu/resource/authority/country/NOR> ;
   prov:wasGeneratedBy <https://data.norge.no/vocabulary/provenance-activity-type#collecting-from-third-party> ;
   dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
   foaf:page <https://data.norge.no/kunstig-intelligens> ;

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nn.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nn.mdx
@@ -61,8 +61,7 @@ dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_datase
   dcat:contactPoint <https://data.digdir.no/contactpoint/kunstig_intelligens> ;
   dct:keyword "kunstig intelligens"@nb , "kunstig intelligens"@nn , "artificial intelligence"@en,
                 "offentlig sektor"@nb , "offentleg sektor"@nn , "public sector"@en ;
-  dcat:theme <http://publications.europa.eu/resource/authority/data-theme/GOVE>,
-               <http://eurovoc.europa.eu/3030> ;
+  dcat:theme <http://publications.europa.eu/resource/authority/data-theme/GOVE> ;
   dct:spatial <http://publications.europa.eu/resource/authority/country/NOR> ;
   prov:wasGeneratedBy <https://data.norge.no/vocabulary/provenance-activity-type#collecting-from-third-party> ;
   dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nn.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nn.mdx
@@ -15,7 +15,7 @@ Helt til slutt må vi knytte datasettet vi har beskrevet til ein katalog, katalo
 
 I eksempelet her går vi ut frå at Digdir har ein datakatalog (`dcat:Catalog`) som inneheld alle datasetta Digdir har publisert informasjon om, og at URI-en til katalogen er `https://data.digdir.no/catalog/1`.
 
-Den komplette beskrivelsen med beskriving av datasett, distribusjon og datatjeneste/API ser då slik ut:
+Den komplette beskrivinga med beskriving av datasett og distribusjon ser då slik ut:
 
 ```turtle
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
@@ -72,18 +72,11 @@ dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_datase
 <https://data.digdir.no/datasets/ai_projects_norwegian_state_distribution> a dcat:Distribution ;
   dcat:accessURL <https://github.com/Informasjonsforvaltning/ai-project-service/blob/main/ai_projects_norwegian_state%20-%20Oversatt_v1.csv> ;
   dcat:downloadURL <https://raw.githubusercontent.com/Informasjonsforvaltning/ai-project-service/main/ai_projects_norwegian_state%20-%20Oversatt_v1.csv> ;
+  dcat:accessService <https://data.digdir.no/apis/ai_projects_norwegian_state_api> ;
   dct:description "CSV-fil med oversikt over kunstig intelligens-prosjekter i offentlig sektor"@nb ;
   dct:issued "2023-02-23"^^xsd:date ;
   dct:license <http://publications.europa.eu/resource/authority/licence/CC0> ;
   dct:format <http://publications.europa.eu/resource/authority/file-type/CSV> ;
   dct:language <http://publications.europa.eu/resource/authority/language/NOB> ;
-  .
-
-<https://data.digdir.no/datasets/ai_projects_norwegian_state_api> a dcat:DataService ;
-  dcat:servesDataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_dataset> ;
-  dcat:endpointURL <https://data.digdir.no/api/ai_projects_norwegian_state> ; # fiktiv URL, fungerer ikke!
-  dct:title "API for oversikt over KI-prosjekter i offentlig sektor"@nb ;
-  dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
-  dcat:contactPoint <https://data.digdir.no/contactpoint/kunstig_intelligens> ;
   .
 ```

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nn.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nn.mdx
@@ -66,6 +66,7 @@ dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_datase
   prov:wasGeneratedBy <https://data.norge.no/vocabulary/provenance-activity-type#collecting-from-third-party> ;
   dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
   foaf:page <https://data.norge.no/kunstig-intelligens> ;
+  dcat:distribution <https://data.digdir.no/datasets/ai_projects_norwegian_state_distribution> ;
   .
 
 <https://data.digdir.no/datasets/ai_projects_norwegian_state_distribution> a dcat:Distribution ;

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nn.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nn.mdx
@@ -40,8 +40,9 @@ dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_datase
   .
 
 <https://data.digdir.no/contactpoint/informasjonsforvaltning> a vcard:Organization ;
-  vcard:hasEmail "informasjonsforvaltning@digdir.no" ;
-  vcard:fn "Informasjonsforvaltning Digdir" ;
+  vcard:hasEmail "mailto:informasjonsforvaltning@digdir.no" ;
+  vcard:hasURL <https://data.norge.no/specification/dcat-ap-no#Kontaktopplysning-kontaktside> ;
+  vcard:fn "Informasjonsforvaltning Digdir"@nb ;
   .
 
 <https://data.digdir.no/contactpoint/kunstig_intelligens> a vcard:Organization ;
@@ -63,7 +64,7 @@ dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_datase
   dcat:theme <http://publications.europa.eu/resource/authority/data-theme/GOVE>,
                <http://eurovoc.europa.eu/3030> ;
   dct:spatial <http://publications.europa.eu/resource/authority/country/NOR> ;
-  prov:wasGeneratedBy provno:collectingFromThirdparty ;
+  prov:wasGeneratedBy <https://data.norge.no/vocabulary/provenance-activity-type#collecting-from-third-party> ;
   dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
   foaf:page <https://data.norge.no/kunstig-intelligens> ;
   .

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nn.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nn.mdx
@@ -27,9 +27,24 @@ Den komplette beskrivelsen med beskriving av datasett, distribusjon og datatjene
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://data.digdir.no/catalog/1> a dcat:Catalog ;
-  dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_dataset> ;
+dct:title "Eksempelkatalog for datasett"@nb ,
+  "Eksempelkatalog for datasett"@nn ,
+  "Example catalog for datasets"@en ;
+dct:description 
+  "En eksempelkatalog for datasett som eies av Digitaliseringsdirektoratet, kun for å illustrere et eksempel"@nb , 
+  "Ei eksempelkatalog for datasett som eiges av Digitaliseringsdorektoratet, bare for å illustrera eit eksempel"@nn ,
+  "An example catalog for datasets that are owned by the Norwegian Digitalization Agency, for illustration purposes only."@en ;
+dct:publisher <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/991825827> ;
+dcat:contactPoint <https://data.digdir.no/contactpoint/informasjonsforvaltning> ;
+dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_dataset> ;
   .
-_:contactPoint a vcard:Organization ;
+
+<https://data.digdir.no/contactpoint/informasjonsforvaltning> a vcard:Organization ;
+  vcard:hasEmail "informasjonsforvaltning@digdir.no" ;
+  vcard:fn "Informasjonsforvaltning Digdir" ;
+  .
+
+<https://data.digdir.no/contactpoint/kunstig_intelligens> a vcard:Organization ;
   vcard:hasEmail "kunstigintelligens@digdir.no" ;
   vcard:fn "Kunstig Intelligens Digdir" ;
   .
@@ -42,7 +57,7 @@ _:contactPoint a vcard:Organization ;
                     "Ei oversikt over kunstig intelligens-prosjekt i offentleg sektor. Oversikta er ikkje komplett"@nn ,
                     "An overview of artificial intelligence projects in the public sector. The overview is not complete."@en ;
   dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
-  dcat:contactPoint _:contactPoint ;
+  dcat:contactPoint <https://data.digdir.no/contactpoint/kunstig_intelligens> ;
   dct:keyword "kunstig intelligens"@nb , "kunstig intelligens"@nn , "artificial intelligence"@en,
                 "offentlig sektor"@nb , "offentleg sektor"@nn , "public sector"@en ;
   dcat:theme <http://publications.europa.eu/resource/authority/data-theme/GOVE>,
@@ -65,9 +80,9 @@ _:contactPoint a vcard:Organization ;
 
 <https://data.digdir.no/datasets/ai_projects_norwegian_state_api> a dcat:DataService ;
   dcat:servesDataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_dataset> ;
-  dcat:endpointURL <https://data.digdir.no/api/ai_projects_norwegian_state> ; # fiktiv URL, fungerar ikkje!
+  dcat:endpointURL <https://data.digdir.no/api/ai_projects_norwegian_state> ; # fiktiv URL, fungerer ikke!
   dct:title "API for oversikt over KI-prosjekter i offentlig sektor"@nb ;
   dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
-  dcat:contactPoint _:contactPoint ;
+  dcat:contactPoint <https://data.digdir.no/contactpoint/kunstig_intelligens> ;
   .
 ```

--- a/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nn.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/how-to-dataset/5-catalog-and-complete-description/5-catalog-and-complete-description.nn.mdx
@@ -62,7 +62,6 @@ dcat:dataset <https://data.digdir.no/datasets/ai_projects_norwegian_state_datase
   dct:keyword "kunstig intelligens"@nb , "kunstig intelligens"@nn , "artificial intelligence"@en,
                 "offentlig sektor"@nb , "offentleg sektor"@nn , "public sector"@en ;
   dcat:theme <http://publications.europa.eu/resource/authority/data-theme/GOVE> ;
-  dct:spatial <http://publications.europa.eu/resource/authority/country/NOR> ;
   prov:wasGeneratedBy <https://data.norge.no/vocabulary/provenance-activity-type#collecting-from-third-party> ;
   dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
   foaf:page <https://data.norge.no/kunstig-intelligens> ;


### PR DESCRIPTION
…e-description.nb.mdx

Adds mandatory fields and an additional contact point for the catalog description in the  turtle example. 

When this addition is approved, I will make the same changes in the english and nynorsk version of the page.