### PR TITLE
fix: update go-to-api button link on dataset details page

### DIFF
--- a/apps/data-norge/src/app/components/details-page/distributions/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/distributions/index.tsx
@@ -116,7 +116,7 @@ const Distributions = ({
                                 </Details.Content>
                             </Details>
                             <ActionButton
-                                uri={`/data-services/${api.id}`}
+                                uri={`/${locale}/data-services/${api.id}`}
                                 className={styles.actionButton}
                             >
                                 {dictionaries.detailsPage.apis.header.gotoBtn}


### PR DESCRIPTION
Fikser slik at disse lenkene peker til de nye detaljsidene for API:

<img width="1138" height="909" alt="Screenshot 2026-03-25 at 12 36 20" src="https://github.com/user-attachments/assets/6be5809f-63d5-44dc-8f86-b64d5b8dd31c" />
