### PR TITLE
feat: move endpoint rows to overview tab

### DIFF
--- a/apps/data-norge/src/app/components/details-page/data-service/data-service-details-tab.tsx
+++ b/apps/data-norge/src/app/components/details-page/data-service/data-service-details-tab.tsx
@@ -12,7 +12,6 @@ import {
     Hstack,
     InputWithCopyButton,
     SmartList,
-    TagList,
     LicenseBoxLink,
 } from '@fdk-frontend/ui';
 import { Heading, Tag, Link, Button } from '@digdir/designsystemet-react';
@@ -143,52 +142,6 @@ export default function DataServiceDetailsTab({
                             )
                         )}
                     </dd>
-                    {!resource.endpointURL?.length && !showEmptyRows ? null : (
-                        <>
-                            <dt>{dictionary.details.general.endpointURL}:</dt>
-                            <dd>
-                                {resource.endpointURL?.length ? (
-                                    <SmartList
-                                        items={resource.endpointURL}
-                                        renderItem={(url) => (
-                                            <ExternalLink
-                                                href={url}
-                                                locale={locale}
-                                                gateway
-                                            >
-                                                {url}
-                                            </ExternalLink>
-                                        )}
-                                    />
-                                ) : (
-                                    <PlaceholderText>{dictionary.details.noData}</PlaceholderText>
-                                )}
-                            </dd>
-                        </>
-                    )}
-                    {!resource.endpointDescription?.length && !showEmptyRows ? null : (
-                        <>
-                            <dt>{dictionary.details.general.endpointDescription}:</dt>
-                            <dd>
-                                {resource.endpointDescription?.length ? (
-                                    <SmartList
-                                        items={resource.endpointDescription}
-                                        renderItem={(url) => (
-                                            <ExternalLink
-                                                href={url}
-                                                locale={locale}
-                                                gateway
-                                            >
-                                                {url}
-                                            </ExternalLink>
-                                        )}
-                                    />
-                                ) : (
-                                    <PlaceholderText>{dictionary.details.noData}</PlaceholderText>
-                                )}
-                            </dd>
-                        </>
-                    )}
                     {!resource.version && !showEmptyRows ? null : (
                         <>
                             <dt>{dictionary.details.general.version}:</dt>
@@ -214,50 +167,6 @@ export default function DataServiceDetailsTab({
                                             </ExternalLink>
                                         )}
                                     />
-                                ) : (
-                                    <PlaceholderText>{dictionary.details.noData}</PlaceholderText>
-                                )}
-                            </dd>
-                        </>
-                    )}
-                    {!resource.page?.length && !showEmptyRows ? null : (
-                        <>
-                            <dt>{dictionary.details.general.page}:</dt>
-                            <dd>
-                                {resource.page?.length ? (
-                                    <SmartList
-                                        items={resource.page}
-                                        renderItem={(url) => (
-                                            <ExternalLink
-                                                href={url}
-                                                locale={locale}
-                                                gateway
-                                            >
-                                                {url}
-                                            </ExternalLink>
-                                        )}
-                                    />
-                                ) : (
-                                    <PlaceholderText>{dictionary.details.noData}</PlaceholderText>
-                                )}
-                            </dd>
-                        </>
-                    )}
-                    {!resource.fdkFormat?.length && !showEmptyRows ? null : (
-                        <>
-                            <dt>{dictionary.details.general.format}:</dt>
-                            <dd>
-                                {resource.fdkFormat?.length ? (
-                                    <TagList>
-                                        {resource.fdkFormat.map((format) => (
-                                            <Tag
-                                                key={format.code}
-                                                data-size='sm'
-                                            >
-                                                {format.name || format.code}
-                                            </Tag>
-                                        ))}
-                                    </TagList>
                                 ) : (
                                     <PlaceholderText>{dictionary.details.noData}</PlaceholderText>
                                 )}

--- a/apps/data-norge/src/app/components/details-page/data-service/data-service-overview-tab.tsx
+++ b/apps/data-norge/src/app/components/details-page/data-service/data-service-overview-tab.tsx
@@ -1,8 +1,8 @@
 import { type Localization, type LocaleCodes } from '@fdk-frontend/localization';
 import { type DataService, type SearchObject } from '@fellesdatakatalog/types';
 import { printLocaleValue } from '@fdk-frontend/utils';
-import { Markdown, Article, PlaceholderBox, noHeadings, Dlist, SmartList, ExternalLink, ScrollShadows, DatasetTable } from '@fdk-frontend/ui';
-import { Heading, Card } from '@digdir/designsystemet-react';
+import { Markdown, Article, PlaceholderBox, PlaceholderText, noHeadings, Dlist, SmartList, ExternalLink, TagList, ScrollShadows, DatasetTable } from '@fdk-frontend/ui';
+import { Heading, Card, Tag } from '@digdir/designsystemet-react';
 import styles from '../details-page.module.scss';
 
 type DataServiceOverviewTabProps = {
@@ -13,10 +13,6 @@ type DataServiceOverviewTabProps = {
 };
 
 export default function DataServiceOverviewTab({ resource, locale, dictionary, resolvedDatasets = [] }: DataServiceOverviewTabProps) {
-    const hasEndpointURL = !!resource.endpointURL?.length;
-    const hasEndpointDescription = !!resource.endpointDescription?.length;
-    const hasEndpointData = hasEndpointURL || hasEndpointDescription;
-
     return (
         <>
             <section className={styles.section}>
@@ -43,56 +39,90 @@ export default function DataServiceOverviewTab({ resource, locale, dictionary, r
                     </PlaceholderBox>
                 )}
             </section>
-            {hasEndpointData && (
-                <section className={styles.section}>
-                    <Heading
-                        level={2}
-                        data-size='xs'
-                    >
-                        Ta i bruk API-et
-                    </Heading>
-                    <Dlist className={styles.dlistWhiteBg}>
-                        {hasEndpointURL && (
-                            <>
-                                <dt>{dictionary.details.general.endpointURL}:</dt>
-                                <dd>
-                                    <SmartList
-                                        items={resource.endpointURL!}
-                                        renderItem={(url) => (
-                                            <ExternalLink
-                                                href={url}
-                                                locale={locale}
-                                                gateway
-                                            >
-                                                {url}
-                                            </ExternalLink>
-                                        )}
-                                    />
-                                </dd>
-                            </>
+            <section className={styles.section}>
+                <Heading
+                    level={2}
+                    data-size='xs'
+                >
+                    {dictionary.details.general.endpointTitle}
+                </Heading>
+                <Dlist>
+                    <dt>{dictionary.details.general.endpointURL}:</dt>
+                    <dd>
+                        {resource.endpointURL?.length ? (
+                            <SmartList
+                                items={resource.endpointURL}
+                                renderItem={(url) => (
+                                    <ExternalLink
+                                        href={url}
+                                        locale={locale}
+                                        gateway
+                                    >
+                                        {url}
+                                    </ExternalLink>
+                                )}
+                            />
+                        ) : (
+                            <PlaceholderText>{dictionary.details.noData}</PlaceholderText>
                         )}
-                        {hasEndpointDescription && (
-                            <>
-                                <dt>{dictionary.details.general.endpointDescription}:</dt>
-                                <dd>
-                                    <SmartList
-                                        items={resource.endpointDescription!}
-                                        renderItem={(url) => (
-                                            <ExternalLink
-                                                href={url}
-                                                locale={locale}
-                                                gateway
-                                            >
-                                                {url}
-                                            </ExternalLink>
-                                        )}
-                                    />
-                                </dd>
-                            </>
+                    </dd>
+                    <dt>{dictionary.details.general.endpointDescription}:</dt>
+                    <dd>
+                        {resource.endpointDescription?.length ? (
+                            <SmartList
+                                items={resource.endpointDescription}
+                                renderItem={(url) => (
+                                    <ExternalLink
+                                        href={url}
+                                        locale={locale}
+                                        gateway
+                                    >
+                                        {url}
+                                    </ExternalLink>
+                                )}
+                            />
+                        ) : (
+                            <PlaceholderText>{dictionary.details.noData}</PlaceholderText>
                         )}
-                    </Dlist>
-                </section>
-            )}
+                    </dd>
+                    <dt>{dictionary.details.general.page}:</dt>
+                    <dd>
+                        {resource.page?.length ? (
+                            <SmartList
+                                items={resource.page}
+                                renderItem={(url) => (
+                                    <ExternalLink
+                                        href={url}
+                                        locale={locale}
+                                        gateway
+                                    >
+                                        {url}
+                                    </ExternalLink>
+                                )}
+                            />
+                        ) : (
+                            <PlaceholderText>{dictionary.details.noData}</PlaceholderText>
+                        )}
+                    </dd>
+                    <dt>{dictionary.details.general.format}:</dt>
+                    <dd>
+                        {resource.fdkFormat?.length ? (
+                            <TagList>
+                                {resource.fdkFormat.map((format) => (
+                                    <Tag
+                                        key={format.code}
+                                        data-size='sm'
+                                    >
+                                        {format.name || format.code}
+                                    </Tag>
+                                ))}
+                            </TagList>
+                        ) : (
+                            <PlaceholderText>{dictionary.details.noData}</PlaceholderText>
+                        )}
+                    </dd>
+                </Dlist>
+            </section>
             {resolvedDatasets.length > 0 && (
                 <section className={styles.section}>
                     <Heading

--- a/libs/localization/src/lib/locales/en/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/en/sections/details-page.ts
@@ -125,6 +125,7 @@ const detailsPage = {
       title: "About this dataset",
       serviceTitle: "About this service",
       dataServiceTitle: "About this API",
+      endpointTitle: "Endpoint",
       publisher: "Publisher",
       firstHarvested: "Published",
       firstHarvestedHelpText: "This date indicates when the dataset was harvested by data.norge.no. It may have been available earlier elsewhere.",

--- a/libs/localization/src/lib/locales/nb/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/nb/sections/details-page.ts
@@ -128,6 +128,7 @@ const detailsPage = {
             title: 'Om datasettet',
             serviceTitle: 'Om tjenesten',
             dataServiceTitle: 'Om API-et',
+            endpointTitle: 'Endepunkt',
             publisher: 'Utgiver',
             firstHarvested: 'Publisert',
             firstHarvestedHelpText:

--- a/libs/localization/src/lib/locales/nn/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/nn/sections/details-page.ts
@@ -128,6 +128,7 @@ const detailsPage = {
             title: 'Om datasettet',
             serviceTitle: 'Om tenesta',
             dataServiceTitle: 'Om API-et',
+            endpointTitle: 'Endepunkt',
             publisher: 'Utgjevar',
             firstHarvested: 'Publisert',
             firstHarvestedHelpText:


### PR DESCRIPTION
# Summary fixes #799

- Removed Endepunkt-URL, Endepunktbeskrivelse, Dokumentasjon and Format from «Om API-et» in the details tab
- Added new «Endepunkt» section in the overview tab, below «Beskrivelse», with the same grey Dlist styling
- Removed the old «Ta i bruk API-et» section from the overview tab
- Added `endpointTitle` dictionary key in nb, nn and en locales