### PR TITLE
chore: change openapi link for search-api in docs

### DIFF
--- a/apps/data-norge/public/content/technical/api/search/search.en.mdx
+++ b/apps/data-norge/public/content/technical/api/search/search.en.mdx
@@ -25,7 +25,7 @@ description: The search endpoint allows you to search data.norge.no using Elasti
 
 ## Documentation
 
-[OpenAPI-specification for the search endpoint (Github)](https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-search-service/main/openapi.yaml)
+[OpenAPI-specification for the search endpoint (Github)](https://search.api.fellesdatakatalog.digdir.no/swagger-ui/index.html)
 
 ## Design queries
 

--- a/apps/data-norge/public/content/technical/api/search/search.nb.mdx
+++ b/apps/data-norge/public/content/technical/api/search/search.nb.mdx
@@ -25,7 +25,7 @@ description: Søkeendepunktet lar deg søke i data på data.norge.no med Elastic
 
 ## Dokumentasjon
 
-[OpenAPI-spesifikasjon for søkeendepunktet (Github)](https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-search-service/main/openapi.yaml)
+[OpenAPI-spesifikasjon for søkeendepunktet (Github)](https://search.api.fellesdatakatalog.digdir.no/swagger-ui/index.html)
 
 ## Utforming av spørringer
 

--- a/apps/data-norge/public/content/technical/api/search/search.nn.mdx
+++ b/apps/data-norge/public/content/technical/api/search/search.nn.mdx
@@ -25,7 +25,7 @@ description: Søkeendepunktet lar deg søke på data.norge.no med Elastic search
 
 ## Dokumentasjon
 
-[OpenAPI-spesifikasjon for søkeendepunktet (Github)](https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-search-service/main/openapi.yaml)
+[OpenAPI-spesifikasjon for søkeendepunktet (Github)](https://search.api.fellesdatakatalog.digdir.no/swagger-ui/index.html)
 
 ## Utforming av spørjingar
 


### PR DESCRIPTION
Gammel fil ble fjerna av [PR 229](https://github.com/Informasjonsforvaltning/fdk-search-service/pull/229)