### PR TITLE
chore: fix security vulnerabilities and cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
-        "eslint-plugin-playwright": "^2.7.1",
+        "eslint-plugin-playwright": "^2.9.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-storybook": "10.2.13",
         "identity-obj-proxy": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9838,14 +9838,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-playwright@npm:^2.7.1":
-  version: 2.7.1
-  resolution: "eslint-plugin-playwright@npm:2.7.1"
+"eslint-plugin-playwright@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "eslint-plugin-playwright@npm:2.9.0"
   dependencies:
     globals: "npm:^17.3.0"
   peerDependencies:
     eslint: ">=8.40.0"
-  checksum: 10c0/efd45122b4d4e77608862f0f25a95200a0e367abbe6d53bdce38c59009c4b90edcf12b6f1c2b50e86b0addea56c68ad0c7767768b0a2a73d7f09a814b827df72
+  checksum: 10c0/8f5528547c7d731b9ff4afad7a8b98ede86d93342842be9f06a5428358180c17f7b7624e4dcaae331f211345bcecf9f3cc48f8a995549f30dfd633b8300e5a08
   languageName: node
   linkType: hard
 
@@ -10425,7 +10425,7 @@ __metadata:
     eslint-config-prettier: "npm:^10.1.8"
     eslint-plugin-import: "npm:^2.32.0"
     eslint-plugin-jsx-a11y: "npm:^6.10.2"
-    eslint-plugin-playwright: "npm:^2.7.1"
+    eslint-plugin-playwright: "npm:^2.9.0"
     eslint-plugin-react: "npm:^7.37.5"
     eslint-plugin-storybook: "npm:10.2.13"
     framer-motion: "npm:^12.29.2"


### PR DESCRIPTION
# Summary

- Bump `koa` resolution to `^3.1.2` to fix Host Header Injection (GHSA-7gcc-r8m5-44qm)
- Bump `minimatch` v10 resolution to `^10.2.3` to fix ReDoS (GHSA-7r86-cg39-jmmj, GHSA-23c5-xmqv-rm74)
- Remove unused `lint-staged` dependency (no git hook runner configured)
- Bump `@swc/core` to `^1.15.18`