### PR TITLE
style: add gap between data service section items

### DIFF
--- a/apps/data-norge/src/app/components/details-page/data-service/data-service.module.scss
+++ b/apps/data-norge/src/app/components/details-page/data-service/data-service.module.scss
@@ -2,12 +2,12 @@
     position: relative;
 
     > section {
+        display: flex;
+        flex-direction: column;
+        gap: var(--ds-size-4);
+
         &:not(:last-child) {
             margin-bottom: 2rem;
-        }
-
-        > :global(.ds-heading) {
-            margin-bottom: 1em;
         }
     }
 


### PR DESCRIPTION
# Summary

- Use flex column layout with `gap: var(--ds-size-4)` on data service sections
- Adds vertical spacing between multiple Dlist items (e.g. costs, contact info)