### PR TITLE
fix: broken urls on theme/keyword links

### DIFF
--- a/apps/data-norge/src/app/components/details-page/dataset-tags/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/dataset-tags/index.tsx
@@ -15,7 +15,7 @@ const DatasetTags = ({ locale, dataset }: DatasetTagsProps & React.HTMLAttribute
             {dataset.theme?.map((theme: any) => (
                 <Link
                     key={theme.code}
-                    href={`/datasets&theme=${theme.code}`}
+                    href={`/datasets?theme=${theme.code}`}
                 >
                     <ChipToggle>{printLocaleValue(locale, theme.title)}</ChipToggle>
                 </Link>
@@ -23,7 +23,7 @@ const DatasetTags = ({ locale, dataset }: DatasetTagsProps & React.HTMLAttribute
             {dataset.losTheme?.map((theme: any) => (
                 <Link
                     key={theme.code}
-                    href={`/datasets&losTheme=${theme.code}`}
+                    href={`/datasets?losTheme=${theme.code}`}
                 >
                     <ChipToggle>{printLocaleValue(locale, theme.name)}</ChipToggle>
                 </Link>

--- a/apps/data-norge/src/app/components/details-page/details-tab/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/index.tsx
@@ -141,7 +141,7 @@ const DatasetDetailsTab = ({
                                     .map((keyword: any, i: number) => (
                                         <Link
                                             key={`keyword-${i}`}
-                                            href={`/datasets&q=${keyword[locale]}`}
+                                            href={`/datasets?q=${keyword[locale]}`}
                                         >
                                             <ChipToggle>{keyword[locale]}</ChipToggle>
                                         </Link>


### PR DESCRIPTION
<img width="735" alt="Screenshot 2025-04-08 at 15 38 16" src="https://github.com/user-attachments/assets/4563e4b9-8d84-48db-996a-46aab72170be" />
