### PR TITLE
fix(project): simplified to use locale instead of baseUri to build uris

### DIFF
--- a/apps/data-norge/src/app/[lang]/data-hunter/page.tsx
+++ b/apps/data-norge/src/app/[lang]/data-hunter/page.tsx
@@ -1,17 +1,11 @@
 import 'server-only';
-
 import React from 'react';
 import type { Metadata } from 'next';
 import { unstable_noStore as noStore } from 'next/cache';
-
 import { Heading, Paragraph } from '@digdir/designsystemet-react';
-
 import { getDictionary, type Locale } from '@fdk-frontend/dictionaries';
 import Breadcrumbs from '@fdk-frontend/ui/breadcrumbs';
-import { getPaths } from '@fdk-frontend/utils';
-
 import DataHunterForm from './components/data-hunter-form';
-
 import styles from './page.module.css';
 
 type DataHunterPageProps = {
@@ -22,22 +16,16 @@ type DataHunterPageProps = {
 
 const DataHunterPage = async (props: DataHunterPageProps) => {
     const params = await props.params;
-
     const { lang } = params;
-
     // Opt-in dynamic rendering
     await noStore();
 
     const dictionary = await getDictionary(lang, 'data-hunter-page');
     const commonDictionary = await getDictionary(lang, 'common');
 
-    const { FDK_DATA_NORGE_BASE_URI, FDK_BASE_URI = '/' } = process.env;
-
-    const baseUri = FDK_DATA_NORGE_BASE_URI || FDK_BASE_URI;
-
     const breadcrumbList = [
         {
-            href: getPaths(baseUri).dataHunter,
+            href: `/${lang}/data-hunter`,
             text: dictionary.dataHunter,
         },
     ];
@@ -46,7 +34,6 @@ const DataHunterPage = async (props: DataHunterPageProps) => {
         <>
             <div style={{ margin: '0 2rem' }}>
                 <Breadcrumbs
-                    baseUri={baseUri}
                     breadcrumbList={breadcrumbList}
                     dictionary={commonDictionary}
                 />

--- a/apps/data-norge/src/app/[lang]/page.tsx
+++ b/apps/data-norge/src/app/[lang]/page.tsx
@@ -20,9 +20,7 @@ const Frontpage = async (props: FrontpageProps) => {
     await noStore();
 
     const {
-        FDK_LLM_SEARCH_BASE_URI: llmSearchBaseUri = '',
-        FDK_COMMUNITY_BASE_URI: communityBaseUri = '/',
-        FDK_REGISTRATION_BASE_URI: registrationBaseUri = '/',
+        FDK_LLM_SEARCH_BASE_URI: llmSearchBaseUri = ''
     } = process.env;
 
     const commonDictionary = await getDictionary(params.lang, 'common');
@@ -33,8 +31,6 @@ const Frontpage = async (props: FrontpageProps) => {
             <Header
                 dictionary={commonDictionary}
                 locale={params.lang}
-                registrationBaseUri={registrationBaseUri}
-                communityBaseUri={communityBaseUri}
                 frontpage
             />
             <main id='main'>

--- a/apps/data-norge/src/app/[lang]/page.tsx
+++ b/apps/data-norge/src/app/[lang]/page.tsx
@@ -1,12 +1,9 @@
 import 'server-only';
-
 import { type Metadata } from 'next';
 import { unstable_noStore as noStore } from 'next/cache';
-
 import { getDictionary, type Locale } from '@fdk-frontend/dictionaries';
 import Header from '@fdk-frontend/ui/header';
 import Footer from '@fdk-frontend/ui/footer';
-
 import { FrontpageBanner } from '../components/frontpage/frontpage-banner';
 import { ShareDataBanner } from '../components/frontpage/share-data-banner';
 import CatalogsBanner from '../components/frontpage/catalogs-banner';
@@ -23,14 +20,10 @@ const Frontpage = async (props: FrontpageProps) => {
     await noStore();
 
     const {
-        FDK_DATA_NORGE_BASE_URI,
-        FDK_BASE_URI = '',
         FDK_LLM_SEARCH_BASE_URI: llmSearchBaseUri = '',
         FDK_COMMUNITY_BASE_URI: communityBaseUri = '/',
         FDK_REGISTRATION_BASE_URI: registrationBaseUri = '/',
     } = process.env;
-
-    const baseUri = FDK_DATA_NORGE_BASE_URI || FDK_BASE_URI;
 
     const commonDictionary = await getDictionary(params.lang, 'common');
     const frontpageDictionary = await getDictionary(params.lang, 'frontpage');
@@ -39,7 +32,7 @@ const Frontpage = async (props: FrontpageProps) => {
         <>
             <Header
                 dictionary={commonDictionary}
-                baseUri={`/${params.lang}`}
+                locale={params.lang}
                 registrationBaseUri={registrationBaseUri}
                 communityBaseUri={communityBaseUri}
                 frontpage
@@ -47,26 +40,24 @@ const Frontpage = async (props: FrontpageProps) => {
             <main id='main'>
                 <FrontpageBanner
                     dictionary={frontpageDictionary}
-                    baseUri={baseUri}
+                    locale={params.lang}
                     endpoint={`${llmSearchBaseUri}/llm`}
                 />
                 <div className='main-content'>
                     <ShareDataBanner
                         dictionary={frontpageDictionary}
-                        baseUri={baseUri}
                         locale={params.lang}
                     />
                     <CatalogsBanner
                         frontpageDictionary={frontpageDictionary}
                         commonDictionary={commonDictionary}
-                        baseUri={baseUri}
                         locale={params.lang}
                     />
                 </div>
             </main>
             <Footer
                 dictionary={commonDictionary}
-                baseUri={`/${params.lang}`}
+                locale={params.lang}
             />
         </>
     );

--- a/apps/data-norge/src/app/components/details-page/dataset/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/dataset/index.tsx
@@ -85,11 +85,10 @@ export default function DatasetDetailsPage({
 
     const breadcrumbList = [
         {
-            href: '/datasets',
+            href: `/datasets`,
             text: dictionaries.detailsPage.breadcrumbs.datasets,
         },
         {
-            href: '#',
             text: printLocaleValue(locale, resource.title),
         },
     ];
@@ -103,7 +102,6 @@ export default function DatasetDetailsPage({
             <Breadcrumbs
                 dictionary={dictionaries.common}
                 breadcrumbList={breadcrumbList}
-                baseUri=''
             />
             <div className={styles.mainContent}>
                 <div className={styles.header}>
@@ -149,11 +147,12 @@ export default function DatasetDetailsPage({
                                 color='info'
                                 size='sm'
                             >
-                                <Link href='/datasets'>{dictionaries.detailsPage.header.datasetsTagLink}</Link>
+                                <Link href={`/datasets`}>{dictionaries.detailsPage.header.datasetsTagLink}</Link>
                             </Tag>
                             <AccessLevelTag
                                 accessCode={resource.accessRights?.code}
                                 dictionary={dictionaries.detailsPage}
+                                locale={locale}
                             />
                             {resource.isOpenData && <OpenDataTag dictionary={dictionaries.common} />}
                         </div>
@@ -327,6 +326,7 @@ export default function DatasetDetailsPage({
                         <MetadataTab
                             uri={`${baseUri}/datasets/${resource.id}`}
                             dictionary={dictionaries.detailsPage}
+                            locale={locale}
                         />
                     </TabContent>
                 </Tabs>

--- a/apps/data-norge/src/app/components/details-page/metadata-tab/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/metadata-tab/index.tsx
@@ -3,7 +3,7 @@ import cn from 'classnames';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import CopyButton from '@fdk-frontend/ui/copy-button';
-import { type Dictionary } from '@fdk-frontend/dictionaries';
+import { type Dictionary, type LocaleCodes } from '@fdk-frontend/dictionaries';
 import { ToggleGroup, Heading, Spinner, Textfield, HelpText, Paragraph, Link } from '@digdir/designsystemet-react';
 import HStack from '@fdk-frontend/ui/hstack';
 
@@ -12,12 +12,14 @@ import styles from './metadata-tab.module.scss';
 export type MetadataTabProps = {
     uri: string;
     dictionary: Dictionary;
+    locale: LocaleCodes;
 };
 
 const MetadataTab = ({
     children,
     uri,
     dictionary,
+    locale,
     ...props
 }: MetadataTabProps & React.HTMLAttributes<HTMLDivElement>) => {
     const [contentType, setContentType] = useState<string>('text/turtle');
@@ -79,7 +81,7 @@ const MetadataTab = ({
                         >
                             <Paragraph size='sm'>{dictionary.rdf.titleHelpText}</Paragraph>
                             <Paragraph size='sm'>
-                                <Link href='/docs/sharing-data/rdf'>{dictionary.rdf.titleHelpTextLink}</Link>
+                                <Link href={`/${locale}/docs/sharing-data/rdf`}>{dictionary.rdf.titleHelpTextLink}</Link>
                             </Paragraph>
                         </HelpText>
                     </HStack>

--- a/apps/data-norge/src/app/components/docs/docs-page/index.tsx
+++ b/apps/data-norge/src/app/components/docs/docs-page/index.tsx
@@ -65,9 +65,6 @@ export default async function DocsPage(pageProps: DocsPageProps) {
 
     const commonDictionary = await getDictionary(locale, 'common');
 
-    const { FDK_DATA_NORGE_BASE_URI, FDK_BASE_URI = '' } = process.env;
-    const baseUri = FDK_DATA_NORGE_BASE_URI || FDK_BASE_URI;
-
     try {
         // Get raw MDX source
         const source = await fs.readFile(filePath, 'utf8');

--- a/apps/data-norge/src/app/components/docs/docs-page/index.tsx
+++ b/apps/data-norge/src/app/components/docs/docs-page/index.tsx
@@ -138,7 +138,6 @@ export default async function DocsPage(pageProps: DocsPageProps) {
             CatalogsMenu: () => (
                 <CatalogsMenu
                     dictionary={commonDictionary}
-                    baseUri={baseUri}
                     locale={locale}
                 />
             ),
@@ -243,7 +242,6 @@ export default async function DocsPage(pageProps: DocsPageProps) {
                 sidebars={frontmatter.sidebars as boolean | undefined}
                 currentPath={[rootContentDirectory, ...slug]}
                 locale={locale}
-                baseUri={baseUri}
                 source={source}
             >
                 {content}

--- a/apps/data-norge/src/app/components/docs/mdx-page/index.tsx
+++ b/apps/data-norge/src/app/components/docs/mdx-page/index.tsx
@@ -15,12 +15,11 @@ import { extractHeadlines, type MdxHeadlineObjectNode } from './utils';
 export type MdxPageProps = PropsWithChildren & {
     currentPath: string[];
     locale: LocaleCodes;
-    baseUri: string;
     source: string;
     sidebars?: boolean;
 };
 
-const MdxPage = async ({ children, sidebars = true, currentPath, locale, baseUri, source }: MdxPageProps) => {
+const MdxPage = async ({ children, sidebars = true, currentPath, locale, source }: MdxPageProps) => {
     const docsDictionary = await getDictionary(locale, 'docs');
     const commonDictionary = await getDictionary(locale, 'common');
 
@@ -31,7 +30,6 @@ const MdxPage = async ({ children, sidebars = true, currentPath, locale, baseUri
             <DynamicBreadcrumbs
                 docsDictionary={docsDictionary}
                 commonDictionary={commonDictionary}
-                baseUri={baseUri}
                 locale={locale}
             />
             <div className={cn(pageStyles.content, { [pageStyles.noSidebars]: !sidebars })}>

--- a/apps/data-norge/src/app/components/error-page/index.tsx
+++ b/apps/data-norge/src/app/components/error-page/index.tsx
@@ -14,7 +14,7 @@ export default async function ErrorPage({ children }: PropsWithChildren) {
         <>
             <Header
                 dictionary={commonDictionary}
-                baseUri={`/${lang}`}
+                locale={lang}
                 registrationBaseUri={registrationBaseUri}
                 communityBaseUri={communityBaseUri}
                 frontpage

--- a/apps/data-norge/src/app/components/error-page/index.tsx
+++ b/apps/data-norge/src/app/components/error-page/index.tsx
@@ -5,18 +5,12 @@ import styles from './error-page.module.scss';
 
 export default async function ErrorPage({ children }: PropsWithChildren) {
     const lang = 'nb';
-    const { FDK_COMMUNITY_BASE_URI: communityBaseUri = '/', FDK_REGISTRATION_BASE_URI: registrationBaseUri = '/' } =
-        process.env;
-
     const commonDictionary = await getDictionary(lang, 'common');
-
     return (
         <>
             <Header
                 dictionary={commonDictionary}
                 locale={lang}
-                registrationBaseUri={registrationBaseUri}
-                communityBaseUri={communityBaseUri}
                 frontpage
             />
             <main

--- a/apps/data-norge/src/app/components/frontpage/catalogs-banner/index.tsx
+++ b/apps/data-norge/src/app/components/frontpage/catalogs-banner/index.tsx
@@ -7,11 +7,10 @@ import styles from './catalogs-banner.module.scss';
 type CatalogsBannerProps = {
     commonDictionary: Dictionary;
     frontpageDictionary: Dictionary;
-    baseUri: string;
     locale: LocaleCodes;
 };
 
-const CatalogsBanner = ({ commonDictionary, frontpageDictionary, baseUri, locale }: CatalogsBannerProps) => (
+const CatalogsBanner = ({ commonDictionary, frontpageDictionary, locale }: CatalogsBannerProps) => (
     <div className={styles.catalogsBanner}>
         <div className={styles.inner}>
             <HeadingWithDivider
@@ -23,7 +22,6 @@ const CatalogsBanner = ({ commonDictionary, frontpageDictionary, baseUri, locale
             </HeadingWithDivider>
             <CatalogsMenu
                 dictionary={commonDictionary}
-                baseUri={baseUri}
                 locale={locale}
             />
         </div>

--- a/apps/data-norge/src/app/components/frontpage/frontpage-banner/index.tsx
+++ b/apps/data-norge/src/app/components/frontpage/frontpage-banner/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Dictionary } from '@fdk-frontend/dictionaries';
+import { type Dictionary, type LocaleCodes } from '@fdk-frontend/dictionaries';
 import { HeadingWithDivider } from '@fdk-frontend/ui/typography';
 
 import LlmSearch from '../llm-search';
@@ -11,11 +11,11 @@ import styles from './frontpage-banner.module.scss';
 
 type FrontpageBannerProps = {
     dictionary: Dictionary;
-    baseUri: string;
+    locale: LocaleCodes;
     endpoint: string;
 };
 
-const FrontpageBanner = ({ dictionary, baseUri, endpoint }: FrontpageBannerProps) => (
+const FrontpageBanner = ({ dictionary, locale, endpoint }: FrontpageBannerProps) => (
     <div
         className={styles.outer}
         id='frontpage-banner'
@@ -29,7 +29,7 @@ const FrontpageBanner = ({ dictionary, baseUri, endpoint }: FrontpageBannerProps
             </HeadingWithDivider>
             <LlmSearch
                 dictionary={dictionary}
-                baseUri={baseUri}
+                locale={locale}
                 endpoint={endpoint}
             />
         </div>

--- a/apps/data-norge/src/app/components/frontpage/llm-search/components/advanced-search-prompt/index.tsx
+++ b/apps/data-norge/src/app/components/frontpage/llm-search/components/advanced-search-prompt/index.tsx
@@ -1,15 +1,15 @@
 import { Button, Alert, Link } from '@digdir/designsystemet-react';
 import { MagnifyingGlassIcon } from '@navikt/aksel-icons';
-import { Dictionary } from '@fdk-frontend/dictionaries';
+import { type Dictionary, type LocaleCodes } from '@fdk-frontend/dictionaries';
 
 import styles from './advanced-search-prompt.module.scss';
 
 type AdvancedSearchPromptProps = {
     dictionary: Dictionary;
-    baseUri: string;
+    locale: LocaleCodes;
 };
 
-const AdvancedSearchPrompt = ({ dictionary, baseUri }: AdvancedSearchPromptProps) => (
+const AdvancedSearchPrompt = ({ dictionary, locale }: AdvancedSearchPromptProps) => (
     <Alert className={styles.searchAlert}>
         <div className={styles.searchAlertContent}>
             {dictionary.aiBanner.advancedSearchPrompt.text}
@@ -19,7 +19,7 @@ const AdvancedSearchPrompt = ({ dictionary, baseUri }: AdvancedSearchPromptProps
                 size='small'
                 variant='primary'
             >
-                <Link href={`${baseUri}/search-all`}>
+                <Link href={`/${locale}/search-all`}>
                     <MagnifyingGlassIcon
                         aria-hidden
                         fontSize='1.5em'

--- a/apps/data-norge/src/app/components/frontpage/llm-search/components/aux-panel/index.tsx
+++ b/apps/data-norge/src/app/components/frontpage/llm-search/components/aux-panel/index.tsx
@@ -2,7 +2,7 @@ import dynamic from 'next/dynamic';
 
 import { Link, Paragraph, HelpText, Button } from '@digdir/designsystemet-react';
 
-import { Dictionary, interpolate } from '@fdk-frontend/dictionaries';
+import { type Dictionary, type LocaleCodes, interpolate } from '@fdk-frontend/dictionaries';
 
 const DynamicQuerySuggestion = dynamic(() => import('../query-suggestion'), {
     ssr: false,
@@ -13,11 +13,11 @@ import styles from './aux-panel.module.scss';
 export type AuxPanelProps = {
     dictionary: Dictionary;
     onRequestSearch: (query: string) => void;
-    baseUri: string;
+    locale: LocaleCodes;
     numResults?: number;
 };
 
-const AuxPanel = ({ dictionary, onRequestSearch, baseUri, numResults }: AuxPanelProps) => {
+const AuxPanel = ({ dictionary, onRequestSearch, locale, numResults }: AuxPanelProps) => {
     const getResultsText = () =>
         numResults !== undefined && numResults > 0
             ? interpolate(dictionary.aiBanner.prompt.responses.resultsFound, { num: numResults })
@@ -49,7 +49,7 @@ const AuxPanel = ({ dictionary, onRequestSearch, baseUri, numResults }: AuxPanel
                         size='sm'
                         asChild
                     >
-                        <Link href={`${baseUri}/docs/finding-data/ai-search`}>
+                        <Link href={`/${locale}/docs/finding-data/ai-search`}>
                             {dictionary.aiBanner.tooltip.readMoreLinkText}
                         </Link>
                     </Button>

--- a/apps/data-norge/src/app/components/frontpage/llm-search/components/result-item/index.tsx
+++ b/apps/data-norge/src/app/components/frontpage/llm-search/components/result-item/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Heading } from '@digdir/designsystemet-react';
 import Markdown from '@fdk-frontend/ui/markdown';
+import { type LocaleCodes } from '@fdk-frontend/dictionaries';
 
 import styles from './result-item.module.scss';
 
@@ -15,17 +16,12 @@ export type ItemObjectType = {
 
 type ResultItemProps = {
     item: ItemObjectType;
-    baseUri: string;
+    locale: LocaleCodes;
 };
 
-const getDatasetLink = (datasetId: string, baseUri: string) => {
-    const datasetsUrl = `${baseUri}/datasets/`;
-    return `${datasetsUrl}${datasetId}`;
-};
-
-const ResultItem = ({ item, baseUri, ...rest }: ResultItemProps & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+const ResultItem = ({ item, locale, ...rest }: ResultItemProps & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
     <a
-        href={getDatasetLink(item.id, baseUri)}
+        href={`/${locale}/datasets/${item.id}`}
         className={styles.link}
         {...rest}
     >
@@ -38,7 +34,9 @@ const ResultItem = ({ item, baseUri, ...rest }: ResultItemProps & React.AnchorHT
                 <span className={styles.title}>{item.title}</span>
                 <span className={styles.publisher}> ({item.publisher})</span>
             </Heading>
-            <Markdown className={styles.description}>{item.description}</Markdown>
+            <div className={styles.description}>
+                <Markdown>{item.description}</Markdown>
+            </div>
         </div>
     </a>
 );

--- a/apps/data-norge/src/app/components/frontpage/llm-search/index.tsx
+++ b/apps/data-norge/src/app/components/frontpage/llm-search/index.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { ForwardRefComponent, motion } from 'framer-motion';
 import { Textfield, Button, Spinner, ErrorMessage } from '@digdir/designsystemet-react';
 import { SparklesIcon } from '@navikt/aksel-icons';
-import { Dictionary } from '@fdk-frontend/dictionaries';
+import { type Dictionary, type LocaleCodes } from '@fdk-frontend/dictionaries';
 import { AdvancedSearchPrompt } from './components/advanced-search-prompt';
 
 import { ResultItem, ItemObjectType } from './components/result-item';
@@ -15,13 +15,13 @@ import styles from './llm-search.module.scss';
 type LlmSearchProps = {
     endpoint: string;
     dictionary: Dictionary;
-    baseUri: string;
+    locale: LocaleCodes;
 };
 
 const MotionDiv: ForwardRefComponent<any, any> = motion.div;
 const MotionUl: ForwardRefComponent<any, any> = motion.ul;
 
-const LlmSearch = ({ endpoint, dictionary, baseUri }: LlmSearchProps) => {
+const LlmSearch = ({ endpoint, dictionary, locale }: LlmSearchProps) => {
     const [loading, setLoading] = useState<boolean>(false);
     const [query, setQuery] = useState<string>('');
     const [results, setResults] = useState<any>(undefined);
@@ -145,7 +145,7 @@ const LlmSearch = ({ endpoint, dictionary, baseUri }: LlmSearchProps) => {
                     dictionary={dictionary}
                     numResults={results?.hits?.length}
                     onRequestSearch={(value: string) => doSearch(value)}
-                    baseUri={baseUri}
+                    locale={locale}
                 />
             )}
             {error && !loading && (
@@ -180,14 +180,14 @@ const LlmSearch = ({ endpoint, dictionary, baseUri }: LlmSearchProps) => {
                                 >
                                     <ResultItem
                                         item={item}
-                                        baseUri={baseUri}
+                                        locale={locale}
                                     />
                                 </motion.li>
                             ))}
                         <motion.li variants={animations.resultsItem}>
                             <AdvancedSearchPrompt
                                 dictionary={dictionary}
-                                baseUri={baseUri}
+                                locale={locale}
                             />
                         </motion.li>
                     </MotionUl>

--- a/apps/data-norge/src/app/components/frontpage/share-data-banner/index.tsx
+++ b/apps/data-norge/src/app/components/frontpage/share-data-banner/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Paragraph, Link } from '@digdir/designsystemet-react';
-import { Dictionary, interpolate, type LocaleCodes } from '@fdk-frontend/dictionaries';
+import { type Dictionary, type LocaleCodes, interpolate } from '@fdk-frontend/dictionaries';
 
 import { HeadingWithDivider } from '@fdk-frontend/ui/typography';
 
@@ -8,11 +8,10 @@ import OrganizationCarousel from '../organization-carousel';
 
 type ShareDataBannerProps = {
     dictionary: Dictionary;
-    baseUri: string;
     locale: LocaleCodes;
 };
 
-const ShareDataBanner = ({ dictionary, baseUri, locale }: ShareDataBannerProps) => (
+const ShareDataBanner = ({ dictionary, locale }: ShareDataBannerProps) => (
     <div className={styles.shareDataBanner}>
         <HeadingWithDivider
             level={2}
@@ -22,13 +21,13 @@ const ShareDataBanner = ({ dictionary, baseUri, locale }: ShareDataBannerProps) 
         </HeadingWithDivider>
         <Paragraph>
             {interpolate(dictionary.shareDataBanner.content, {
-                link: <Link href={`${baseUri}/organizations`}>{dictionary.shareDataBanner.organizationsLinkText}</Link>,
+                link: <Link href={`/${locale}/organizations`}>{dictionary.shareDataBanner.organizationsLinkText}</Link>,
             })}
         </Paragraph>
         <div className={styles.buttons}>
             <Button asChild>
                 <Link
-                    href={`${baseUri}/publishing`}
+                    href={`/${locale}/publishing`}
                     inverted
                 >
                     {dictionary.shareDataBanner.shareDataLinkText}
@@ -38,7 +37,7 @@ const ShareDataBanner = ({ dictionary, baseUri, locale }: ShareDataBannerProps) 
                 asChild
                 variant='secondary'
             >
-                <Link href={`${baseUri}/${locale}/docs`}>{dictionary.shareDataBanner.documentationLinkText}</Link>
+                <Link href={`/${locale}/docs`}>{dictionary.shareDataBanner.documentationLinkText}</Link>
             </Button>
         </div>
     </div>

--- a/libs/ui/src/lib/access-level-tag/index.tsx
+++ b/libs/ui/src/lib/access-level-tag/index.tsx
@@ -1,14 +1,15 @@
 import { Link, Tag, TagProps, HelpText, Paragraph } from '@digdir/designsystemet-react';
-import { type Dictionary } from '@fdk-frontend/dictionaries';
+import { type Dictionary, type LocaleCodes } from '@fdk-frontend/dictionaries';
 import { AccessRightsCodes } from '@fdk-frontend/fdk-types';
 
 type AccessLevelTagProps = {
     accessCode?: AccessRightsCodes;
     dictionary: Dictionary;
     nonInteractive?: boolean;
+    locale: LocaleCodes;
 };
 
-const AccessLevelTag = ({ accessCode, dictionary, nonInteractive, ...props }: AccessLevelTagProps) => {
+const AccessLevelTag = ({ accessCode, dictionary, nonInteractive, locale, ...props }: AccessLevelTagProps) => {
     let color = 'neutral';
 
     const label = accessCode ? dictionary.accessRights.codes[accessCode]?.label : dictionary.accessRights.unknownLabel;
@@ -35,7 +36,7 @@ const AccessLevelTag = ({ accessCode, dictionary, nonInteractive, ...props }: Ac
                     >
                         <Paragraph size='sm'>{helpText}</Paragraph>
                         <Paragraph size='sm'>
-                            <Link href='/docs/finding-data/access-data'>
+                            <Link href={`/${locale}/docs/finding-data/access-data`}>
                                 {dictionary.accessRights.readMoreLinkText}
                             </Link>
                         </Paragraph>

--- a/libs/ui/src/lib/breadcrumbs/index.tsx
+++ b/libs/ui/src/lib/breadcrumbs/index.tsx
@@ -8,12 +8,11 @@ import ScrollShadows from '../scroll-shadows';
 import styles from './breadcrumbs.module.scss';
 
 export type BreadcrumbType = {
-    href: string;
     text: string;
+    href?: string;
 };
 
 export type BreadcrumbsProps = {
-    baseUri: string;
     breadcrumbList?: BreadcrumbType[];
     dictionary: Dictionary;
 };
@@ -22,7 +21,7 @@ const BreadcrumbsContainer = ({ children }: React.PropsWithChildren) => (
     <div className={styles.container}>{children}</div>
 );
 
-const Breadcrumbs = ({ baseUri, breadcrumbList, dictionary }: BreadcrumbsProps) => (
+const Breadcrumbs = ({ breadcrumbList, dictionary }: BreadcrumbsProps) => (
     <div className={styles.container}>
         <ScrollShadows>
             <nav
@@ -39,7 +38,7 @@ const Breadcrumbs = ({ baseUri, breadcrumbList, dictionary }: BreadcrumbsProps) 
                 {breadcrumbList?.map((breadcrumb, i) => (
                     <div
                         className={styles.crumb}
-                        key={breadcrumb.href}
+                        key={`${breadcrumb.href}-${i}`}
                     >
                         <ChevronRightIcon
                             className={styles.separator}

--- a/libs/ui/src/lib/catalogs-menu/index.tsx
+++ b/libs/ui/src/lib/catalogs-menu/index.tsx
@@ -8,12 +8,12 @@ import styles from './catalogs-menu.module.scss';
 
 type CatalogsMenuProps = {
     dictionary: Dictionary;
-    baseUri: string;
     locale: LocaleCodes;
 };
 
-const CatalogsMenu = ({ dictionary, baseUri, locale }: CatalogsMenuProps) => {
-    const data = getMainMenuData(dictionary, `${baseUri}/${locale}`);
+const CatalogsMenu = ({ dictionary, locale }: CatalogsMenuProps) => {
+    const baseUri = `/${locale}`;
+    const data = getMainMenuData(dictionary, baseUri);
 
     return (
         <nav

--- a/libs/ui/src/lib/catalogs-menu/index.tsx
+++ b/libs/ui/src/lib/catalogs-menu/index.tsx
@@ -12,9 +12,7 @@ type CatalogsMenuProps = {
 };
 
 const CatalogsMenu = ({ dictionary, locale }: CatalogsMenuProps) => {
-    const baseUri = `/${locale}`;
-    const data = getMainMenuData(dictionary, baseUri);
-
+    const data = getMainMenuData(dictionary, locale);
     return (
         <nav
             className={styles.catalogsMenu}

--- a/libs/ui/src/lib/dataset-table/index.tsx
+++ b/libs/ui/src/lib/dataset-table/index.tsx
@@ -53,6 +53,7 @@ const DatasetTable = ({
                                     <AccessLevelTag
                                         accessCode={dataset.accessRights?.code}
                                         dictionary={dictionary}
+                                        locale={locale}
                                         nonInteractive
                                     />
                                 </HStack>

--- a/libs/ui/src/lib/dynamic-breadcrumbs/index.tsx
+++ b/libs/ui/src/lib/dynamic-breadcrumbs/index.tsx
@@ -9,11 +9,10 @@ import Breadcrumbs from '../breadcrumbs';
 type DynamicBreadcrumbsProps = {
     commonDictionary: Dictionary;
     docsDictionary: Dictionary;
-    baseUri: string;
     locale: LocaleCodes;
 };
 
-const DynamicBreadcrumbs = ({ commonDictionary, docsDictionary, baseUri, locale }: DynamicBreadcrumbsProps) => {
+const DynamicBreadcrumbs = ({ commonDictionary, docsDictionary, locale }: DynamicBreadcrumbsProps) => {
     const pathname = usePathname();
 
     const createBreadcrumbPaths = function (pname: string) {
@@ -42,7 +41,6 @@ const DynamicBreadcrumbs = ({ commonDictionary, docsDictionary, baseUri, locale 
         <Breadcrumbs
             breadcrumbList={textedItems}
             dictionary={commonDictionary}
-            baseUri={baseUri}
         />
     );
 };

--- a/libs/ui/src/lib/footer/index.tsx
+++ b/libs/ui/src/lib/footer/index.tsx
@@ -1,17 +1,15 @@
-import { Dictionary } from '@fdk-frontend/dictionaries';
-
+import { type Dictionary, type LocaleCodes } from '@fdk-frontend/dictionaries';
 import { LogoLink, DigdirLogoLink } from '../logo';
 import LanguageSwitcher from '../language-switcher';
 import MainMenu from '../main-menu';
-
 import styles from './footer.module.scss';
 
 export type FooterProps = {
     dictionary: Dictionary;
-    baseUri: string;
+    locale: LocaleCodes;
 };
 
-const Footer = ({ dictionary, baseUri }: FooterProps) => {
+const Footer = ({ dictionary, locale }: FooterProps) => {
     return (
         <footer
             className={styles.footer}
@@ -21,7 +19,7 @@ const Footer = ({ dictionary, baseUri }: FooterProps) => {
                 <MainMenu
                     className={styles.footerNav}
                     dictionary={dictionary}
-                    baseUri={baseUri}
+                    locale={locale}
                     motionProps={{
                         initial: 'show',
                     }}
@@ -30,7 +28,7 @@ const Footer = ({ dictionary, baseUri }: FooterProps) => {
             </div>
             <div className={styles.bottom}>
                 <div className={styles.bottomInner}>
-                    <LogoLink baseUri={baseUri} />
+                    <LogoLink href={`/${locale}`} />
                     <div className={styles.digdirCredit}>
                         <span>{dictionary.footer.digdirCredit}</span>
                         <DigdirLogoLink href={`https://www.digdir.no/`} />

--- a/libs/ui/src/lib/header/index.tsx
+++ b/libs/ui/src/lib/header/index.tsx
@@ -1,22 +1,17 @@
 'use client';
-
 import { useState, useEffect, useRef } from 'react';
 import cn from 'classnames';
 import { ForwardRefComponent, motion } from 'framer-motion';
-
 import { Link, Button } from '@digdir/designsystemet-react';
 import { MagnifyingGlassIcon, MenuHamburgerIcon, XMarkIcon } from '@navikt/aksel-icons';
-
-import { Dictionary } from '@fdk-frontend/dictionaries';
-
+import { type Dictionary, type LocaleCodes } from '@fdk-frontend/dictionaries';
 import { LogoLink } from '../logo';
 import MainMenu from '../main-menu';
-
 import styles from './header.module.scss';
 
 export type HeaderProps = {
     dictionary: Dictionary;
-    baseUri?: string;
+    locale: LocaleCodes;
     communityBaseUri?: string;
     registrationBaseUri?: string;
     frontpage?: boolean;
@@ -26,7 +21,7 @@ const MotionDiv: ForwardRefComponent<any, any> = motion.div;
 
 const Header = ({
     dictionary,
-    baseUri = '/',
+    locale,
     communityBaseUri = '#',
     registrationBaseUri = '#',
     frontpage,
@@ -90,7 +85,7 @@ const Header = ({
                 <div className={styles.headerInner}>
                     <LogoLink
                         className={styles.headerLogo}
-                        baseUri={baseUri}
+                        href={`/${locale}`}
                     />
                     <div className={styles.headerToolbar}>
                         <Button
@@ -99,7 +94,7 @@ const Header = ({
                             variant='tertiary'
                             aria-label={dictionary.header.findDataButton}
                         >
-                            <Link href={`/search-all`}>
+                            <Link href={`/${locale}/search-all`}>
                                 <MagnifyingGlassIcon
                                     aria-hidden
                                     fontSize='1.5em'
@@ -148,7 +143,7 @@ const Header = ({
                         >
                             <MainMenu
                                 dictionary={dictionary}
-                                baseUri={baseUri}
+                                locale={locale}
                             />
                         </MotionDiv>
                     </div>

--- a/libs/ui/src/lib/header/index.tsx
+++ b/libs/ui/src/lib/header/index.tsx
@@ -12,8 +12,6 @@ import styles from './header.module.scss';
 export type HeaderProps = {
     dictionary: Dictionary;
     locale: LocaleCodes;
-    communityBaseUri?: string;
-    registrationBaseUri?: string;
     frontpage?: boolean;
 };
 
@@ -22,8 +20,6 @@ const MotionDiv: ForwardRefComponent<any, any> = motion.div;
 const Header = ({
     dictionary,
     locale,
-    communityBaseUri = '#',
-    registrationBaseUri = '#',
     frontpage,
 }: HeaderProps) => {
     const headerRef = useRef<HTMLDivElement>(null);
@@ -94,7 +90,7 @@ const Header = ({
                             variant='tertiary'
                             aria-label={dictionary.header.findDataButton}
                         >
-                            <Link href={`/${locale}/search-all`}>
+                            <Link href={`/search-all`}>
                                 <MagnifyingGlassIcon
                                     aria-hidden
                                     fontSize='1.5em'

--- a/libs/ui/src/lib/layouts/docs-layout/index.tsx
+++ b/libs/ui/src/lib/layouts/docs-layout/index.tsx
@@ -12,29 +12,25 @@ const DocsLayout = async ({ children, params }: PropsWithChildren & RootLayoutPr
     const docsDictionary = await getDictionary(lang, 'docs');
 
     const {
-        FDK_DATA_NORGE_BASE_URI,
-        FDK_BASE_URI = '',
         FDK_COMMUNITY_BASE_URI: communityBaseUri = '/',
         FDK_REGISTRATION_BASE_URI: registrationBaseUri = '/',
     } = process.env;
 
-    const baseUri = FDK_DATA_NORGE_BASE_URI || FDK_BASE_URI;
-
     return (
         <HeaderLayout
             dictionary={commonDictionary}
-            baseUri={`/${lang}`}
+            locale={lang}
             registrationBaseUri={registrationBaseUri}
             communityBaseUri={communityBaseUri}
         >
             <FooterLayout
                 dictionary={commonDictionary}
-                baseUri={`/${lang}`}
+                locale={lang}
             >
                 <main id='main'>
                     <FeedbackLayout
                         dictionary={docsDictionary}
-                        baseUri={baseUri}
+                        locale={lang}
                         communityBaseUri={communityBaseUri}
                     >
                         {children}

--- a/libs/ui/src/lib/layouts/docs-layout/index.tsx
+++ b/libs/ui/src/lib/layouts/docs-layout/index.tsx
@@ -12,16 +12,13 @@ const DocsLayout = async ({ children, params }: PropsWithChildren & RootLayoutPr
     const docsDictionary = await getDictionary(lang, 'docs');
 
     const {
-        FDK_COMMUNITY_BASE_URI: communityBaseUri = '/',
-        FDK_REGISTRATION_BASE_URI: registrationBaseUri = '/',
+        FDK_COMMUNITY_BASE_URI: communityBaseUri,
     } = process.env;
 
     return (
         <HeaderLayout
             dictionary={commonDictionary}
             locale={lang}
-            registrationBaseUri={registrationBaseUri}
-            communityBaseUri={communityBaseUri}
         >
             <FooterLayout
                 dictionary={commonDictionary}

--- a/libs/ui/src/lib/layouts/feedback-layout/index.tsx
+++ b/libs/ui/src/lib/layouts/feedback-layout/index.tsx
@@ -3,21 +3,21 @@ import { PropsWithChildren } from 'react';
 import { Heading, Link } from '@digdir/designsystemet-react';
 import { ExternalLinkIcon } from '@navikt/aksel-icons';
 
-import { type Dictionary, interpolate } from '@fdk-frontend/dictionaries';
+import { type Dictionary, type LocaleCodes, interpolate } from '@fdk-frontend/dictionaries';
 
 import styles from './feedback-layout.module.scss';
 import { cookies } from 'next/headers';
 
 type FeedbackLayoutProps = {
     dictionary: Dictionary;
-    baseUri: string;
+    locale: LocaleCodes;
     communityBaseUri: string;
 };
 
 const FeedbackLayout = async ({
     children,
     dictionary,
-    baseUri,
+    locale,
     communityBaseUri,
 }: PropsWithChildren & FeedbackLayoutProps) => {
     // Opt-in SSR
@@ -38,7 +38,7 @@ const FeedbackLayout = async ({
                     <div>
                         {interpolate(dictionary.feedbackBanner.text, {
                             contactLink: (
-                                <Link href={`${baseUri}/contact`}>{dictionary.feedbackBanner.contactLinkText}</Link>
+                                <Link href={`/${locale}/contact`}>{dictionary.feedbackBanner.contactLinkText}</Link>
                             ),
                             communityLink: (
                                 <Link href={communityBaseUri}>

--- a/libs/ui/src/lib/layouts/feedback-layout/index.tsx
+++ b/libs/ui/src/lib/layouts/feedback-layout/index.tsx
@@ -11,7 +11,7 @@ import { cookies } from 'next/headers';
 type FeedbackLayoutProps = {
     dictionary: Dictionary;
     locale: LocaleCodes;
-    communityBaseUri: string;
+    communityBaseUri?: string;
 };
 
 const FeedbackLayout = async ({

--- a/libs/ui/src/lib/layouts/footer-layout/index.tsx
+++ b/libs/ui/src/lib/layouts/footer-layout/index.tsx
@@ -3,14 +3,14 @@ import { PropsWithChildren } from 'react';
 import Footer, { type FooterProps } from '../../footer';
 
 const FooterLayout = ({ children, ...props }: FooterProps & PropsWithChildren) => {
-    const { dictionary, baseUri } = props;
+    const { dictionary, locale } = props;
 
     return (
         <>
             {children}
             <Footer
                 dictionary={dictionary}
-                baseUri={baseUri}
+                locale={locale}
             />
         </>
     );

--- a/libs/ui/src/lib/layouts/header-footer-layout/index.tsx
+++ b/libs/ui/src/lib/layouts/header-footer-layout/index.tsx
@@ -7,15 +7,10 @@ import FooterLayout from '../footer-layout';
 const HeaderFooterLayout = async ({ children, params }: PropsWithChildren & RootLayoutProps) => {
     const { lang } = await params;
     const dictionary = await getDictionary(lang, 'common');
-    const { FDK_COMMUNITY_BASE_URI: communityBaseUri = '/', FDK_REGISTRATION_BASE_URI: registrationBaseUri = '/' } =
-        process.env;
-
     return (
         <HeaderLayout
             dictionary={dictionary}
             locale={lang}
-            registrationBaseUri={registrationBaseUri}
-            communityBaseUri={communityBaseUri}
         >
             <FooterLayout
                 dictionary={dictionary}

--- a/libs/ui/src/lib/layouts/header-footer-layout/index.tsx
+++ b/libs/ui/src/lib/layouts/header-footer-layout/index.tsx
@@ -13,13 +13,13 @@ const HeaderFooterLayout = async ({ children, params }: PropsWithChildren & Root
     return (
         <HeaderLayout
             dictionary={dictionary}
-            baseUri={`/${lang}`}
+            locale={lang}
             registrationBaseUri={registrationBaseUri}
             communityBaseUri={communityBaseUri}
         >
             <FooterLayout
                 dictionary={dictionary}
-                baseUri={`/${lang}`}
+                locale={lang}
             >
                 {children}
             </FooterLayout>

--- a/libs/ui/src/lib/layouts/header-layout/index.tsx
+++ b/libs/ui/src/lib/layouts/header-layout/index.tsx
@@ -3,13 +3,13 @@ import { PropsWithChildren } from 'react';
 import Header, { type HeaderProps } from '../../header';
 
 const HeaderLayout = ({ children, ...props }: HeaderProps & PropsWithChildren) => {
-    const { dictionary, baseUri, registrationBaseUri, communityBaseUri, frontpage } = props;
+    const { dictionary, locale, registrationBaseUri, communityBaseUri, frontpage } = props;
 
     return (
         <>
             <Header
                 dictionary={dictionary}
-                baseUri={baseUri}
+                locale={locale}
                 registrationBaseUri={registrationBaseUri}
                 communityBaseUri={communityBaseUri}
                 frontpage={frontpage}

--- a/libs/ui/src/lib/layouts/header-layout/index.tsx
+++ b/libs/ui/src/lib/layouts/header-layout/index.tsx
@@ -3,15 +3,12 @@ import { PropsWithChildren } from 'react';
 import Header, { type HeaderProps } from '../../header';
 
 const HeaderLayout = ({ children, ...props }: HeaderProps & PropsWithChildren) => {
-    const { dictionary, locale, registrationBaseUri, communityBaseUri, frontpage } = props;
-
+    const { dictionary, locale, frontpage } = props;
     return (
         <>
             <Header
                 dictionary={dictionary}
                 locale={locale}
-                registrationBaseUri={registrationBaseUri}
-                communityBaseUri={communityBaseUri}
                 frontpage={frontpage}
             />
             {children}

--- a/libs/ui/src/lib/logo/index.tsx
+++ b/libs/ui/src/lib/logo/index.tsx
@@ -18,9 +18,8 @@ export type LogoLinkProps = {
     baseUri?: string;
 };
 
-const LogoLink = ({ className, baseUri, ...rest }: LogoLinkProps & Omit<LinkProps, 'children'>) => (
+const LogoLink = ({ className, ...rest }: LogoLinkProps & Omit<LinkProps, 'children'>) => (
     <Link
-        href={baseUri}
         className={cn(styles.logoLink, className)}
         {...rest}
     >

--- a/libs/ui/src/lib/main-menu/data/index.ts
+++ b/libs/ui/src/lib/main-menu/data/index.ts
@@ -52,11 +52,11 @@ const getMainMenuData = (dictionary: Dictionary, baseUri: string) => ({
     tools: [
         {
             title: dictionary.mainMenu.tools.links.organizations,
-            href: `/organizations`,
+            href: `${baseUri}/organizations`,
         },
         {
             title: dictionary.mainMenu.tools.links.requestData,
-            href: `/requests`,
+            href: `${baseUri}/requests`,
         },
         {
             title: dictionary.mainMenu.tools.links.dataHunter,
@@ -64,11 +64,11 @@ const getMainMenuData = (dictionary: Dictionary, baseUri: string) => ({
         },
         {
             title: dictionary.mainMenu.tools.links.sparqlSandbox,
-            href: `/sparql`,
+            href: `${baseUri}/sparql`,
         },
         {
             title: dictionary.mainMenu.catalogs.ai.title,
-            href: `/kunstig-intelligens`,
+            href: `${baseUri}/kunstig-intelligens`,
         },
     ],
     about: [
@@ -78,7 +78,7 @@ const getMainMenuData = (dictionary: Dictionary, baseUri: string) => ({
         },
         {
             title: dictionary.mainMenu.about.links.reports,
-            href: `/reports`,
+            href: `${baseUri}/reports`,
         },
         {
             title: dictionary.mainMenu.about.links.contactUs,

--- a/libs/ui/src/lib/main-menu/data/index.ts
+++ b/libs/ui/src/lib/main-menu/data/index.ts
@@ -1,42 +1,42 @@
 import { Dictionary } from '@fdk-frontend/dictionaries';
 
-const getMainMenuData = (dictionary: Dictionary, baseUri: string) => ({
+const getMainMenuData = (dictionary: Dictionary, locale: string) => ({
     catalogs: [
         {
             key: 'datasets',
             title: dictionary.mainMenu.catalogs.datasets.title,
             description: dictionary.mainMenu.catalogs.datasets.description,
-            href: `${baseUri}/catalogs/datasets`,
+            href: `/${locale}/catalogs/datasets`,
         },
         {
             key: 'apis',
             title: dictionary.mainMenu.catalogs.apis.title,
             description: dictionary.mainMenu.catalogs.apis.description,
-            href: `${baseUri}/catalogs/data-services`,
+            href: `/${locale}/catalogs/data-services`,
         },
         {
             key: 'terms',
             title: dictionary.mainMenu.catalogs.terms.title,
             description: dictionary.mainMenu.catalogs.terms.description,
-            href: `${baseUri}/catalogs/concepts`,
+            href: `/${locale}/catalogs/concepts`,
         },
         {
             key: 'information-models',
             title: dictionary.mainMenu.catalogs.informationModels.title,
             description: dictionary.mainMenu.catalogs.informationModels.description,
-            href: `${baseUri}/catalogs/information-models`,
+            href: `/${locale}/catalogs/information-models`,
         },
         {
             key: 'services-events',
             title: dictionary.mainMenu.catalogs.servicesEvents.title,
             description: dictionary.mainMenu.catalogs.servicesEvents.description,
-            href: `${baseUri}/catalogs/public-services-and-events`,
+            href: `/${locale}/catalogs/public-services-and-events`,
         },
     ],
     help: [
         {
             title: dictionary.mainMenu.help.links.getStarted,
-            href: `${baseUri}/docs`,
+            href: `/${locale}/docs`,
         },
         {
             title: dictionary.mainMenu.help.links.documentation,
@@ -52,37 +52,37 @@ const getMainMenuData = (dictionary: Dictionary, baseUri: string) => ({
     tools: [
         {
             title: dictionary.mainMenu.tools.links.organizations,
-            href: `${baseUri}/organizations`,
+            href: `/${locale}/organizations`,
         },
         {
             title: dictionary.mainMenu.tools.links.requestData,
-            href: `${baseUri}/requests`,
+            href: `/${locale}/requests`,
         },
         {
             title: dictionary.mainMenu.tools.links.dataHunter,
-            href: `${baseUri}/data-hunter`,
+            href: `/${locale}/data-hunter`,
         },
         {
             title: dictionary.mainMenu.tools.links.sparqlSandbox,
-            href: `${baseUri}/sparql`,
+            href: `/${locale}/sparql`,
         },
         {
             title: dictionary.mainMenu.catalogs.ai.title,
-            href: `${baseUri}/kunstig-intelligens`,
+            href: `/${locale}/kunstig-intelligens`,
         },
     ],
     about: [
         {
             title: dictionary.mainMenu.about.links.aboutUs,
-            href: `${baseUri}/about`,
+            href: `/${locale}/about`,
         },
         {
             title: dictionary.mainMenu.about.links.reports,
-            href: `${baseUri}/reports`,
+            href: `/${locale}/reports`,
         },
         {
             title: dictionary.mainMenu.about.links.contactUs,
-            href: `${baseUri}/contact`,
+            href: `/${locale}/contact`,
         },
         {
             title: dictionary.mainMenu.about.links.a11yStatement,

--- a/libs/ui/src/lib/main-menu/index.tsx
+++ b/libs/ui/src/lib/main-menu/index.tsx
@@ -20,9 +20,7 @@ type MainMenuProps = React.HTMLAttributes<HTMLDivElement> & {
 const MotionNav: ForwardRefComponent<any, any> = motion.nav;
 
 const MainMenu = ({ className, dictionary, locale, motionProps = {} }: MainMenuProps) => {
-    const baseUri = `/${locale}`
-    const data = getMainMenuData(dictionary, baseUri);
-
+    const data = getMainMenuData(dictionary, locale);
     const animations = {
         links: {
             hidden: { opacity: 0 },

--- a/libs/ui/src/lib/main-menu/index.tsx
+++ b/libs/ui/src/lib/main-menu/index.tsx
@@ -5,7 +5,7 @@ import cn from 'classnames';
 import { ForwardRefComponent, motion } from 'framer-motion';
 import { Link, Heading } from '@digdir/designsystemet-react';
 import { ExternalLinkIcon } from '@navikt/aksel-icons';
-import { Dictionary } from '@fdk-frontend/dictionaries';
+import { type Dictionary, type LocaleCodes } from '@fdk-frontend/dictionaries';
 
 import styles from './main-menu.module.scss';
 import GithubLogo from './images/github-logo';
@@ -13,13 +13,14 @@ import getMainMenuData from './data';
 
 type MainMenuProps = React.HTMLAttributes<HTMLDivElement> & {
     dictionary: Dictionary;
-    baseUri: string;
+    locale: LocaleCodes;
     motionProps?: any;
 };
 
 const MotionNav: ForwardRefComponent<any, any> = motion.nav;
 
-const MainMenu = ({ className, dictionary, baseUri, motionProps = {} }: MainMenuProps) => {
+const MainMenu = ({ className, dictionary, locale, motionProps = {} }: MainMenuProps) => {
+    const baseUri = `/${locale}`
     const data = getMainMenuData(dictionary, baseUri);
 
     const animations = {


### PR DESCRIPTION
- fjerner bruk av baseUri for å bygge uri-er i komponentene, og sender i stedet bare locale
- fikser tilfeller der brukerens språkvalg ikke ble tatt med videre i navigeringen
- fikser tilfeller der baseUri i prod var fellesdatakatalog.digdir.no i stedet for data.norge.no