### PR TITLE
fix: removed DownloadIcon from modal close button

### DIFF
--- a/libs/ui/src/lib/download-button/index.tsx
+++ b/libs/ui/src/lib/download-button/index.tsx
@@ -102,10 +102,6 @@ const DownloadButton = ({
                         variant='secondary'
                         onClick={() => modalRef.current?.close()}
                     >
-                        <DownloadIcon
-                            aria-hidden
-                            fontSize='1.2em'
-                        />
                         {dictionary.distributions.downloadModal.closeBtn}
                     </Button>
                 </Modal.Footer>


### PR DESCRIPTION
<img width="763" alt="Screenshot 2025-07-03 at 12 54 24" src="https://github.com/user-attachments/assets/54e90c3b-2e5c-4188-93c2-fc7e5a15b6d4" />
