### PR TITLE
Task: Add two orgs to organizations.json

### DIFF
--- a/apps/data-norge/src/app/components/frontpage/organization-carousel/organizations.json
+++ b/apps/data-norge/src/app/components/frontpage/organization-carousel/organizations.json
@@ -13,6 +13,7 @@
     "Høgskulen på Vestlandet",
     "Kystverket",
     "Landbruksdirektoratet",
+    "Lillestrøm kommune",
     "Mattilsynet",
     "Meteorologisk institutt",
     "Miljødirektoratet",
@@ -24,12 +25,13 @@
     "Oslo kommune",
     "Registerenheten i Brønnøysund",
     "Riksantikvaren",
-    "Sokkeldirektoratet",
     "Skatteetaten",
+    "Sokkeldirektoratet",
     "Statens kartverk",
     "Statens lånekasse for utdanning",
     "Statens vegvesen",
     "Statistisk sentralbyrå",
     "Stavanger kommune",
-    "Tolletaten"
+    "Tolletaten",
+    "Utdanningsdirektoratet"
 ]


### PR DESCRIPTION
Utdanningsdirektoratet and Lillestrøm kommune has published 10 or more datasets. This task adds them to the carousel on the front page of data.norge.no. 

Also changed Sokkeldirektoratet's place in the list, to make the list alphabetical.