### PR TITLE
Chore: Remove org from carousel Update organizations.json

### DIFF
--- a/apps/data-norge/src/app/components/frontpage/organization-carousel/organizations.json
+++ b/apps/data-norge/src/app/components/frontpage/organization-carousel/organizations.json
@@ -31,6 +31,5 @@
     "Statens vegvesen",
     "Statistisk sentralbyrå",
     "Stavanger kommune",
-    "Tolletaten",
-    "Utdanningsdirektoratet"
+    "Tolletaten"
 ]


### PR DESCRIPTION
Removes Utdanningsdirektoratet from the carousel, as they have removed datasets and are now below 10 dataset descriptions.