### PR TITLE
feat: uid with copyButton to dataset details

### DIFF
--- a/apps/data-norge/src/app/components/details-page/details-tab/components/general-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/general-details/index.tsx
@@ -167,7 +167,7 @@ const GeneralDetails = ({ dataset, locale, dictionary, metadataScore }: DatasetD
                 </dd>
                 <dt>UID:</dt>
                 <dd>
-                    <HStack>
+                    <Hstack>
                         {dataset.id}
                         <CopyButton
                             copyLabel={dictionary.details.general.copyButton[0]}
@@ -177,7 +177,7 @@ const GeneralDetails = ({ dataset, locale, dictionary, metadataScore }: DatasetD
                                 style: { margin: '-0.25rem 0' }
                             }}
                         />
-                    </HStack>
+                    </Hstack>
                 </dd>
             </Dlist>
         </section>

--- a/apps/data-norge/src/app/components/details-page/details-tab/components/general-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/general-details/index.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import { Heading, Link, Tag, type TagProps, HelpText, Paragraph } from '@digdir/designsystemet-react';
-import { Hstack, PlaceholderText, ExternalLink, SmartList, Dlist } from '@fdk-frontend/ui';
+import { Hstack, PlaceholderText, ExternalLink, SmartList, Dlist, CopyButton } from '@fdk-frontend/ui';
 import { calculateMetadataScore, printLocaleValue } from '@fdk-frontend/utils';
 import { type DatasetType } from '@fellesdatakatalog/types';
 import { DatasetDetailsProps, DatasetDetailsTabContext } from '../../';
@@ -164,6 +164,20 @@ const GeneralDetails = ({ dataset, locale, dictionary, metadataScore }: DatasetD
                     >
                         {metadataQuality.label}
                     </Tag>
+                </dd>
+                <dt>UID:</dt>
+                <dd>
+                    <HStack>
+                        {dataset.id}
+                        <CopyButton
+                            copyLabel={dictionary.details.general.copyButton[0]}
+                            copiedLabel={dictionary.details.general.copyButton[1]}
+                            copyOnClick={dataset.id}
+                            buttonProps={{
+                                style: { margin: '-0.25rem 0' }
+                            }}
+                        />
+                    </HStack>
                 </dd>
             </Dlist>
         </section>

--- a/libs/dictionaries/src/lib/dictionaries/en/details-page.json
+++ b/libs/dictionaries/src/lib/dictionaries/en/details-page.json
@@ -121,7 +121,8 @@
                     "sufficient": "Sufficient",
                     "poor": "Poor"
                 }
-            }
+            },
+            "copyButton": ["Copy", "Copied!"]
         },
         "contactPoint": {
             "title": "Contact information",

--- a/libs/dictionaries/src/lib/dictionaries/nb/details-page.json
+++ b/libs/dictionaries/src/lib/dictionaries/nb/details-page.json
@@ -121,7 +121,8 @@
                     "sufficient": "Tilstrekkelig",
                     "poor": "Dårlig"
                 }
-            }
+            },
+            "copyButton": ["Kopier", "Kopiert!"]
         },
         "contactPoint": {
             "title": "Kontaktinformasjon",

--- a/libs/dictionaries/src/lib/dictionaries/nn/details-page.json
+++ b/libs/dictionaries/src/lib/dictionaries/nn/details-page.json
@@ -121,7 +121,8 @@
                     "sufficient": "Tilstrekkeleg",
                     "poor": "Dårleg"
                 }
-            }
+            },
+            "copyButton": ["Kopier", "Kopiert!"]
         },
         "contactPoint": {
             "title": "Kontaktinformasjon",


### PR DESCRIPTION
Legger til UID på detaljsiden for datasett:

<img width="1063" height="478" alt="Screenshot 2025-08-14 at 10 26 34" src="https://github.com/user-attachments/assets/7d05e395-cdfa-4ddd-8465-06445a7d4a93" />

Resolves https://github.com/Informasjonsforvaltning/behov/issues/856
