### PR TITLE
feat: add keyword row to data service details

### DIFF
--- a/apps/data-norge/src/app/components/details-page/data-service/data-service-details-tab.tsx
+++ b/apps/data-norge/src/app/components/details-page/data-service/data-service-details-tab.tsx
@@ -261,6 +261,29 @@ export default function DataServiceDetailsTab({ resource, locale, dictionary }: 
                             </dd>
                         </>
                     )}
+                    {!resource.keyword?.length && !showEmptyRows ? null : (
+                        <>
+                            <dt>{dictionary.details.general.keyword}:</dt>
+                            <dd>
+                                {resource.keyword?.filter((keyword) => keyword[locale]).length ? (
+                                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+                                        {resource.keyword
+                                            .filter((keyword) => keyword[locale])
+                                            .map((keyword, i) => (
+                                                <Tag
+                                                    key={`keyword-${i}`}
+                                                    data-size='sm'
+                                                >
+                                                    {keyword[locale]}
+                                                </Tag>
+                                            ))}
+                                    </div>
+                                ) : (
+                                    <PlaceholderText>{dictionary.details.noData}</PlaceholderText>
+                                )}
+                            </dd>
+                        </>
+                    )}
                     <dt>{dictionary.details.general.firstHarvested}:</dt>
                     <dd>
                         {resource.harvest?.firstHarvested ? (

--- a/libs/localization/src/lib/locales/en/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/en/sections/details-page.ts
@@ -131,6 +131,7 @@ const detailsPage = {
       endpointDescription: "Endpoint description",
       format: "Format",
       version: "Version",
+      keyword: "Keywords",
       servesDataset: "Datasets served by this API",
       openAccess: "Open access",
       openLicense: "Open license",

--- a/libs/localization/src/lib/locales/nb/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/nb/sections/details-page.ts
@@ -135,6 +135,7 @@ const detailsPage = {
             endpointDescription: 'Endepunktbeskrivelse',
             format: 'Format',
             version: 'Versjon',
+            keyword: 'Emneord',
             servesDataset: 'Datasett som dette API-et tilgjengeliggjør',
             openAccess: 'Åpen tilgang',
             openLicense: 'Åpen lisens',

--- a/libs/localization/src/lib/locales/nn/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/nn/sections/details-page.ts
@@ -135,6 +135,7 @@ const detailsPage = {
             endpointDescription: 'Endepunktskildring',
             format: 'Format',
             version: 'Versjon',
+            keyword: 'Emneord',
             servesDataset: 'Datasett som dette API-et tilgjengeleggjer',
             openAccess: 'Open tilgang',
             openLicense: 'Open lisens',


### PR DESCRIPTION
# Summary fixes #774

- Add "Emneord" / "Keywords" row to "Om API-et" section on API details page
- Keywords render as tags, hidden when empty and "hide empty rows" is active
- Add `keyword` translation key to nb, nn, and en locales