### PR TITLE
add losThemes on service page

### DIFF
--- a/apps/data-norge/src/app/components/details-page/service/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/service/index.tsx
@@ -435,33 +435,17 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
                             </dd>
                         </Dlist>
 
-                        {!service.euDataThemes?.length &&
-                        !service.eurovocThemes?.length &&
-                        !service.losThemes?.length &&
-                        !showEmptyRows ? null : (
+                        {!service.eurovocThemes?.length && !service.losThemes?.length && !showEmptyRows ? null : (
                             <>
                                 <Heading
                                     level={2}
                                     data-size='xs'
                                     className={styles.heading}
                                 >
-                                    {dictionaries.detailsPage.details.themes}
+                                    {dictionaries.detailsPage.details.thematicArea}
                                 </Heading>
-                                {service.euDataThemes?.length ||
-                                service.eurovocThemes?.length ||
-                                service.losThemes?.length ? (
+                                {service.eurovocThemes?.length || service.losThemes?.length ? (
                                     <TagList>
-                                        {service.euDataThemes?.map((theme) => (
-                                            <Link
-                                                key={theme.code}
-                                                href={`/public-services-and-events?euDataTheme=${theme.code}`}
-                                            >
-                                                <Tag data-size='sm'>
-                                                    {printLocaleValue(locale, theme.title) || theme.code}
-                                                </Tag>
-                                            </Link>
-                                        ))}
-
                                         {service.eurovocThemes?.map((theme) => (
                                             <Link
                                                 key={theme.code}

--- a/libs/dictionaries/src/lib/dictionaries/en/details-page.json
+++ b/libs/dictionaries/src/lib/dictionaries/en/details-page.json
@@ -214,6 +214,7 @@
             }
         },
         "themes": "Themes",
+        "thematicArea": "Thematic area",
         "keywords": "Keywords"
     },
     "community": {

--- a/libs/dictionaries/src/lib/dictionaries/nb/details-page.json
+++ b/libs/dictionaries/src/lib/dictionaries/nb/details-page.json
@@ -214,6 +214,7 @@
             }
         },
         "themes": "Tema",
+        "thematicArea": "Temaområde",
         "keywords": "Søkord"
     },
     "community": {

--- a/libs/dictionaries/src/lib/dictionaries/nn/details-page.json
+++ b/libs/dictionaries/src/lib/dictionaries/nn/details-page.json
@@ -214,6 +214,7 @@
             }
         },
         "themes": "Tema",
+        "thematicArea": "Temaområde",
         "keywords": "Nøkkelord"
     },
     "community": {


### PR DESCRIPTION
Test her: https://staging.fellesdatakatalog.digdir.no/nb/services/d7f359d6-908f-3e45-a5db-af6d5579b8ab/parkeringstillatelse-for-forflytningshemmede?tab=details

Legger til seksjon "Tema" under "Detaljer" på detaljside for tjeneste. 

Disse lenker til f.eks https://data.norge.no/public-services-and-events?losTheme=parkering-og-hvileplasser

<img width="278" height="122" alt="Screenshot 2025-11-27 at 13 58 08" src="https://github.com/user-attachments/assets/a26ab205-e3e8-4c9d-925a-b299cfdd04da" />

<img width="292" height="156" alt="Screenshot 2025-11-27 at 13 58 46" src="https://github.com/user-attachments/assets/f85f311d-8749-4de9-95e5-5140246872f6" />
