### PR TITLE
feat: move serves-dataset section to overview tab

### DIFF
--- a/apps/data-norge/src/app/components/details-page/data-service/data-service-details-tab.tsx
+++ b/apps/data-norge/src/app/components/details-page/data-service/data-service-details-tab.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { type Localization, type LocaleCodes } from '@fdk-frontend/localization';
-import { type DataService, type SearchObject } from '@fellesdatakatalog/types';
+import { type DataService } from '@fellesdatakatalog/types';
 import { printLocaleValue } from '@fdk-frontend/utils';
 import {
     PlaceholderText,
@@ -23,14 +23,12 @@ type DataServiceDetailsTabProps = {
     resource: DataService;
     locale: LocaleCodes;
     dictionary: Localization;
-    resolvedDatasets?: SearchObject[];
 };
 
 export default function DataServiceDetailsTab({
     resource,
     locale,
     dictionary,
-    resolvedDatasets = [],
 }: DataServiceDetailsTabProps) {
     const [showEmptyRows, setShowEmptyRows] = useState<boolean>(true);
 
@@ -378,45 +376,6 @@ export default function DataServiceDetailsTab({
                                 )}
                             </Dlist>
                         ))
-                    ) : (
-                        <PlaceholderBox>{dictionary.details.noData}</PlaceholderBox>
-                    )}
-                </section>
-            )}
-
-            {!resource.servesDataset?.length && !showEmptyRows ? null : (
-                <section>
-                    <Heading
-                        level={2}
-                        data-size='xs'
-                    >
-                        {dictionary.details.general.servesDataset}
-                    </Heading>
-                    {resource.servesDataset && resource.servesDataset.length > 0 ? (
-                        resource.servesDataset.map((datasetUri, index) => {
-                            const resolvedDataset = resolvedDatasets.find((dataset) => dataset.uri === datasetUri);
-
-                            return (
-                                <Dlist key={index}>
-                                    <dt>{dictionary.details.general.servesDatasetLabel}:</dt>
-                                    <dd>
-                                        {resolvedDataset ? (
-                                            <Link href={`/datasets/${resolvedDataset.id}`}>
-                                                {printLocaleValue(locale, resolvedDataset.title) || resolvedDataset.uri}
-                                            </Link>
-                                        ) : (
-                                            <ExternalLink
-                                                href={datasetUri}
-                                                locale={locale}
-                                                gateway
-                                            >
-                                                {datasetUri}
-                                            </ExternalLink>
-                                        )}
-                                    </dd>
-                                </Dlist>
-                            );
-                        })
                     ) : (
                         <PlaceholderBox>{dictionary.details.noData}</PlaceholderBox>
                     )}

--- a/apps/data-norge/src/app/components/details-page/data-service/data-service-overview-tab.tsx
+++ b/apps/data-norge/src/app/components/details-page/data-service/data-service-overview-tab.tsx
@@ -1,7 +1,7 @@
 import { type Localization, type LocaleCodes } from '@fdk-frontend/localization';
-import { type DataService } from '@fellesdatakatalog/types';
+import { type DataService, type SearchObject } from '@fellesdatakatalog/types';
 import { printLocaleValue } from '@fdk-frontend/utils';
-import { Markdown, Article, PlaceholderBox, noHeadings, Dlist, SmartList, ExternalLink } from '@fdk-frontend/ui';
+import { Markdown, Article, PlaceholderBox, noHeadings, Dlist, SmartList, ExternalLink, ScrollShadows, DatasetTable } from '@fdk-frontend/ui';
 import { Heading, Card } from '@digdir/designsystemet-react';
 import styles from '../details-page.module.scss';
 
@@ -9,9 +9,10 @@ type DataServiceOverviewTabProps = {
     resource: DataService;
     locale: LocaleCodes;
     dictionary: Localization;
+    resolvedDatasets?: SearchObject[];
 };
 
-export default function DataServiceOverviewTab({ resource, locale, dictionary }: DataServiceOverviewTabProps) {
+export default function DataServiceOverviewTab({ resource, locale, dictionary, resolvedDatasets = [] }: DataServiceOverviewTabProps) {
     const hasEndpointURL = !!resource.endpointURL?.length;
     const hasEndpointDescription = !!resource.endpointDescription?.length;
     const hasEndpointData = hasEndpointURL || hasEndpointDescription;
@@ -90,6 +91,23 @@ export default function DataServiceOverviewTab({ resource, locale, dictionary }:
                             </>
                         )}
                     </Dlist>
+                </section>
+            )}
+            {resolvedDatasets.length > 0 && (
+                <section className={styles.section}>
+                    <Heading
+                        level={2}
+                        data-size='xs'
+                    >
+                        {dictionary.overview.servesDataset.title}
+                    </Heading>
+                    <ScrollShadows className={styles.tableScroller}>
+                        <DatasetTable
+                            datasets={resolvedDatasets}
+                            locale={locale}
+                            dictionary={dictionary}
+                        />
+                    </ScrollShadows>
                 </section>
             )}
         </>

--- a/apps/data-norge/src/app/components/details-page/data-service/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/data-service/index.tsx
@@ -148,6 +148,7 @@ export default function DataServiceDetailsPage({
                             resource={resource}
                             locale={locale}
                             dictionary={dictionaries.detailsPage}
+                            resolvedDatasets={resolvedDatasets}
                         />
                     </TabsPanel>
                     <TabsPanel
@@ -158,7 +159,6 @@ export default function DataServiceDetailsPage({
                             resource={resource}
                             locale={locale}
                             dictionary={dictionaries.detailsPage}
-                            resolvedDatasets={resolvedDatasets}
                         />
                     </TabsPanel>
                     <TabsPanel

--- a/libs/localization/src/lib/locales/en/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/en/sections/details-page.ts
@@ -61,6 +61,9 @@ const detailsPage = {
     description: {
       title: "Description",
       placeholder: "This dataset has no description"
+    },
+    servesDataset: {
+      title: "Serves datasets"
     }
   },
   distributions: {
@@ -137,8 +140,6 @@ const detailsPage = {
       format: "Format",
       version: "Version",
       license: "License",
-      servesDataset: "Datasets served by this API",
-      servesDatasetLabel: "Title",
       openAccess: "Open access",
       openLicense: "Open license",
       free: "Free of charge",

--- a/libs/localization/src/lib/locales/nb/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/nb/sections/details-page.ts
@@ -65,6 +65,9 @@ const detailsPage = {
             title: 'Beskrivelse',
             placeholder: 'Dette datasettet har ingen beskrivelse',
         },
+        servesDataset: {
+            title: 'Tilgjengeliggjør datasett',
+        },
     },
     distributions: {
         title: 'Distribusjoner',
@@ -141,8 +144,6 @@ const detailsPage = {
             format: 'Format',
             version: 'Versjon',
             license: 'Lisens',
-            servesDataset: 'Datasett som dette API-et tilgjengeliggjør',
-            servesDatasetLabel: 'Tittel',
             openAccess: 'Åpen tilgang',
             openLicense: 'Åpen lisens',
             free: 'Gratis',

--- a/libs/localization/src/lib/locales/nn/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/nn/sections/details-page.ts
@@ -65,6 +65,9 @@ const detailsPage = {
             title: 'Skildring',
             placeholder: 'Dette datasettet har inga skildring',
         },
+        servesDataset: {
+            title: 'Tilgjengeleggjer datasett',
+        },
     },
     distributions: {
         title: 'Distribusjonar',
@@ -141,8 +144,6 @@ const detailsPage = {
             format: 'Format',
             version: 'Versjon',
             license: 'Lisens',
-            servesDataset: 'Datasett som dette API-et tilgjengeleggjer',
-            servesDatasetLabel: 'Tittel',
             openAccess: 'Open tilgang',
             openLicense: 'Open lisens',
             free: 'Gratis',

--- a/libs/ui/src/lib/dataset-table/dataset-table.module.scss
+++ b/libs/ui/src/lib/dataset-table/dataset-table.module.scss
@@ -10,5 +10,6 @@
 
     td {
         white-space: nowrap;
+        padding: 1rem 1.5rem;
     }
 }


### PR DESCRIPTION
# Summary fixes #797

- Move "Tilgjengeliggjør datasett" section from details tab to overview tab on API pages
- Rename section from "Datasett som dette API-et tilgjengeliggjør" to "Tilgjengeliggjør datasett"
- Redesign as a table using existing `DatasetTable` component (dataset link, org name, access level badge)
- Update localization keys for nb, nn, and en
- Add more spacing to dataset table cells

### UX
<img width="1036" height="324" alt="Screenshot 2026-03-24 at 13 06 01" src="https://github.com/user-attachments/assets/e02fee42-1afe-498c-ab91-129cd66b9699" />
