### PR TITLE
feat: add version field and white dlist bg

### DIFF
--- a/apps/data-norge/src/app/components/details-page/data-service/data-service-details-tab.tsx
+++ b/apps/data-norge/src/app/components/details-page/data-service/data-service-details-tab.tsx
@@ -184,6 +184,16 @@ export default function DataServiceDetailsTab({ resource, locale, dictionary }: 
                             </dd>
                         </>
                     )}
+                    {!resource.version && !showEmptyRows ? null : (
+                        <>
+                            <dt>{dictionary.details.general.version}:</dt>
+                            <dd>
+                                {resource.version || (
+                                    <PlaceholderText>{dictionary.details.noData}</PlaceholderText>
+                                )}
+                            </dd>
+                        </>
+                    )}
                     {!resource.landingPage?.length && !showEmptyRows ? null : (
                         <>
                             <dt>{dictionary.details.general.landingPage}:</dt>

--- a/apps/data-norge/src/app/components/details-page/data-service/data-service-overview-tab.tsx
+++ b/apps/data-norge/src/app/components/details-page/data-service/data-service-overview-tab.tsx
@@ -50,7 +50,7 @@ export default function DataServiceOverviewTab({ resource, locale, dictionary }:
                     >
                         Ta i bruk API-et
                     </Heading>
-                    <Dlist>
+                    <Dlist className={styles.dlistWhiteBg}>
                         {hasEndpointURL && (
                             <>
                                 <dt>{dictionary.details.general.endpointURL}:</dt>

--- a/apps/data-norge/src/app/components/details-page/details-page.module.scss
+++ b/apps/data-norge/src/app/components/details-page/details-page.module.scss
@@ -117,3 +117,9 @@
         max-width: 400px; /* Adjust as needed */
     }
 }
+
+.dlistWhiteBg {
+    dl {
+        background: white;
+    }
+}

--- a/libs/localization/src/lib/locales/en/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/en/sections/details-page.ts
@@ -130,6 +130,7 @@ const detailsPage = {
       endpointURL: "Endpoint URL",
       endpointDescription: "Endpoint description",
       format: "Format",
+      version: "Version",
       servesDataset: "Datasets served by this API",
       openAccess: "Open access",
       openLicense: "Open license",

--- a/libs/localization/src/lib/locales/nb/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/nb/sections/details-page.ts
@@ -134,6 +134,7 @@ const detailsPage = {
             endpointURL: 'Endepunkt-URL',
             endpointDescription: 'Endepunktbeskrivelse',
             format: 'Format',
+            version: 'Versjon',
             servesDataset: 'Datasett som dette API-et tilgjengeliggjør',
             openAccess: 'Åpen tilgang',
             openLicense: 'Åpen lisens',

--- a/libs/localization/src/lib/locales/nn/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/nn/sections/details-page.ts
@@ -134,6 +134,7 @@ const detailsPage = {
             endpointURL: 'Endepunkt-URL',
             endpointDescription: 'Endepunktskildring',
             format: 'Format',
+            version: 'Versjon',
             servesDataset: 'Datasett som dette API-et tilgjengeleggjer',
             openAccess: 'Open tilgang',
             openLicense: 'Open lisens',

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "@digdir/designsystemet-css": "^1.11.1",
         "@digdir/designsystemet-react": "^1.11.1",
         "@digdir/designsystemet-theme": "^1.11.0",
-        "@fellesdatakatalog/types": "^1.0.15",
+        "@fellesdatakatalog/types": "^1.0.16",
         "@fellesdatakatalog/ui": "^1.0.19",
         "@mdx-js/loader": "^3.1.1",
         "@mdx-js/react": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1998,12 +1998,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fellesdatakatalog/types@npm:^1.0.15":
-  version: 1.0.15
-  resolution: "@fellesdatakatalog/types@npm:1.0.15"
+"@fellesdatakatalog/types@npm:^1.0.16":
+  version: 1.0.16
+  resolution: "@fellesdatakatalog/types@npm:1.0.16"
   dependencies:
     typescript: "npm:^5.9.3"
-  checksum: 10c0/fc8eb2c004745c011a3e7f3a5384c3ee1a57ab40e7d80b2c528a0b606cf047e74c8fee344d7d6d9c1d824728f423607ba60bdf5ca791f0b12c64971e08f0fef2
+  checksum: 10c0/19e7507268427cc3470f84a3b05fb677ce148f853ff3ed2d61c4e0b48de55b2ed3483ce2529754dff130b2ba8135e6688ba5f44aba32b5c1a3427b8e54c5afe3
   languageName: node
   linkType: hard
 
@@ -10615,7 +10615,7 @@ __metadata:
     "@digdir/designsystemet-react": "npm:^1.11.1"
     "@digdir/designsystemet-theme": "npm:^1.11.0"
     "@eslint/js": "npm:^9.39.2"
-    "@fellesdatakatalog/types": "npm:^1.0.15"
+    "@fellesdatakatalog/types": "npm:^1.0.16"
     "@fellesdatakatalog/ui": "npm:^1.0.19"
     "@mdx-js/loader": "npm:^3.1.1"
     "@mdx-js/react": "npm:^3.1.1"


### PR DESCRIPTION
# Summary fixes #770

- Add `version` field to data-service details tab, removing @ts-expect-error now that @fellesdatakatalog/types@1.0.16 includes the type
- White background for Dlist in "Ta i bruk API-et" section on overview tab
- Add `version` localization strings (nb, nn, en)
- Bump @fellesdatakatalog/types to 1.0.16