### PR TITLE
Updated texts about Datalandsbyen

### DIFF
--- a/apps/data-norge/public/content/docs/community/community.en.mdx
+++ b/apps/data-norge/public/content/docs/community/community.en.mdx
@@ -25,18 +25,21 @@ With a user account, you can:
 ## Tips for Use
 
 ### Request Data
-If you need help finding data or want to request that data be published, you can write a post in the [category "Request Datasets and APIs"](https://datalandsbyen.norge.no/category/6/ettersp%C3%B8r-datasett-og-api-er). We will follow up and contact relevant data providers and others in our network to assist you. Perhaps others in the Data Village also have tips for you?
+If you need help finding data or want to request that data be published, you can write a post in the [category "Etterspør datasett og API-er" (Request Datasets and APIs)](https://datalandsbyen.norge.no/category/6/ettersp%C3%B8r-datasett-og-api-er). We will follow up and contact relevant data providers and others in our network to assist you. Perhaps others in the Data Village also have tips for you?
 
 [Tips for writing a post about data requests (in norwegian)](https://datalandsbyen.norge.no/topic/56/ettersp%C3%B8rr-data-og-api).
 
 ### Questions or Comments on Datasets
 If you have questions or comments about a dataset described in data.norge.no, you can ask the question in the Data Village. We will then notify the data owner that a post has been made that they should respond to.
-Check if there is an existing discussion thread about the dataset you are interested in, or create a new thread in the [category "Comment Threads"](https://datalandsbyen.norge.no/category/12/kommentartr%C3%A5der). Existing discussion threads that link to the dataset can also be found on the dataset page in data.norge.no, under the "Discussions" tab.
+
+Please check if there is an existing discussion thread about the dataset you are interested in, or create a new thread in the [category "Kommentartråder" (Comment Threads)](https://datalandsbyen.norge.no/category/12/kommentartr%C3%A5der). Existing discussion threads that link to the dataset can also be found on the dataset page in data.norge.no, under the "Discussions" tab.
 
 ### Good Examples of Data Use
-In the category [“Good Examples of Use”](https://datalandsbyen.norge.no/category/2/gode-eksempler-p%C3%A5-bruk), you can find examples of how others have used data, whether it is to create an app, service, visualization, or something else.
+In the category ["Gode eksempler på bruk" (Good Examples of Use)](https://datalandsbyen.norge.no/category/2/gode-eksempler-p%C3%A5-bruk), you can find examples of how others have used data, whether it is to create an app, service, visualization, or something else.
 
 Have you created something with data that you would like to share? Feel free to post in this category.
+
+[Tips for writing a post about example of use of data (in norwegian)](https://datalandsbyen.norge.no/topic/60/tips-til-%C3%A5-dele-gode-eksempel-p%C3%A5-bruk-av-data).
 
 ## Feedback on data.norge.no
 If you have feedback or questions about data.norge.no, you can write a post in the [category "Tilbakemeldinger og nyheter" (Feedback and news)](https://datalandsbyen.norge.no/category/5/tilbakemeldinger-p%C3%A5-data-norge-no).

--- a/apps/data-norge/public/content/docs/community/community.en.mdx
+++ b/apps/data-norge/public/content/docs/community/community.en.mdx
@@ -1,12 +1,48 @@
 # Data Village
 
-[Data Village](https://datalandsbyen.norge.no/) is an online forum where you can request data, share experiences, and ask for advice on data sharing and information management.
+[Data Village](https://datalandsbyen.norge.no/) is an online forum about data sharing, information governance and related topics.
+
+Here you will meet others who work with data and data sharing, both in the public and private sectors. The Data Village is a place to share experiences, ask questions, and get help finding data.
+
+The Data Village is mainly in Norwegian, but you can write in English as well. When logged in, you can choose to change the language of the forum interface to English. This will not affect the content of the posts, but it will make it easier for you to navigate the forum.
 
 ## Getting Started
 
-To use Data Village, you need to register. This is easily done by following the steps below.
-Note: Anyone can read all content in Data Village without being registered.
+The Data Village is open to everyone. You can read all posts without registering. However, if you want to write posts, you need to create a user account. This is easily done by following the steps below.
+1. Go to [Datalandsbyen.norge.no](https://datalandsbyen.norge.no/)
+2. Click on `Log in` at the top right
+3. Select `Register` and follow the instructions if you do not already have a user account that you have used in other Digdir services, such as Samarbeidsportalen.
+4. Approve consent and terms of use for the online forum
 
-1. Register a user in the Common User Management
-2. Approve consent and terms of use for the online forum
-3. The first post published by a new user in the forum must be approved by an administrator
+The first post published by a new user in the forum must be approved by an administrator.
+
+With a user account, you can:
+- Write and reply to posts
+- Upvote posts
+- Subscribe to topics to receive email notifications about new posts
+- Choose to receive an email summary of recent activity in the forum
+
+## Tips for Use
+
+### Request Data
+If you need help finding data or want to request that data be published, you can write a post in the [category "Request Datasets and APIs"](https://datalandsbyen.norge.no/category/6/ettersp%C3%B8r-datasett-og-api-er). We will follow up and contact relevant data providers and others in our network to assist you. Perhaps others in the Data Village also have tips for you?
+
+[Tips for writing a post about data requests (in norwegian)](https://datalandsbyen.norge.no/topic/56/ettersp%C3%B8rr-data-og-api).
+
+### Questions or Comments on Datasets
+If you have questions or comments about a dataset described in data.norge.no, you can ask the question in the Data Village. We will then notify the data owner that a post has been made that they should respond to.
+Check if there is an existing discussion thread about the dataset you are interested in, or create a new thread in the [category "Comment Threads"](https://datalandsbyen.norge.no/category/12/kommentartr%C3%A5der). Existing discussion threads that link to the dataset can also be found on the dataset page in data.norge.no, under the "Discussions" tab.
+
+### Good Examples of Data Use
+In the category [“Good Examples of Use”](https://datalandsbyen.norge.no/category/2/gode-eksempler-p%C3%A5-bruk), you can find examples of how others have used data, whether it is to create an app, service, visualization, or something else.
+
+Have you created something with data that you would like to share? Feel free to post in this category.
+
+## Feedback on data.norge.no
+If you have feedback or questions about data.norge.no, you can write a post in the [category "Tilbakemeldinger og nyheter" (Feedback and news)](https://datalandsbyen.norge.no/category/5/tilbakemeldinger-p%C3%A5-data-norge-no).
+
+## Other
+In the Data Village, there are also categories for meetings and events, questions about law, artificial intelligence, information modeling, and more. Visit [Datalandsbyen](https://datalandsbyen.norge.no/) to see all categories.
+
+## Questions about the Data Village?
+Contact us at datalandsbyen@norge.no

--- a/apps/data-norge/public/content/docs/community/community.nb.mdx
+++ b/apps/data-norge/public/content/docs/community/community.nb.mdx
@@ -1,6 +1,8 @@
 # Datalandsbyen
 
-[Datalandsbyen](https://datalandsbyen.norge.no/) er et nettforum hvor man kan etterspørre data, dele erfaringer og spørre om råd som gjelder datadeling og informasjonsforvaltning.
+[Datalandsbyen](https://datalandsbyen.norge.no/) er et nettforum knytt til temaene datadeling og informasjonsforvaltning.
+
+Her møter du andre som jobber med data og datadeling, både i offentlig og privat sektor. Datalandsbyen er et sted for å dele erfaringer, stille spørsmål og få hjelp til å finne data.
 
 ## Ta i bruk
 

--- a/apps/data-norge/public/content/docs/community/community.nb.mdx
+++ b/apps/data-norge/public/content/docs/community/community.nb.mdx
@@ -24,17 +24,19 @@ Med en brukerkonto kan du:
 ### Etterspørre data
 Om du vil ha hjelp til å finne data, eller be om at data blir publisert, kan du skrive et innlegg i [kategorien «Etterspør datasett og API-er»](https://datalandsbyen.norge.no/category/6/ettersp%C3%B8r-datasett-og-api-er). Vi følger opp og kontakter aktuelle datatilbydere og andre i vårt nettverk for å hjelpe deg. Kanskje andre i Datalandsbyen også har tips til deg?
 
-Se [tips til å skrive innlegg om etterspørsel etter data](https://datalandsbyen.norge.no/topic/56/ettersp%C3%B8rr-data-og-api).
+[Tips til å skrive innlegg om etterspørsel etter data](https://datalandsbyen.norge.no/topic/56/ettersp%C3%B8rr-data-og-api).
 
 ### Spørsmål eller kommentarer på datasett
-Dersom du har spørsmål eller kommentarer til et datasett som er beskrivet i data.norge.no kan du stille spørsmålet i Datalandsbyen. Vi vil da gi beskjed til dataeier om at det er kommet et innlegg de bør svare på.
+Dersom du har spørsmål eller kommentarer til et datasett som er beskrevet i data.norge.no kan du stille spørsmålet i Datalandsbyen. Vi vil da gi beskjed til dataeier om at det er kommet et innlegg de bør svare på.
 
 Sjekk om det er en eksisterende diskusjonstråd om datasettet du lurer på, eller opprett en ny tråd i [kategorien «Kommentartråder»](https://datalandsbyen.norge.no/category/12/kommentartr%C3%A5der). Eksisterende diskusjonstråder som lenker til datasettet finner du også på siden til datasettet i data.norge.no, under fanen «Diskusjoner».
 
 ### Gode eksempel på bruk av data
 I kategorien [«Gode eksempler på bruk»](https://datalandsbyen.norge.no/category/2/gode-eksempler-p%C3%A5-bruk) finner du eksempel på hvordan andre har brukt data, enten det er til å lage en app, tjeneste, visualisering eller annet.
 
-Har du laget noe med data som du vil dele? Legg gjerne ut et innlegg i denne kategorien. Se [tips for å skrive innlegg om eksempel](https://datalandsbyen.norge.no/topic/60/tips-til-%C3%A5-dele-gode-eksempel-p%C3%A5-bruk-av-data).
+Har du laget noe med data som du vil dele? Legg gjerne ut et innlegg i denne kategorien. 
+
+[Tips for å skrive innlegg om eksempel](https://datalandsbyen.norge.no/topic/60/tips-til-%C3%A5-dele-gode-eksempel-p%C3%A5-bruk-av-data).
 
 ### Tilbakemeldinger på data.norge.no
 Dersom du har tilbakemeldinger eller spørsmål til data.norge.no kan du skrive et innlegg i [kategorien «Tilbakemeldinger og nyheter»](https://datalandsbyen.norge.no/category/5/tilbakemeldinger-p%C3%A5-data-norge-no).

--- a/apps/data-norge/public/content/docs/community/community.nb.mdx
+++ b/apps/data-norge/public/content/docs/community/community.nb.mdx
@@ -4,9 +4,43 @@
 
 ## Ta i bruk
 
-For å ta i bruk Datalandsbyen må du registrere deg. Dette gjøres enkelt ved å følge stegene under.
-NB. Alle kan lese alt innhold i Datalandsbyen uten å være registrert.
+Alle kan lese innlegg i Datalandsbyen. Dersom du vil skrive innlegg, må du lage en brukerkonto. Dette gjøres enkelt ved å følge stegene under.
 
-1. Registrer bruker i Felles brukerhåndtering
-2. Godkjenn samtykke og brukervilkår for nettforumet
-3. Første innlegg som publiseres av en ny bruker i forumet må godkjennes av en administrator
+1. Gå til [Datalandsbyen.norge.no](https://datalandsbyen.norge.no/)
+2. Klikk på `Logg inn` øverst til høyre
+3. Velg `Registrer deg` og følg instruksjonene dersom du ikke allerede har en brukerkonto du har brukt i andre Digdir-tjenester som for eksempel Samarbeidsportalen.
+4. Godkjenn samtykke og brukervilkår for nettforumet
+
+Første innlegg som publiseres av en ny bruker i forumet må godkjennes av en administrator.
+
+Med en brukerkonto kan du:
+- Skrive og svare på innlegg
+- Stemme opp innlegg
+- Abonnere på diskusjonstråder for å få varsler på e-post om nye innlegg
+- Velge å få e-post med sammendrag av nylig aktivitet på forumet
+
+## Tips til bruk
+
+### Etterspørre data
+Om du vil ha hjelp til å finne data, eller be om at data blir publisert, kan du skrive et innlegg i [kategorien «Etterspør datasett og API-er»](https://datalandsbyen.norge.no/category/6/ettersp%C3%B8r-datasett-og-api-er). Vi følger opp og kontakter aktuelle datatilbydere og andre i vårt nettverk for å hjelpe deg. Kanskje andre i Datalandsbyen også har tips til deg?
+
+Se [tips til å skrive innlegg om etterspørsel etter data](https://datalandsbyen.norge.no/topic/56/ettersp%C3%B8rr-data-og-api).
+
+### Spørsmål eller kommentarer på datasett
+Dersom du har spørsmål eller kommentarer til et datasett som er beskrivet i data.norge.no kan du stille spørsmålet i Datalandsbyen. Vi vil da gi beskjed til dataeier om at det er kommet et innlegg de bør svare på.
+
+Sjekk om det er en eksisterende diskusjonstråd om datasettet du lurer på, eller opprett en ny tråd i [kategorien «Kommentartråder»](https://datalandsbyen.norge.no/category/12/kommentartr%C3%A5der). Eksisterende diskusjonstråder som lenker til datasettet finner du også på siden til datasettet i data.norge.no, under fanen «Diskusjoner».
+
+### Gode eksempel på bruk av data
+I kategorien [«Gode eksempler på bruk»](https://datalandsbyen.norge.no/category/2/gode-eksempler-p%C3%A5-bruk) finner du eksempel på hvordan andre har brukt data, enten det er til å lage en app, tjeneste, visualisering eller annet.
+
+Har du laget noe med data som du vil dele? Legg gjerne ut et innlegg i denne kategorien. Se [tips for å skrive innlegg om eksempel](https://datalandsbyen.norge.no/topic/60/tips-til-%C3%A5-dele-gode-eksempel-p%C3%A5-bruk-av-data).
+
+### Tilbakemeldinger på data.norge.no
+Dersom du har tilbakemeldinger eller spørsmål til data.norge.no kan du skrive et innlegg i [kategorien «Tilbakemeldinger og nyheter»](https://datalandsbyen.norge.no/category/5/tilbakemeldinger-p%C3%A5-data-norge-no).
+
+### Annet
+I Datalandsbyen er det også kategorier for møter og arrangementer, spørsmål om juss, kunstig intelligens, informasjonsmodellering og mer. Besøk [Datalandsbyen](https://datalandsbyen.norge.no/) for å se alle kategorier.
+
+## Spørsmål om Datalandsbyen?
+Kontakt oss på datalandsbyen@norge.no

--- a/apps/data-norge/public/content/docs/community/community.nn.mdx
+++ b/apps/data-norge/public/content/docs/community/community.nn.mdx
@@ -1,12 +1,50 @@
 # Datalandsbyen
 
-[Datalandsbyen](https://datalandsbyen.norge.no/) er eit nettforum der ein kan etterspørje data, dele erfaringar og spørje om råd som gjeld datadeling og informasjonsforvaltning.
+[Datalandsbyen](https://datalandsbyen.norge.no/) er eit nettforum knytt til temaene datadeling og informasjonsforvaltning.
+
+Her møter du andre som jobber med data og datadeling, både i offentlig og privat sektor. Datalandsbyen er ein stad for å dele erfaringar, stille spørsmål og få hjelp til å finne data.
 
 ## Ta i bruk
 
-For å ta i bruk Datalandsbyen må du registrere deg. Dette gjer du enkelt ved å følgje stega nedanfor.
-NB. Alle kan lese alt innhald i Datalandsbyen utan å vere registrert.
+Alle kan lese innlegg i Datalandsbyen. Dersom du vil skrive innlegg, må du lage ein brukarkonto. Dette gjer ein enkelt ved å følgje stega under.
 
-1. Registrer brukar i Felles brukarhandtering
-2. Godkjenn samtykke og bruksvilkår for nettforumet
-3. Fyrste innlegg som blir publisert av ein ny brukar i forumet må godkjennast av ein administrator
+1. Gå til [Datalandsbyen.norge.no](https://datalandsbyen.norge.no/)
+2. Klikk på `Logg inn` øvst til høgre
+3. Velg `Registrer deg` og følg instruksjonane dersom du ikkje allerede har ein brukarkonto du har brukt i andre Digdir-tenester som for eksempel Samarbeidsportalen.
+4. Godkjenn samtykke og brukervilkår for nettforumet
+
+Første innlegg som vert publisert av ein ny bruker må godkjennast av ein administrator før det vert synleg for andre.
+
+Med ein brukarkonto kan du:
+- Skrive og svare på innlegg
+- Stemme opp innlegg
+- Abonnere på diskusjonstråder for å få varsel på e-post om nye innlegg
+- Velje å få e-post med sammendrag av nyleg aktivitet på forumet
+
+## Tips til bruk
+
+### Etterspørre data
+Om du vil ha hjelp til å finne data, eller be om at data vert publisert, kan du skrive eit innlegg i [kategorien «Etterspør datasett og API-er»](https://datalandsbyen.norge.no/category/6/ettersp%C3%B8r-datasett-og-api-er). Vi følgjer opp og kontaktar aktuelle datatilbydarar og andre i vårt nettverk for å hjelpe deg. Kanskje andre i Datalandsbyen òg har tips til deg?
+
+[Tips til å skrive innlegg om etterspørsel etter data](https://datalandsbyen.norge.no/topic/56/ettersp%C3%B8rr-data-og-api).
+
+### Spørsmål eller kommentarer på datasett
+Dersom du har spørsmål eller kommentarar til eit datasett som er beskrive i data.norge.no kan du stille spørsmålet i Datalandsbyen. Vi vil då gje beskjed til dataeigar om at det er kome eit innlegg dei bør svare på.
+
+Sjekk om det er ein eksisterande diskusjonstråd om datasettet du lurer på, eller opprett en ny tråd i [kategorien «Kommentartråder»](https://datalandsbyen.norge.no/category/12/kommentartr%C3%A5der). Eksisterande diskusjonstrådar som lenker til datasettet finn du òg på datasettet si side i data.norge.no, under fana «Diskusjoner».
+
+### Gode eksempel på bruk av data
+I kategorien [«Gode eksempler på bruk»](https://datalandsbyen.norge.no/category/2/gode-eksempler-p%C3%A5-bruk) finn du eksempel på korleis andre har brukt data, enten det er til å lage ein app, teneste, visualisering eller anna.
+
+Vil du dele at du har laga noko med data? Legg gjerne ut eit innlegg i denne kategorien. 
+
+[Tips for å skrive innlegg om eksempel](https://datalandsbyen.norge.no/topic/60/tips-til-%C3%A5-dele-gode-eksempel-p%C3%A5-bruk-av-data).
+
+### Tilbakemeldinger på data.norge.no
+Dersom du har tilbakemeldingar eller spørsmål til data.norge.no kan du skrive eit innlegg i [kategorien «Tilbakemeldinger og nyheter»](https://datalandsbyen.norge.no/category/5/tilbakemeldinger-p%C3%A5-data-norge-no).
+
+### Annet
+I Datalandsbyen er det òg kategorier for møter og arrangementer, spørsmål om juss, kunstig intelligens, informasjonsmodellering og meir. Besøk [Datalandsbyen](https://datalandsbyen.norge.no/) for å sjå alle kategorier.
+
+## Spørsmål om Datalandsbyen?
+Kontakt oss på datalandsbyen@norge.no

--- a/apps/data-norge/public/content/docs/finding-data/assisted-search/assisted-search.en.mdx
+++ b/apps/data-norge/public/content/docs/finding-data/assisted-search/assisted-search.en.mdx
@@ -12,7 +12,7 @@ description: 'Do you not know if the data you're looking for exists, or is it da
     datasets and APIs in the Data Village.
 </Ingress>
 
-## The Data Hunter: Find and Access Public Datasets
+## [The Data Hunter: Find and Access Public Datasets](/data-hunter)
 
 The Data Hunter is a service that helps you find and access datasets from the public sector. Although many datasets are available via data.norge.no, the catalog is not complete.
 
@@ -20,4 +20,7 @@ You can ask the Data Hunter for help via a simple contact form. Here, you can de
 
 ## The Data Village: Request Datasets and APIs
 
-The Data Village is an online forum dedicated to dialogue between data providers and consumers. Here, you can request datasets and APIs you want access to or have questions about. You can also request extensions of existing datasets and APIs, such as more available data or changes in API functionality. Visit the Data Village user forum to post your request. See the guide on how to request data in the Data Village.
+The Data Village is an online forum dedicated to dialogue between data providers and consumers. Here, you can request datasets and APIs you want access to or have questions about. You can also request extensions of existing datasets and APIs, such as more available data or changes in API functionality. Visit the Data Village user forum to post your request.
+
+- [Tips for how to request data i Datalandsbyen (in norwegian)](https://datalandsbyen.norge.no/topic/56/ettersp%C3%B8rr-data-og-api)
+- [About Datalandsbyen](/docs/community)

--- a/apps/data-norge/public/content/docs/finding-data/assisted-search/assisted-search.nb.mdx
+++ b/apps/data-norge/public/content/docs/finding-data/assisted-search/assisted-search.nb.mdx
@@ -20,4 +20,4 @@ Du kan be Datajegeren om hjelp via et enkelt kontaktskjema. Her kan du beskrive 
 
 ## Datalandsbyen: Etterspørre datasett og API-er
 
-Datalandsbyen er et nettforum dedikert til dialog mellom tilbydere og konsumenter av data. Her kan du etterlyse datasett og API-er du ønsker tilgang til eller har spørsmål om. Du kan også be om utvidelser av eksisterende datasett og API-er, for eksempel mer tilgjengelig data eller endringer i API-funksjonalitet. Besøk nettforumet Datalandsbyen for å legge inn din etterspørsel. Se [tips for hvordan etterspørre data i Datalandsbyen](https://datalandsbyen.norge.no/topic/56/ettersp%C3%B8rr-data-og-api).
+Datalandsbyen er et nettforum dedikert til dialog mellom tilbydere og konsumenter av data. Her kan du etterlyse datasett og API-er du ønsker tilgang til eller har spørsmål om. Du kan også be om utvidelser av eksisterende datasett og API-er, for eksempel mer tilgjengelig data eller endringer i API-funksjonalitet. Besøk nettforumet Datalandsbyen for å legge inn din etterspørsel. [Se tips for hvordan etterspørre data i Datalandsbyen](https://datalandsbyen.norge.no/topic/56/ettersp%C3%B8rr-data-og-api).

--- a/apps/data-norge/public/content/docs/finding-data/assisted-search/assisted-search.nb.mdx
+++ b/apps/data-norge/public/content/docs/finding-data/assisted-search/assisted-search.nb.mdx
@@ -20,4 +20,7 @@ Du kan be Datajegeren om hjelp via et enkelt kontaktskjema. Her kan du beskrive 
 
 ## Datalandsbyen: Etterspørre datasett og API-er
 
-Datalandsbyen er et nettforum dedikert til dialog mellom tilbydere og konsumenter av data. Her kan du etterlyse datasett og API-er du ønsker tilgang til eller har spørsmål om. Du kan også be om utvidelser av eksisterende datasett og API-er, for eksempel mer tilgjengelig data eller endringer i API-funksjonalitet. Besøk nettforumet Datalandsbyen for å legge inn din etterspørsel. [Se tips for hvordan etterspørre data i Datalandsbyen](https://datalandsbyen.norge.no/topic/56/ettersp%C3%B8rr-data-og-api).
+Datalandsbyen er et nettforum dedikert til dialog mellom tilbydere og konsumenter av data. Her kan du etterlyse datasett og API-er du ønsker tilgang til eller har spørsmål om. Du kan også be om utvidelser av eksisterende datasett og API-er, for eksempel mer tilgjengelig data eller endringer i API-funksjonalitet. Besøk nettforumet Datalandsbyen for å legge inn din etterspørsel. 
+
+- [Tips for hvordan etterspørre data i Datalandsbyen](https://datalandsbyen.norge.no/topic/56/ettersp%C3%B8rr-data-og-api)
+- [Mer om Datalandsbyen](/docs/community)

--- a/apps/data-norge/public/content/docs/finding-data/assisted-search/assisted-search.nb.mdx
+++ b/apps/data-norge/public/content/docs/finding-data/assisted-search/assisted-search.nb.mdx
@@ -12,7 +12,7 @@ description: 'Vet du ikke om data du ser etter finnes eller er det data du treng
     i Datalandsbyen.
 </Ingress>
 
-## Datajegeren: Finn og få tilgang til offentlige datasett
+## [Datajegeren: Finn og få tilgang til offentlige datasett](/data-hunter)
 
 Datajegeren er en tjeneste som hjelper deg med å finne og få tilgang til datasett fra offentlig sektor. Selv om mange datasett er tilgjengelige via data.norge.no, er ikke katalogen komplett.
 
@@ -20,4 +20,4 @@ Du kan be Datajegeren om hjelp via et enkelt kontaktskjema. Her kan du beskrive 
 
 ## Datalandsbyen: Etterspørre datasett og API-er
 
-Datalandsbyen er et nettforum dedikert til dialog mellom tilbydere og konsumenter av data. Her kan du etterlyse datasett og API-er du ønsker tilgang til eller har spørsmål om. Du kan også be om utvidelser av eksisterende datasett og API-er, for eksempel mer tilgjengelig data eller endringer i API-funksjonalitet. Besøk brukerforumet Datalandsbyen for å legge inn din etterspørsel. Se veileder for hvordan etterspørre data i Datalandsbyen.
+Datalandsbyen er et nettforum dedikert til dialog mellom tilbydere og konsumenter av data. Her kan du etterlyse datasett og API-er du ønsker tilgang til eller har spørsmål om. Du kan også be om utvidelser av eksisterende datasett og API-er, for eksempel mer tilgjengelig data eller endringer i API-funksjonalitet. Besøk nettforumet Datalandsbyen for å legge inn din etterspørsel. Se [tips for hvordan etterspørre data i Datalandsbyen](https://datalandsbyen.norge.no/topic/56/ettersp%C3%B8rr-data-og-api).

--- a/apps/data-norge/public/content/docs/finding-data/assisted-search/assisted-search.nn.mdx
+++ b/apps/data-norge/public/content/docs/finding-data/assisted-search/assisted-search.nn.mdx
@@ -12,7 +12,7 @@ description: 'Veit du ikkje om dataene du leitar etter finst, eller er det data 
     i Datalandsbyen.
 </Ingress>
 
-## Datajegeren: Finn og få tilgang til offentlige datasett
+## [Datajegeren: Finn og få tilgang til offentlige datasett](/data-hunter)
 
 Datajegeren er en tjeneste som hjelper deg med å finne og få tilgang til datasett fra offentlig sektor. Selv om mange datasett er tilgjengelige via data.norge.no, er ikke katalogen komplett.
 
@@ -20,4 +20,7 @@ Du kan be Datajegeren om hjelp via et enkelt kontaktskjema. Her kan du beskrive 
 
 ## Datalandsbyen: Etterspørre datasett og API-er
 
-Datalandsbyen er et nettforum dedikert til dialog mellom tilbydere og konsumenter av data. Her kan du etterlyse datasett og API-er du ønsker tilgang til eller har spørsmål om. Du kan også be om utvidelser av eksisterende datasett og API-er, for eksempel mer tilgjengelig data eller endringer i API-funksjonalitet. Besøk brukerforumet Datalandsbyen for å legge inn din etterspørsel. Se veileder for hvordan etterspørre data i Datalandsbyen.
+Datalandsbyen er et nettforum dedikert til dialog mellom tilbydere og konsumenter av data. Her kan du etterlyse datasett og API-er du ønsker tilgang til eller har spørsmål om. Du kan også be om utvidelser av eksisterende datasett og API-er, for eksempel mer tilgjengelig data eller endringer i API-funksjonalitet. Besøk brukerforumet Datalandsbyen for å legge inn din etterspørsel. 
+
+- [Tips for korleis etterspørre data i Datalandsbyen](https://datalandsbyen.norge.no/topic/56/ettersp%C3%B8rr-data-og-api)
+- [Meir om Datalandsbyen](/docs/community)


### PR DESCRIPTION
Added links to assisted-search. Datalandsbyen-page now has more details on different use cases, links to posts with tips etc.

This is the first draft. Changed only made in norwegian (nb). When we are satisfied, en and nn will be updated accordingly.