### PR TITLE
feat: use-dataset-popover

### DIFF
--- a/apps/data-norge/src/app/[lang]/leaving-gateway/styles.module.scss
+++ b/apps/data-norge/src/app/[lang]/leaving-gateway/styles.module.scss
@@ -1,4 +1,4 @@
-@use '@fdk-frontend/ui/placeholder-box/placeholder-box.module' as placeholder-box;
+@use '@fdk-frontend/ui/box/box.module' as box;
 @import '@fdk-frontend/ui/core/mixins';
 
 .wrapper {
@@ -15,7 +15,7 @@
     }
 
     .urlBox {
-        @include placeholder-box.placeholder-box-mixin();
+        @include box.grey-box-mixin();
     }
 
     .toolbar {

--- a/apps/data-norge/src/app/components/details-page/dataset-header/dataset-header.module.scss
+++ b/apps/data-norge/src/app/components/details-page/dataset-header/dataset-header.module.scss
@@ -1,0 +1,71 @@
+.header {
+    display: grid;
+    grid-template-areas: 'a a' 'b c' 'd d';
+    grid-template-columns: auto auto;
+    grid-template-rows: auto auto;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+
+    .orgBtn {
+        grid-area: a;
+        grid-column: 1 / -1;
+        justify-self: start;
+    }
+
+    .title {
+        grid-area: b;
+        font-size: 2.25rem;
+    }
+
+    .headerToolbar {
+        display: flex;
+        align-items: flex-start;
+        gap: 1rem;
+        grid-area: c;
+        justify-self: end;
+
+        button {
+            white-space: nowrap;
+        }
+    }
+
+    .headerTags {
+        grid-area: d;
+        grid-column: 1 / -1;
+
+        a:not(:hover) {
+            text-decoration: none;
+        }
+    }
+
+    .lastUpdated {
+        font-size: 0.9em;
+        opacity: 0.7;
+        margin-left: 0.25rem;
+        white-space: nowrap;
+        line-height: 2em;
+    }
+
+    @media (max-width: 650px) {
+        grid-template-areas: 'a a' 'b c' 'd d' 'e e';
+
+        .orgBtn {
+            grid-column: 1;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            min-width: 0;
+        }
+
+        .headerToolbar {
+            grid-area: e;
+            grid-column: 1 / -1;
+            justify-self: start;
+            margin-top: 0.5rem;
+        }
+
+        .title {
+            grid-column: 1 / -1;
+        }
+    }
+}

--- a/apps/data-norge/src/app/components/details-page/dataset-header/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/dataset-header/index.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import React from 'react';
+import { type DatasetWithIdentifier, type DataService } from '@fdk-frontend/fdk-types';
+import { type Dictionary, type LocaleCodes } from '@fdk-frontend/dictionaries';
+import { printLocaleValue } from '@fdk-frontend/utils';
+import OrgButton from '@fdk-frontend/ui/org-button';
+import OpenDataTag from '@fdk-frontend/ui/open-data-tag';
+import { Heading, Link, Tag, Popover } from '@digdir/designsystemet-react';
+import AccessRequestButton from '@fdk-frontend/ui/access-request-button';
+import AccessLevelTag from '@fdk-frontend/ui/access-level-tag';
+import UseDatasetPopover from '@fdk-frontend/ui/use-dataset-popover';
+import TagList from '@fdk-frontend/ui/tag-list';
+import styles from './dataset-header.module.scss';
+
+type DatasetHeaderProps = {
+    dataset: DatasetWithIdentifier;
+    apis?: DataService[];
+    dictionaries: {
+        common: Dictionary;
+        detailsPage: Dictionary;
+    };
+    locale: LocaleCodes;
+    orgLogo?: string | null;
+    accessRequestDemo?: boolean;
+    isAvailable?: boolean;
+};
+
+const DatasetHeader = ({
+    children,
+    dataset,
+    apis = [],
+    dictionaries,
+    orgLogo,
+    locale,
+    accessRequestDemo,
+    isAvailable,
+    ...props
+}: DatasetHeaderProps & React.HTMLAttributes<HTMLDivElement>) => {
+    return (
+        <div className={styles.header}>
+            <OrgButton
+                href={`/organizations/${dataset.publisher?.id}`}
+                orgLogoSrc={orgLogo}
+                className={styles.orgBtn}
+            >
+                {dataset.publisher
+                    ? printLocaleValue(locale, dataset.publisher?.prefLabel)
+                    : dictionaries.detailsPage.header.namelessOrganization}
+            </OrgButton>
+            <Heading
+                level={1}
+                size='lg'
+                className={styles.title}
+            >
+                {printLocaleValue(locale, dataset.title) || dictionaries.detailsPage.header.namelessDataset}
+            </Heading>
+            <div className={styles.headerToolbar}>
+                {accessRequestDemo && (
+                    <AccessRequestButton
+                        kind='datasets'
+                        id={dataset.id}
+                        locale={locale}
+                        dictionary={dictionaries.detailsPage}
+                        isAvailable={isAvailable}
+                    />
+                )}
+                <Popover
+                    size='sm'
+                    placement='bottom-end'
+                >
+                    <Popover.Trigger size='sm'>{dictionaries.detailsPage.header.useDatasetButton}</Popover.Trigger>
+                    <Popover.Content style={{ maxWidth: 350 }}>
+                        <UseDatasetPopover
+                            dataset={dataset}
+                            apis={apis}
+                            dictionary={dictionaries.detailsPage}
+                            locale={locale}
+                        />
+                    </Popover.Content>
+                </Popover>
+            </div>
+            <TagList className={styles.headerTags}>
+                <Tag
+                    color='info'
+                    size='sm'
+                >
+                    <Link href='/datasets'>{dictionaries.detailsPage.header.datasetsTagLink}</Link>
+                </Tag>
+                <AccessLevelTag
+                    accessCode={dataset.accessRights?.code}
+                    locale={locale}
+                    dictionary={dictionaries.detailsPage}
+                />
+                {dataset.isOpenData && <OpenDataTag dictionary={dictionaries.common} />}
+            </TagList>
+        </div>
+    );
+};
+
+export default DatasetHeader;

--- a/apps/data-norge/src/app/components/details-page/dataset/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/dataset/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState } from 'react';
-import cn from 'classnames';
 import { type Dictionary, type LocaleCodes } from '@fdk-frontend/dictionaries';
 import {
     type DatasetWithIdentifier,
@@ -17,28 +16,19 @@ import Badge from '@fdk-frontend/ui/badge';
 import { BrandDivider } from '@fdk-frontend/ui/divider';
 import Markdown from '@fdk-frontend/ui/markdown';
 import Article from '@fdk-frontend/ui/article';
-import OrgButton from '@fdk-frontend/ui/org-button';
 import ScrollShadows from '@fdk-frontend/ui/scroll-shadows';
 import ExpandableContent from '@fdk-frontend/ui/expandable-content';
-import AccessLevelTag from '@fdk-frontend/ui/access-level-tag';
-import OpenDataTag from '@fdk-frontend/ui/open-data-tag';
 import PlaceholderBox from '@fdk-frontend/ui/placeholder-box';
 import DatasetTable from '@fdk-frontend/ui/dataset-table';
-import AccessRequestButton from '@fdk-frontend/ui/access-request-button';
 import ResourceNotAvailableNotice from '@fdk-frontend/ui/resource-not-available-notice';
 import ExternalLink from '@fdk-frontend/ui/external-link';
 import { accessRequestWhiteList } from '@fdk-frontend/utils/access-request';
-import {
-    trackSiteImproveEvent,
-    EventCategory,
-    EventAction,
-    EventLabel,
-} from '@fdk-frontend/utils/siteimprove-analytics';
-import { Button, Heading, Link, Tag, Tabs, TabList, Tab, TabContent } from '@digdir/designsystemet-react';
+import { Heading, Tabs, TabList, Tab, TabContent } from '@digdir/designsystemet-react';
 import Distributions from '../distributions';
 import DatasetDetailsTab from '../details-tab';
 import MetadataTab from '../metadata-tab';
 import CommunityTab from '../community-tab';
+import DatasetHeader from '../dataset-header';
 import styles from '../details-page.module.scss';
 
 export type DatasetDetailsPageType = {
@@ -84,15 +74,8 @@ export default function DatasetDetailsPage({
     resolvedDistributionInformationModels,
 }: DatasetDetailsPageType) {
     const [activeTab, setActiveTab] = useState(defaultActiveTab);
-    const [highlight, setHighlight] = useState(false);
-
     const isAvailable = !!sumArrayLengths(resource.distribution, resource.sample, apis);
     const accessRequestDemo = accessRequestWhiteList.some((i) => i.id === resource.id);
-
-    const blink = () => {
-        setHighlight(true);
-        setTimeout(() => setHighlight(false), 1000);
-    };
 
     const breadcrumbList = [
         {
@@ -115,67 +98,17 @@ export default function DatasetDetailsPage({
                 breadcrumbList={breadcrumbList}
             />
             <div className={styles.mainContent}>
-                <div className={styles.header}>
-                    <OrgButton
-                        href={`/organizations/${resource.publisher?.id}`}
-                        orgLogoSrc={orgLogo}
-                    >
-                        {resource.publisher
-                            ? printLocaleValue(locale, resource.publisher?.prefLabel)
-                            : dictionaries.detailsPage.header.namelessOrganization}
-                    </OrgButton>
-                    <div className={styles.headerGrid}>
-                        <Heading
-                            level={1}
-                            size='lg'
-                            className={styles.title}
-                        >
-                            {printLocaleValue(locale, resource.title) ||
-                                dictionaries.detailsPage.header.namelessDataset}
-                        </Heading>
-                        <div className={styles.headerToolbar}>
-                            {accessRequestDemo && (
-                                <AccessRequestButton
-                                    kind='datasets'
-                                    id={resource.id}
-                                    dictionary={dictionaries.detailsPage}
-                                    isAvailable={isAvailable}
-                                    locale={locale}
-                                />
-                            )}
-                            <Button
-                                size='sm'
-                                onClick={() => {
-                                    setActiveTab('distributions');
-                                    updateUri('distributions');
-                                    blink();
-                                    trackSiteImproveEvent({
-                                        category: EventCategory.DETAILS_PAGE,
-                                        action: EventAction.CLICK,
-                                        label: EventLabel.USE_DATASET_BUTTON,
-                                    });
-                                }}
-                            >
-                                {dictionaries.detailsPage.header.useDatasetButton}
-                            </Button>
-                        </div>
-                        <div className={styles.headerTags}>
-                            <Tag
-                                color='info'
-                                size='sm'
-                            >
-                                <Link href={`/datasets`}>{dictionaries.detailsPage.header.datasetsTagLink}</Link>
-                            </Tag>
-                            <AccessLevelTag
-                                accessCode={resource.accessRights?.code}
-                                dictionary={dictionaries.detailsPage}
-                                locale={locale}
-                            />
-                            {resource.isOpenData && <OpenDataTag dictionary={dictionaries.common} />}
-                        </div>
-                    </div>
-                </div>
+                <DatasetHeader
+                    dataset={resource}
+                    apis={apis}
+                    dictionaries={dictionaries}
+                    locale={locale}
+                    orgLogo={orgLogo}
+                    accessRequestDemo={accessRequestDemo}
+                    isAvailable={isAvailable}
+                />
                 <Tabs
+                    className={styles.tabs}
                     defaultValue='overview'
                     size='sm'
                     value={activeTab}
@@ -257,7 +190,6 @@ export default function DatasetDetailsPage({
                         <section className={styles.section}>
                             {!isAvailable && accessRequestDemo ? (
                                 <ResourceNotAvailableNotice
-                                    className={cn({ [styles.highlight]: highlight })}
                                     kind='datasets'
                                     id={resource.id}
                                     dictionary={dictionaries.detailsPage}
@@ -268,7 +200,6 @@ export default function DatasetDetailsPage({
                                     datasets={resource.distribution}
                                     exampleData={resource.sample}
                                     apis={apis}
-                                    className={cn({ [styles.highlight]: highlight })}
                                     locale={locale}
                                     dictionaries={dictionaries}
                                     resolvedDistributionDataServices={resolvedDistributionDataServices}
@@ -321,7 +252,6 @@ export default function DatasetDetailsPage({
                     <TabContent value='distributions'>
                         {!isAvailable && accessRequestDemo ? (
                             <ResourceNotAvailableNotice
-                                className={cn({ [styles.highlight]: highlight })}
                                 kind='datasets'
                                 id={resource.id}
                                 dictionary={dictionaries.detailsPage}
@@ -332,7 +262,6 @@ export default function DatasetDetailsPage({
                                 datasets={resource.distribution}
                                 exampleData={resource.sample}
                                 apis={apis}
-                                className={cn({ [styles.highlight]: highlight })}
                                 locale={locale}
                                 dictionaries={dictionaries}
                                 resolvedDistributionDataServices={resolvedDistributionDataServices}

--- a/apps/data-norge/src/app/components/details-page/details-page.module.scss
+++ b/apps/data-norge/src/app/components/details-page/details-page.module.scss
@@ -1,30 +1,5 @@
 @import '@fdk-frontend/ui/core/mixins';
 
-.highlight {
-    > :global(.fds-alert),
-    > :global(.fds-accordion) {
-        animation: blink-border 1s ease-in-out 2;
-    }
-}
-
-@keyframes blink-border {
-    0% {
-        box-shadow: 0px 0px 0px 10px transparent;
-    }
-    25% {
-        box-shadow: 0px 0px 0px 10px var(--fds-semantic-surface-focus-default);
-    }
-    50% {
-        box-shadow: 0px 0px 0px 10px transparent;
-    }
-    75% {
-        box-shadow: 0px 0px 0px 10px var(--fds-semantic-surface-focus-default);
-    }
-    100% {
-        box-shadow: 0px 0px 0px 10px transparent;
-    }
-}
-
 .detailsPage {
     margin: 0 2rem 3rem;
     container-type: inline-size;
@@ -45,68 +20,6 @@
 
         @media (max-width: 650px) {
             margin-top: 1rem;
-        }
-
-        .header {
-            margin-bottom: 1.5rem;
-
-            .headerGrid {
-                margin-top: 0.5rem;
-                display: grid;
-                grid-template-areas: 'a b' 'c c';
-                grid-template-columns: auto auto;
-                grid-template-rows: auto auto;
-                gap: 0.75rem;
-
-                .title {
-                    grid-area: a;
-                    font-size: 2.25rem;
-                }
-
-                .headerToolbar {
-                    grid-area: b;
-                    display: flex;
-                    align-items: flex-start;
-                    gap: 1rem;
-                    justify-self: end;
-
-                    button {
-                        white-space: nowrap;
-                    }
-                }
-
-                .headerTags {
-                    grid-area: c;
-                    grid-column: 1 / -1;
-
-                    :global(.fds-tag) {
-                        display: inline-flex;
-                        margin-right: 0.5rem;
-                    }
-
-                    a:not(:hover) {
-                        text-decoration: none;
-                    }
-
-                    .lastUpdated {
-                        font-size: 0.9em;
-                        opacity: 0.7;
-                        margin-left: 0.25rem;
-                        white-space: nowrap;
-                        line-height: 2em;
-                    }
-                }
-
-                @media (max-width: 500px) {
-                    grid-template-areas: 'a' 'c' 'b';
-                    grid-template-columns: 1fr;
-
-                    .headerToolbar {
-                        justify-self: start;
-                        margin-top: 0.5rem;
-                    }
-                }
-            }
         }
 
         .tabsScrollShadows {
@@ -132,16 +45,18 @@
             }
         }
 
-        :global(.fds-tabs__tab) {
-            padding: 0.75rem 1rem;
-            white-space: nowrap;
-        }
+        .tabs {
+            :global(.fds-tabs__tab) {
+                padding: 0.75rem 1rem;
+                white-space: nowrap;
+            }
 
-        :global(.fds-tabs__content) {
-            padding: 1.5rem 0;
+            :global(.fds-tabs__content) {
+                padding: 1.5rem 0;
 
-            > * + * {
-                margin-top: 1.5rem;
+                > * + * {
+                    margin-top: 1.5rem;
+                }
             }
         }
 

--- a/apps/data-norge/src/app/components/details-page/distributions/components/api-header/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/distributions/components/api-header/index.tsx
@@ -1,7 +1,8 @@
 import { PropsWithChildren } from 'react';
 import { type DataService } from '@fdk-frontend/fdk-types';
-import { type LocaleCodes, type Dictionary, i18n } from '@fdk-frontend/dictionaries';
+import { type LocaleCodes, type Dictionary } from '@fdk-frontend/dictionaries';
 import ApiTags from '@fdk-frontend/ui/api-tags';
+import { printLocaleValue } from '@fdk-frontend/utils';
 import styles from '../distribution-header/distribution-header.module.scss';
 
 type ApiHeaderProps = {
@@ -14,7 +15,7 @@ const ApiHeader = ({ api, locale, dictionary, ...props }: ApiHeaderProps & Props
     return (
         <div className={styles.headerContent}>
             <span className={styles.title}>
-                {api.title?.[locale] || api.title?.[i18n.defaultLocale] || dictionary.apis.header.nameless}
+                {printLocaleValue(locale, api.title) || dictionary.apis.header.nameless}
                 <ApiTags
                     api={api}
                     dictionary={dictionary}

--- a/apps/data-norge/src/app/components/details-page/distributions/components/distribution-header/distribution-header.module.scss
+++ b/apps/data-norge/src/app/components/details-page/distributions/components/distribution-header/distribution-header.module.scss
@@ -16,6 +16,10 @@
         font-size: 1.1rem;
         font-weight: 600;
         flex-grow: 1;
+
+        ul {
+            margin-top: 0.25rem;
+        }
     }
 
     :global(.fds-link) {

--- a/apps/data-norge/src/app/components/details-page/distributions/components/distribution-header/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/distributions/components/distribution-header/index.tsx
@@ -21,21 +21,15 @@ const DistributionHeader = ({
 }: DistributionHeaderProps & PropsWithChildren) => {
     const hasOpenLicense = distribution.license && distribution.license.some((l: any) => isOpenLicense(l.uri));
     const hasTags = hasOpenLicense || exampleData || distribution.fdkFormat?.length || hasOpenLicense;
-    const hasApi = Boolean(distribution.accessService?.length);
 
     return (
         <div className={styles.headerContent}>
             <span className={styles.title}>
-                {distribution.title
-                    ? printLocaleValue(locale, distribution.title)
-                    : distribution.accessURL
-                      ? distribution.accessURL
-                      : dictionary.distributions.header.nameless}
+                {printLocaleValue(locale, distribution.title) || dictionary.distributions.header.nameless}
                 {hasTags && (
                     <DistributionTags
                         distribution={distribution}
                         exampleData={exampleData}
-                        hasApi={hasApi}
                         dictionary={dictionary}
                     />
                 )}

--- a/apps/data-norge/src/app/components/details-page/distributions/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/distributions/index.tsx
@@ -4,7 +4,7 @@ import { Accordion, Heading } from '@digdir/designsystemet-react';
 import { type LocaleCodes, type Dictionary } from '@fdk-frontend/dictionaries';
 import { type JSONValue } from '@fdk-frontend/types';
 import { sumArrayLengths, printLocaleValue } from '@fdk-frontend/utils';
-import { ArrowRightIcon, DownloadIcon } from '@navikt/aksel-icons';
+import { ArrowRightIcon } from '@navikt/aksel-icons';
 import { type SearchObject } from '@fdk-frontend/fdk-types';
 import Badge from '@fdk-frontend/ui/badge';
 import HStack from '@fdk-frontend/ui/hstack';
@@ -74,14 +74,13 @@ const Distributions = ({
                                 <DownloadButton
                                     uris={distribution.accessURL}
                                     className={styles.actionButton}
-                                    modalTitle={printLocaleValue(locale, distribution.title)}
+                                    modalTitle={
+                                        printLocaleValue(locale, distribution.title) ||
+                                        dictionaries.detailsPage.distributions.header.nameless
+                                    }
                                     dictionary={dictionaries.detailsPage}
                                     locale={locale}
                                 >
-                                    <DownloadIcon
-                                        aria-hidden
-                                        fontSize='1.2em'
-                                    />
                                     {dictionaries.detailsPage.distributions.header.downloadBtnLabel}
                                 </DownloadButton>
                             )}
@@ -116,14 +115,13 @@ const Distributions = ({
                                 <DownloadButton
                                     uris={example.accessURL}
                                     className={styles.actionButton}
-                                    modalTitle={printLocaleValue(locale, example.title)}
+                                    modalTitle={
+                                        printLocaleValue(locale, example.title) ||
+                                        dictionaries.detailsPage.distributions.header.nameless
+                                    }
                                     dictionary={dictionaries.detailsPage}
                                     locale={locale}
                                 >
-                                    <DownloadIcon
-                                        aria-hidden
-                                        fontSize='1.2em'
-                                    />
                                     {dictionaries.detailsPage.distributions.header.downloadBtnLabel}
                                 </DownloadButton>
                                 <Accordion.Content className={styles.content}>

--- a/libs/dictionaries/src/lib/dictionaries/en/details-page.json
+++ b/libs/dictionaries/src/lib/dictionaries/en/details-page.json
@@ -11,6 +11,10 @@
         "requestAccessButton": "Request access",
         "showInterestButton": "Report interest"
     },
+    "useDatasetPopover": {
+        "distributions": "Distributions",
+        "apis": "APIs"
+    },
     "resourceNotAvailableNotice": {
         "title": "This dataset is not yet available",
         "body": "This dataset has no distributions. This means that only the description of the dataset is available, while the actual content and data have not yet been published. You can express your interest in the dataset to the responsible organization by clicking the button below. The more people show interest, the greater the chance that the data will be made available.",
@@ -37,7 +41,7 @@
     },
     "tabs": {
         "overview": "Overview",
-        "distributions": "Distributions & API",
+        "distributions": "Distributions & APIs",
         "details": "Details",
         "community": "Discussions",
         "rdf": "RDF"

--- a/libs/dictionaries/src/lib/dictionaries/nb/details-page.json
+++ b/libs/dictionaries/src/lib/dictionaries/nb/details-page.json
@@ -11,6 +11,10 @@
         "requestAccessButton": "Be om tilgang",
         "showInterestButton": "Meld interesse"
     },
+    "useDatasetPopover": {
+        "distributions": "Distribusjoner",
+        "apis": "API-er"
+    },
     "resourceNotAvailableNotice": {
         "title": "Dette datasettet er enda ikke tilgjengelig",
         "body": "Dette datasettet har ingen distribusjoner. Det betyr at kun beskrivelsen av datasettet er tilgjengelig, mens selve innholdet og dataene ennå ikke er publisert. Du kan melde din interesse for datasettet til den ansvarlige virksomheten ved å klikke på knappen nedenfor. Jo flere som viser interesse, desto større er sjansen for at dataene blir gjort tilgjengelige.",
@@ -37,7 +41,7 @@
     },
     "tabs": {
         "overview": "Oversikt",
-        "distributions": "Distribusjoner og API",
+        "distributions": "Distribusjoner og API-er",
         "details": "Detaljer",
         "community": "Diskusjoner",
         "rdf": "RDF"

--- a/libs/dictionaries/src/lib/dictionaries/nn/details-page.json
+++ b/libs/dictionaries/src/lib/dictionaries/nn/details-page.json
@@ -11,6 +11,10 @@
         "requestAccessButton": "Be om tilgong",
         "showInterestButton": "Meld interesse"
     },
+    "useDatasetPopover": {
+        "distributions": "Distribusjonar",
+        "apis": "API-ar"
+    },
     "resourceNotAvailableNotice": {
         "title": "Dette datasettet er ikkje tilgjengeleg enno",
         "body": "Dette datasettet har ingen distribusjonar. Det betyr at berre skildringa av datasettet er tilgjengeleg, medan sjølve innhaldet og dataa ikkje er publiserte enno. Du kan melde di interesse for datasettet til den ansvarlege verksemda ved å klikke på knappen nedanfor. Jo fleire som viser interesse, dess større er sjansen for at dataa blir gjorde tilgjengelege.",
@@ -37,7 +41,7 @@
     },
     "tabs": {
         "overview": "Oversikt",
-        "distributions": "Distribusjonar og API",
+        "distributions": "Distribusjonar og API-ar",
         "details": "Detaljar",
         "community": "Diskusjonar",
         "rdf": "RDF"

--- a/libs/ui/src/lib/api-tags/index.tsx
+++ b/libs/ui/src/lib/api-tags/index.tsx
@@ -3,16 +3,16 @@ import mime from 'mime-types';
 import { type DataService } from '@fdk-frontend/fdk-types';
 import { type Dictionary } from '@fdk-frontend/dictionaries';
 import { Tag } from '@digdir/designsystemet-react';
-import TagList from '../tag-list';
+import TagList, { type TagListProps } from '../tag-list';
 
-type ApiTagsProps = {
+type ApiTagsProps = TagListProps & {
     api: DataService;
     dictionary: Dictionary;
 };
 
-const ApiTags = ({ children, api, dictionary, ...props }: ApiTagsProps & React.HTMLAttributes<HTMLDivElement>) => {
+const ApiTags = ({ children, api, dictionary, ...props }: ApiTagsProps & React.HTMLAttributes<HTMLUListElement>) => {
     return (
-        <TagList>
+        <TagList {...props}>
             {api.fdkFormat
                 ?.filter((format: any) => format?.code)
                 .map((format: any, i: number) => (

--- a/libs/ui/src/lib/box/box.module.scss
+++ b/libs/ui/src/lib/box/box.module.scss
@@ -4,6 +4,11 @@
     padding: 0.75rem;
 }
 
+@mixin grey-box-mixin {
+    @include box-mixin();
+    background: #fafafa;
+}
+
 .box {
     @include box-mixin();
 }

--- a/libs/ui/src/lib/core/fds-overrides.scss
+++ b/libs/ui/src/lib/core/fds-overrides.scss
@@ -129,3 +129,11 @@ Fix for bug where items doesnt wrap
 .fds-paragraph {
     color: currentColor;
 }
+
+.fds-popover {
+    box-shadow: var(--fds-shadow-medium);
+
+    &:not(.fds-popover--info) {
+        border-color: var(--fds-semantic-border-neutral-subtle);
+    }
+}

--- a/libs/ui/src/lib/distribution-tags/index.tsx
+++ b/libs/ui/src/lib/distribution-tags/index.tsx
@@ -4,9 +4,9 @@ import { type Distribution } from '@fdk-frontend/fdk-types';
 import { isOpenLicense } from '@fdk-frontend/utils';
 import { type Dictionary } from '@fdk-frontend/dictionaries';
 import { Tag } from '@digdir/designsystemet-react';
-import TagList from '../tag-list';
+import TagList, { type TagListProps } from '../tag-list';
 
-type DistributionTagsProps = {
+type DistributionTagsProps = TagListProps & {
     distribution: Distribution;
     exampleData?: boolean;
     dictionary: Dictionary;
@@ -18,13 +18,13 @@ const DistributionTags = ({
     distribution,
     exampleData,
     dictionary,
-    hasApi,
     ...props
-}: DistributionTagsProps & React.HTMLAttributes<HTMLDivElement>) => {
+}: DistributionTagsProps & React.HTMLAttributes<HTMLUListElement>) => {
     const hasOpenLicense = distribution.license && distribution.license.some((l: any) => isOpenLicense(l.uri));
+    const hasApi = Boolean(distribution.accessService?.length);
 
     return (
-        <TagList>
+        <TagList {...props}>
             {hasOpenLicense && (
                 <Tag
                     color='success'

--- a/libs/ui/src/lib/download-button/index.tsx
+++ b/libs/ui/src/lib/download-button/index.tsx
@@ -9,7 +9,7 @@ import styles from './styles.module.scss';
 
 type DownloadButtonProps = {
     modalTitle: string;
-    uris: string[];
+    uris?: string[];
     dictionary: Dictionary;
     locale: LocaleCodes;
 };
@@ -23,6 +23,8 @@ const DownloadButton = ({
     ...props
 }: DownloadButtonProps & ButtonProps) => {
     const modalRef = useRef<HTMLDialogElement>(null);
+
+    if (!uris) return null;
 
     if (uris.length === 1) {
         return (
@@ -40,6 +42,10 @@ const DownloadButton = ({
                     gateway
                     locale={locale}
                 >
+                    <DownloadIcon
+                        aria-hidden
+                        fontSize='1.2em'
+                    />
                     {children}
                 </ExternalLink>
             </Button>
@@ -54,6 +60,10 @@ const DownloadButton = ({
                     variant='secondary'
                     {...props}
                 >
+                    <DownloadIcon
+                        aria-hidden
+                        fontSize='1.2em'
+                    />
                     {children}
                     <Badge>{uris.length}</Badge>
                 </Button>
@@ -63,10 +73,11 @@ const DownloadButton = ({
                 className={styles.dialog}
                 onInteractOutside={() => modalRef.current?.close()}
             >
-                <Modal.Header closeButton={true}>{dictionary.distributions.downloadModal.header}</Modal.Header>
+                <Modal.Header closeButton={true}>{modalTitle}</Modal.Header>
                 <Modal.Content className={styles.content}>
+                    {dictionary.distributions.downloadModal.header}
                     <ul className='fdk-box-list'>
-                        {uris.map((uri: string, index: number) => (
+                        {uris?.map((uri: string, index: number) => (
                             <li key={`${uri}-${index}`}>
                                 <ExternalLink
                                     href={uri}
@@ -91,6 +102,10 @@ const DownloadButton = ({
                         variant='secondary'
                         onClick={() => modalRef.current?.close()}
                     >
+                        <DownloadIcon
+                            aria-hidden
+                            fontSize='1.2em'
+                        />
                         {dictionary.distributions.downloadModal.closeBtn}
                     </Button>
                 </Modal.Footer>

--- a/libs/ui/src/lib/download-button/styles.module.scss
+++ b/libs/ui/src/lib/download-button/styles.module.scss
@@ -4,10 +4,13 @@
 }
 
 .content {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
     ul,
     ol {
         background: #fafafa;
-        margin-top: 0.5rem;
     }
 }
 

--- a/libs/ui/src/lib/header/header.module.scss
+++ b/libs/ui/src/lib/header/header.module.scss
@@ -58,7 +58,7 @@
 
 .headerOuter {
     position: absolute;
-    z-index: 100;
+    z-index: 1600;
     width: 100%;
     transition: all linear 200ms;
     max-height: 100vh;
@@ -82,7 +82,7 @@
         padding: 1rem 2rem;
         justify-content: space-between;
         position: relative;
-        z-index: 102;
+        z-index: 1601;
         container-type: inline-size;
 
         &.full {

--- a/libs/ui/src/lib/org-button/index.tsx
+++ b/libs/ui/src/lib/org-button/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import cn from 'classnames';
 import { Buildings3Icon } from '@navikt/aksel-icons';
 import { Button, type ButtonProps, Link } from '@digdir/designsystemet-react';
 import styles from './org-button.module.scss';
@@ -8,13 +9,13 @@ export type OrgButtonProps = {
     href?: string;
 };
 
-const OrgButton = ({ children, href, orgLogoSrc, ...props }: OrgButtonProps & ButtonProps) => {
+const OrgButton = ({ children, className, href, orgLogoSrc, ...props }: OrgButtonProps & ButtonProps) => {
     return (
         <Button
             asChild
             size='sm'
             variant='tertiary'
-            className={styles.wrapper}
+            className={cn(styles.wrapper, className)}
             {...props}
         >
             <Link href={href}>

--- a/libs/ui/src/lib/placeholder-box/placeholder-box.module.scss
+++ b/libs/ui/src/lib/placeholder-box/placeholder-box.module.scss
@@ -1,10 +1,5 @@
 @use '../box/box.module' as box;
 
-@mixin placeholder-box-mixin {
-    @include box.box-mixin();
-    background: #fafafa;
-}
-
 .placeholderBox {
-    @include placeholder-box-mixin();
+    @include box.grey-box-mixin();
 }

--- a/libs/ui/src/lib/scroll-shadows/scroll-shadows.module.scss
+++ b/libs/ui/src/lib/scroll-shadows/scroll-shadows.module.scss
@@ -64,11 +64,11 @@
         opacity: 0.5;
     }
 
-    &.shadowTop .inner::before {
+    &.shadowTop .scroller::before {
         opacity: 0.5;
     }
 
-    &.shadowBottom .inner::after {
+    &.shadowBottom .scroller::after {
         opacity: 0.5;
     }
 }

--- a/libs/ui/src/lib/tag-list/index.tsx
+++ b/libs/ui/src/lib/tag-list/index.tsx
@@ -1,18 +1,36 @@
 import React from 'react';
 import cn from 'classnames';
+import { Tag } from '@digdir/designsystemet-react';
 import styles from './styles.module.scss';
 
-const TagList = ({ children, className, ...props }: React.HTMLAttributes<HTMLUListElement>) => {
+export type TagListProps = {
+    maxTags?: number;
+};
+
+const TagList = ({ children, className, maxTags, ...props }: TagListProps & React.HTMLAttributes<HTMLUListElement>) => {
+    const childArray = React.Children.toArray(children);
+    if (!childArray.length) return null;
     return (
         <ul
             className={cn(styles.tagList, className)}
             {...props}
         >
-            {React.Children.toArray(children)
+            {childArray
                 .filter((child) => Boolean(child))
+                .slice(0, maxTags ?? childArray.length)
                 .map((child, i) => (
                     <li key={i}>{child}</li>
                 ))}
+            {maxTags && maxTags < childArray.length && (
+                <li>
+                    <Tag
+                        size='sm'
+                        className={styles.tagsOmitted}
+                    >
+                        <span>+{childArray.length - maxTags}</span>
+                    </Tag>
+                </li>
+            )}
         </ul>
     );
 };

--- a/libs/ui/src/lib/tag-list/styles.module.scss
+++ b/libs/ui/src/lib/tag-list/styles.module.scss
@@ -9,4 +9,9 @@
     :global(.fds-tag) {
         min-height: 1.5rem;
     }
+
+    .tagsOmitted span {
+        font-size: 0.9em;
+        opacity: 0.7;
+    }
 }

--- a/libs/ui/src/lib/use-dataset-popover/index.tsx
+++ b/libs/ui/src/lib/use-dataset-popover/index.tsx
@@ -1,0 +1,149 @@
+import React, { useState, useEffect } from 'react';
+import { printLocaleValue } from '@fdk-frontend/utils';
+import { ArrowRightIcon } from '@navikt/aksel-icons';
+import Badge from '../badge';
+import PlaceholderBox from '../placeholder-box';
+import DownloadButton from '../download-button';
+import ActionButton from '../action-button';
+import { Tabs, TabList, Tab, TabContent } from '@digdir/designsystemet-react';
+import ApiTags from '../api-tags';
+import DistributionTags from '../distribution-tags';
+import ScrollShadows from '../scroll-shadows';
+import {
+    trackSiteImproveEvent,
+    EventCategory,
+    EventAction,
+    EventLabel,
+} from '@fdk-frontend/utils/siteimprove-analytics';
+import { type DatasetWithIdentifier, type DataService } from '@fdk-frontend/fdk-types';
+import { type Dictionary, type LocaleCodes } from '@fdk-frontend/dictionaries';
+import styles from './styles.module.scss';
+
+export type UseDatasetPopoverProps = {
+    dataset: DatasetWithIdentifier;
+    apis?: DataService[];
+    dictionary: Dictionary;
+    locale: LocaleCodes;
+};
+
+const UseDatasetPopover = ({
+    children,
+    dataset,
+    apis = [],
+    dictionary,
+    locale,
+    ...props
+}: UseDatasetPopoverProps & React.HTMLAttributes<HTMLDivElement>) => {
+    const distributions = [...(dataset.distribution ?? []), ...(dataset.sample ?? [])];
+    const defaultActiveTab = !distributions.length && apis.length ? 'apis' : 'dist';
+    const [activeTab, setActiveTab] = useState(defaultActiveTab);
+
+    useEffect(() => {
+        trackSiteImproveEvent({
+            category: EventCategory.DETAILS_PAGE,
+            action: EventAction.CLICK,
+            label: EventLabel.USE_DATASET_BUTTON,
+        });
+    }, []);
+
+    return (
+        <div
+            className={styles.wrapper}
+            {...props}
+        >
+            <Tabs
+                defaultValue='dist'
+                size='sm'
+                value={activeTab}
+                onChange={(value) => {
+                    setActiveTab(value);
+                }}
+            >
+                <TabList>
+                    <Tab value='dist'>
+                        {dictionary.useDatasetPopover.distributions}&nbsp;
+                        <Badge>{[...(dataset.distribution ?? []), ...(dataset.sample ?? [])].length}</Badge>
+                    </Tab>
+                    <Tab value='apis'>
+                        {dictionary.useDatasetPopover.apis}&nbsp;
+                        <Badge>{apis.length}</Badge>
+                    </Tab>
+                </TabList>
+                <TabContent value='dist'>
+                    {distributions.length ? (
+                        <ScrollShadows className={styles.popoverScroller}>
+                            <ul className='fdk-box-list'>
+                                {distributions.map((d, index) => (
+                                    <li key={`distribution-${index}`}>
+                                        <div className={styles.popoverListItem}>
+                                            <div className={styles.itemDetails}>
+                                                <span className={styles.itemTitle}>
+                                                    {printLocaleValue(locale, d.title) ||
+                                                        dictionary.distributions.header.nameless}
+                                                </span>
+                                                <DistributionTags
+                                                    distribution={d}
+                                                    dictionary={dictionary}
+                                                    maxTags={4}
+                                                />
+                                            </div>
+                                            <DownloadButton
+                                                uris={d.accessURL}
+                                                className={styles.actionButton}
+                                                modalTitle={
+                                                    printLocaleValue(locale, d.title) ||
+                                                    dictionary.distributions.header.nameless
+                                                }
+                                                dictionary={dictionary}
+                                                locale={locale}
+                                            >
+                                                {dictionary.distributions.header.downloadBtnLabel}
+                                            </DownloadButton>
+                                        </div>
+                                    </li>
+                                ))}
+                            </ul>
+                        </ScrollShadows>
+                    ) : (
+                        <PlaceholderBox>{dictionary.distributions.placeholder}</PlaceholderBox>
+                    )}
+                </TabContent>
+                <TabContent value='apis'>
+                    {apis.length ? (
+                        <ul className='fdk-box-list'>
+                            {apis.map((api, index) => (
+                                <li key={`api-${index}`}>
+                                    <div className={styles.popoverListItem}>
+                                        <div className={styles.itemDetails}>
+                                            <span className={styles.itemTitle}>
+                                                {printLocaleValue(locale, api.title) || dictionary.apis.header.nameless}
+                                            </span>
+                                            <ApiTags
+                                                api={api}
+                                                dictionary={dictionary}
+                                            />
+                                        </div>
+                                        <ActionButton
+                                            uri={`/data-services/${api.id}`}
+                                            className={styles.actionButton}
+                                        >
+                                            {dictionary.apis.header.gotoBtn}
+                                            <ArrowRightIcon
+                                                aria-hidden
+                                                fontSize='1.2em'
+                                            />
+                                        </ActionButton>
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
+                    ) : (
+                        <PlaceholderBox>{dictionary.apis.placeholder}</PlaceholderBox>
+                    )}
+                </TabContent>
+            </Tabs>
+        </div>
+    );
+};
+
+export default UseDatasetPopover;

--- a/libs/ui/src/lib/use-dataset-popover/styles.module.scss
+++ b/libs/ui/src/lib/use-dataset-popover/styles.module.scss
@@ -1,0 +1,63 @@
+@use '../box/box.module' as box;
+
+.wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: 350px;
+
+    @media (max-width: 400px) {
+        width: auto;
+    }
+
+    :global(.fds-tabs__tablist) {
+        margin: -0.5rem -0.75rem 0;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+
+        :global(.fds-tabs__tab) {
+            padding: 1rem 1.25rem;
+        }
+    }
+
+    :global(.fds-tabs__content) {
+        padding: 0.75rem 0 0.25rem 0;
+    }
+
+    .popoverScroller > div {
+        max-height: 50vh;
+    }
+
+    .popoverListItem {
+        @include box.grey-box-mixin();
+        display: grid;
+        grid-template-areas: 'a b';
+        grid-template-columns: auto min-content;
+        align-items: start;
+        gap: 1rem;
+
+        > :global(.fds-link),
+        > :global(.fds-btn) {
+            white-space: nowrap;
+        }
+
+        > ul {
+            margin-top: 0.25rem;
+        }
+    }
+
+    .itemDetails {
+        overflow: hidden;
+
+        ul {
+            margin-top: 0.5rem;
+        }
+    }
+
+    .itemTitle {
+        font-weight: 600;
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+}


### PR DESCRIPTION
Denne PR-en endrer funksjonen til "Bruk datasett"-knappen. Vi går bort ifra dagens funksjon hvor knappen switcher til distribusjoner-fanen og highlighter/blinker områdene med distribusjoner og api-er, og erstatter dette med en popover-meny med snarveier til distribusjoner og api-er:

<img width="1440" alt="Screenshot 2025-06-27 at 13 17 15" src="https://github.com/user-attachments/assets/43be4a00-5fb9-4713-af1a-e6e3461650e8" />

PR-en innebærer også en refaktorering hvor headeren på detalj-siden skilles ut som en egen komponent: `DatasetHeader`:

<img width="1079" alt="Screenshot 2025-06-27 at 13 30 40" src="https://github.com/user-attachments/assets/3e69d78d-c00d-4b4d-8614-96eb77c69157" />
