### PR TITLE
chore: add resolutions for security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
         "minimatch@^3.1.2": "^3.1.3",
         "minimatch@^5.0.1": "^5.1.7",
         "minimatch@^9.0.4": "^9.0.6",
-        "minimatch@^9.0.5": "^9.0.6"
+        "minimatch@^9.0.5": "^9.0.6",
+        "flatted": "^3.4.2",
+        "undici": "^6.24.1",
+        "dompurify": "^3.3.2"
     },
     "packageManager": "yarn@4.11.0",
     "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9142,15 +9142,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.2.4":
-  version: 3.3.0
-  resolution: "dompurify@npm:3.3.0"
+"dompurify@npm:^3.3.2":
+  version: 3.3.3
+  resolution: "dompurify@npm:3.3.3"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/66b1787b0bc8250d8f58e13284cf7f5f6bb400a0a55515e7a2a030316a4bb0d8306fdb669c17ed86ed58ff7e53c62b5da4488c2f261d11c58870fe01b8fcc486
+  checksum: 10c0/097c14a21a3f6cb95beded9ecd255f7c3512c42767b048390c747b0fe35736f6a71e02320fc50a9ac2be645834b463e4760915d595d502a56452daf339d0ea9c
   languageName: node
   linkType: hard
 
@@ -10603,10 +10603,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flatted@npm:^3.2.7, flatted@npm:^3.2.9":
-  version: 3.3.3
-  resolution: "flatted@npm:3.3.3"
-  checksum: 10c0/e957a1c6b0254aa15b8cce8533e24165abd98fadc98575db082b786b5da1b7d72062b81bfdcd1da2f4d46b6ed93bec2434e62333e9b4261d79ef2e75a10dd538
+"flatted@npm:^3.4.2":
+  version: 3.4.2
+  resolution: "flatted@npm:3.4.2"
+  checksum: 10c0/a65b67aae7172d6cdf63691be7de6c5cd5adbdfdfe2e9da1a09b617c9512ed794037741ee53d93114276bff3f93cd3b0d97d54f9b316e1e4885dde6e9ffdf7ed
   languageName: node
   linkType: hard
 
@@ -18976,10 +18976,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^6.23.0":
-  version: 6.23.0
-  resolution: "undici@npm:6.23.0"
-  checksum: 10c0/d846b3fdfd05aa6081ba1eab5db6bbc21b283042c7a43722b86d1ee2bf749d7c990ceac0c809f9a07ffd88b1b0f4c0f548a8362c035088cb1997d63abdda499c
+"undici@npm:^6.24.1":
+  version: 6.24.1
+  resolution: "undici@npm:6.24.1"
+  checksum: 10c0/53fdbaa357139a2c12deed34f67d67fc6ad269630ba85a1507e7717f53ad2d3a02c95fbd17d3ab321e34c60b6f0a716cdc2f7e2eca1e07178702dc89cc3a73c4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
  - Add yarn resolution for `flatted@^3.4.2` to fix Prototype Pollution and DoS vulnerabilities (GHSA-rf6f-7fwh-wjgh, GHSA-25h7-pfq9-p65f)
  - Add yarn resolution for `undici@^6.24.1` to fix WebSocket crashes, HTTP smuggling, and CRLF injection (4 advisories)                                                                                                      
  - Add yarn resolution for `dompurify@^3.3.2` to fix XSS vulnerability in `@zazuko/yasgui` (GHSA-v2wj-7wpq-c8vv)       
                                                                                                                    