### PR TITLE
chore: ignore next-env.d.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ Thumbs.db
 .vercel
 .next
 out
+next-env.d.ts
 
 # local env files
 .env*

--- a/apps/data-norge/next-env.d.ts
+++ b/apps/data-norge/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./../../dist/apps/data-norge/.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Som anbefalt ifølge docs: https://nextjs.org/docs/app/api-reference/config/typescript#next-envdts