### PR TITLE
fix: precision-aware temporal period date rendering

### DIFF
--- a/apps/data-norge/src/app/components/details-page/details-tab/components/content-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/content-details/index.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { Heading, Paragraph } from '@digdir/designsystemet-react';
 import { Hstack, PlaceholderText, ExternalLink, SmartList, Dlist } from '@fdk-frontend/ui';
 import { DatasetDetailsProps, DatasetDetailsTabContext } from '../../';
-import { printLocaleValue } from '@fdk-frontend/utils';
+import { formatTemporalDate, printLocaleValue } from '@fdk-frontend/utils';
 import { HelpText } from '@fellesdatakatalog/ui';
 
 const ContentDetails = ({ dataset, locale, dictionary }: DatasetDetailsProps) => {
@@ -218,21 +218,13 @@ const ContentDetails = ({ dataset, locale, dictionary }: DatasetDetailsProps) =>
                                             {temporal.startDate && (
                                                 <>
                                                     <dt>{dictionary.details.content.temporalFrom}:</dt>
-                                                    <dd>
-                                                        {new Date(temporal.startDate).toLocaleString(locale, {
-                                                            dateStyle: 'long',
-                                                        })}
-                                                    </dd>
+                                                    <dd>{formatTemporalDate(temporal.startDate, locale)}</dd>
                                                 </>
                                             )}
                                             {temporal.endDate && (
                                                 <>
                                                     <dt>{dictionary.details.content.temporalTo}:</dt>
-                                                    <dd>
-                                                        {new Date(temporal.endDate).toLocaleString(locale, {
-                                                            dateStyle: 'long',
-                                                        })}
-                                                    </dd>
+                                                    <dd>{formatTemporalDate(temporal.endDate, locale)}</dd>
                                                 </>
                                             )}
                                         </Dlist>

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -4,3 +4,4 @@ export * from './lib/form-utils';
 export * from './lib/common';
 export * from './lib/context/env';
 export * from './lib/structured-data';
+export * from './lib/temporalDate';

--- a/libs/utils/src/lib/temporalDate/index.ts
+++ b/libs/utils/src/lib/temporalDate/index.ts
@@ -1,7 +1,10 @@
 import type { LocaleCodes } from '@fdk-frontend/localization';
 
+// Matches year-only values, e.g. "2024"
 const yearPattern = /^\d{4}$/;
+// Matches year + month values, e.g. "2024-06"
 const yearMonthPattern = /^\d{4}-\d{2}$/;
+// Matches full ISO-style dates, e.g. "2024-06-15"
 const fullDatePattern = /^\d{4}-\d{2}-\d{2}$/;
 
 const formatYearMonth = (value: string, locale: LocaleCodes): string => {

--- a/libs/utils/src/lib/temporalDate/index.ts
+++ b/libs/utils/src/lib/temporalDate/index.ts
@@ -4,13 +4,14 @@ const yearPattern = /^\d{4}$/;
 const yearMonthPattern = /^\d{4}-\d{2}$/;
 const fullDatePattern = /^\d{4}-\d{2}-\d{2}$/;
 
-export const formatTemporalDate = (
-    value: string | undefined | null,
-    locale: LocaleCodes,
-): string => {
-    if (!value) return '';
+export const formatTemporalDate = (value: string | undefined | null, locale: LocaleCodes): string => {
+    if (!value) {
+        return '';
+    }
 
-    if (yearPattern.test(value)) return value;
+    if (yearPattern.test(value)) {
+        return value;
+    }
 
     if (yearMonthPattern.test(value)) {
         const [year, month] = value.split('-').map(Number);

--- a/libs/utils/src/lib/temporalDate/index.ts
+++ b/libs/utils/src/lib/temporalDate/index.ts
@@ -1,0 +1,33 @@
+import type { LocaleCodes } from '@fdk-frontend/localization';
+
+const yearPattern = /^\d{4}$/;
+const yearMonthPattern = /^\d{4}-\d{2}$/;
+const fullDatePattern = /^\d{4}-\d{2}-\d{2}$/;
+
+export const formatTemporalDate = (
+    value: string | undefined | null,
+    locale: LocaleCodes,
+): string => {
+    if (!value) return '';
+
+    if (yearPattern.test(value)) return value;
+
+    if (yearMonthPattern.test(value)) {
+        const [year, month] = value.split('-').map(Number);
+        const date = new Date(Date.UTC(year, month - 1, 1));
+        if (Number.isNaN(date.getTime())) return value;
+        return new Intl.DateTimeFormat(locale, {
+            year: 'numeric',
+            month: 'long',
+            timeZone: 'UTC',
+        }).format(date);
+    }
+
+    if (fullDatePattern.test(value)) {
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) return value;
+        return date.toLocaleString(locale, { dateStyle: 'long' });
+    }
+
+    return value;
+};

--- a/libs/utils/src/lib/temporalDate/index.ts
+++ b/libs/utils/src/lib/temporalDate/index.ts
@@ -4,6 +4,31 @@ const yearPattern = /^\d{4}$/;
 const yearMonthPattern = /^\d{4}-\d{2}$/;
 const fullDatePattern = /^\d{4}-\d{2}-\d{2}$/;
 
+const formatYearMonth = (value: string, locale: LocaleCodes): string => {
+    const [year, month] = value.split('-').map(Number);
+    const date = new Date(Date.UTC(year, month - 1, 1));
+
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+
+    return new Intl.DateTimeFormat(locale, {
+        year: 'numeric',
+        month: 'long',
+        timeZone: 'UTC',
+    }).format(date);
+};
+
+const formatFullDate = (value: string, locale: LocaleCodes): string => {
+    const date = new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+
+    return date.toLocaleString(locale, { dateStyle: 'long' });
+};
+
 export const formatTemporalDate = (value: string | undefined | null, locale: LocaleCodes): string => {
     if (!value) {
         return '';
@@ -11,23 +36,10 @@ export const formatTemporalDate = (value: string | undefined | null, locale: Loc
 
     if (yearPattern.test(value)) {
         return value;
-    }
-
-    if (yearMonthPattern.test(value)) {
-        const [year, month] = value.split('-').map(Number);
-        const date = new Date(Date.UTC(year, month - 1, 1));
-        if (Number.isNaN(date.getTime())) return value;
-        return new Intl.DateTimeFormat(locale, {
-            year: 'numeric',
-            month: 'long',
-            timeZone: 'UTC',
-        }).format(date);
-    }
-
-    if (fullDatePattern.test(value)) {
-        const date = new Date(value);
-        if (Number.isNaN(date.getTime())) return value;
-        return date.toLocaleString(locale, { dateStyle: 'long' });
+    } else if (yearMonthPattern.test(value)) {
+        return formatYearMonth(value, locale);
+    } else if (fullDatePattern.test(value)) {
+        return formatFullDate(value, locale);
     }
 
     return value;

--- a/libs/utils/src/lib/temporalDate/temporalDate.spec.ts
+++ b/libs/utils/src/lib/temporalDate/temporalDate.spec.ts
@@ -1,0 +1,41 @@
+import { formatTemporalDate } from '.';
+
+describe('formatTemporalDate', () => {
+    it('renders year-only values as the raw year (nb)', () => {
+        expect(formatTemporalDate('2024', 'nb')).toBe('2024');
+    });
+
+    it('renders year+month as "<month> <year>" in nb (no synthesized day)', () => {
+        expect(formatTemporalDate('2024-06', 'nb')).toBe('juni 2024');
+    });
+
+    it('preserves full-date rendering for ISO dates (nb)', () => {
+        expect(formatTemporalDate('2024-06-15', 'nb')).toBe('15. juni 2024');
+    });
+
+    it('respects other supported locales (en year+month)', () => {
+        expect(formatTemporalDate('2024-06', 'en')).toBe('June 2024');
+    });
+
+    it('returns empty string for empty input', () => {
+        expect(formatTemporalDate('', 'nb')).toBe('');
+    });
+
+    it('returns empty string for undefined input', () => {
+        expect(formatTemporalDate(undefined, 'nb')).toBe('');
+    });
+
+    it('returns empty string for null input', () => {
+        expect(formatTemporalDate(null, 'nb')).toBe('');
+    });
+
+    it('passes malformed input through without throwing', () => {
+        expect(() => formatTemporalDate('not-a-date', 'nb')).not.toThrow();
+        expect(formatTemporalDate('not-a-date', 'nb')).toBe('not-a-date');
+    });
+
+    it('does not throw when year+month has an invalid month', () => {
+        expect(() => formatTemporalDate('2024-13', 'nb')).not.toThrow();
+        expect(typeof formatTemporalDate('2024-13', 'nb')).toBe('string');
+    });
+});


### PR DESCRIPTION
# Summary

- Adds `formatTemporalDate` util that detects year-only, year+month, and full-date precision
- Year-only ("2024") renders as "2024"; year+month ("2024-06") renders as "juni 2024"; full date preserves existing behavior
- Swaps temporal period startDate/endDate call sites in content-details to use the new util
- Adds 9 unit tests covering all precisions, empty/null/undefined, and malformed input

Related: Informasjonsforvaltning/catalog-frontend#1859
Closes: Informasjonsforvaltning/fdk-issue-tracker#1248