### PR TITLE
chore: bump yarn to 4.14.1

### DIFF
--- a/.github/workflows/deploy-prod&demo.yaml
+++ b/.github/workflows/deploy-prod&demo.yaml
@@ -44,7 +44,6 @@ jobs:
             - name: Yarn install
               run: |
                   corepack enable
-                  yarn set version stable
                   yarn install --immutable
 
             - name: Caching Nx

--- a/.github/workflows/deploy-prod&demo.yaml
+++ b/.github/workflows/deploy-prod&demo.yaml
@@ -86,7 +86,6 @@ jobs:
 
             - name: Yarn install
               run: |
-                  yarn set version stable
                   yarn install --no-immutable
 
             - name: Caching Nx

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -44,7 +44,6 @@ jobs:
 
             - name: Yarn install
               run: |
-                  yarn set version stable
                   yarn install --no-immutable
 
             - name: Caching Nx
@@ -87,7 +86,6 @@ jobs:
 
             - name: Yarn install
               run: |
-                  yarn set version stable
                   yarn install --no-immutable
 
             - name: Caching Nx

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,5 @@
+enableScripts: true
+
 nodeLinker: node-modules
 
-npmRegistryServer: "https://registry.npmjs.org"
+npmRegistryServer: 'https://registry.npmjs.org'

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "axios": "^1.15.0",
         "lodash-es": "^4.18.1"
     },
-    "packageManager": "yarn@4.11.0",
+    "packageManager": "yarn@4.14.1",
     "lint-staged": {
         "*.tsx": [
             "eslint --cache --fix",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10c0
 
 "@adobe/css-tools@npm:^4.4.0":


### PR DESCRIPTION
# Summary

- Bumps `packageManager` from `yarn@4.11.0` to `yarn@4.14.1`
- Regenerates `yarn.lock` at metadata version 9
- Removes `yarn set version stable` from all CI workflow steps so the pinned `packageManager` is authoritative
- Adds `enableScripts: true` to `.yarnrc.yml` to preserve install script behavior across the 4.13 default change