### PR TITLE
fix: patch critical axios vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "qs": "^6.15.0",
         "serialize-javascript": "^7.0.5",
         "path-to-regexp@0.1.12": "0.1.13",
-        "axios": "^1.14.0",
+        "axios": "^1.15.0",
         "lodash-es": "^4.18.1"
     },
     "packageManager": "yarn@4.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7642,14 +7642,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.14.0":
-  version: 1.14.0
-  resolution: "axios@npm:1.14.0"
+"axios@npm:^1.15.0":
+  version: 1.15.0
+  resolution: "axios@npm:1.15.0"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/2541f4aa215a7d1842429dad006fc682d82bc0e74bd14500823f7d8cce3bbae0e0a8c328c8538946718f366ab8ce5a4c12e9ad40e5a0f3482ff8bff0cd115d45
+  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

- Bump axios resolution from ^1.14.0 to ^1.15.0 to fix two critical CVEs (transitive via nx):
  - GHSA-3p68-rc4w-qgx5: NO_PROXY hostname normalization bypass (SSRF)
  - GHSA-fvcv-3m26-pcqx: unrestricted cloud metadata exfiltration via header injection