### PR TITLE
fix: use correct path in URI for service RDF tab

### DIFF
--- a/apps/data-norge/src/app/components/details-page/service/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/service/index.tsx
@@ -578,7 +578,7 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
                         value='rdf'
                     >
                         <MetadataTab
-                            uri={`${baseUri}/public-services/${service.id}`}
+                            uri={`${baseUri}/services/${service.id}`}
                             dictionary={dictionaries.detailsPage}
                             locale={locale}
                         />


### PR DESCRIPTION
fixes #834 