### PR TITLE
fix: show correct label based on specializedType

### DIFF
--- a/apps/data-norge/src/app/components/details-page/service/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/service/index.tsx
@@ -113,9 +113,7 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
                             data-size='md'
                         >
                             <Link href='/public-services-and-events'>
-                                {service.specializedType === 'publicService'
-                                    ? dictionaries.common.specializedServices.publicService
-                                    : dictionaries.common.specializedServices.service}
+                                {dictionaries.detailsPage.header.servicesTagLink}
                             </Link>
                         </Tag>
                         {service.admsStatus && (

--- a/apps/data-norge/src/app/components/details-page/service/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/service/index.tsx
@@ -113,7 +113,9 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
                             data-size='md'
                         >
                             <Link href='/public-services-and-events'>
-                                {dictionaries.detailsPage.header.servicesTagLink}
+                                {service.specializedType === 'publicService'
+                                    ? dictionaries.common.specializedServices.publicService
+                                    : dictionaries.common.specializedServices.service}
                             </Link>
                         </Tag>
                         {service.admsStatus && (

--- a/libs/localization/src/lib/locales/en/sections/common.ts
+++ b/libs/localization/src/lib/locales/en/sections/common.ts
@@ -128,6 +128,10 @@ const common = {
     INFORMATION_MODEL: 'Information model',
     SERVICE: 'Service',
     EVENT: 'Event'
+  },
+  specializedServices: {
+    service: 'Service',
+    publicService: 'Public service',
   }
 };
 

--- a/libs/localization/src/lib/locales/en/sections/common.ts
+++ b/libs/localization/src/lib/locales/en/sections/common.ts
@@ -130,8 +130,8 @@ const common = {
     EVENT: 'Event'
   },
   specializedServices: {
-    service: 'Service',
-    publicService: 'Public service',
+    SERVICE: 'Service',
+    PUBLIC_SERVICE: 'Public service',
   }
 };
 

--- a/libs/localization/src/lib/locales/en/sections/common.ts
+++ b/libs/localization/src/lib/locales/en/sections/common.ts
@@ -130,8 +130,8 @@ const common = {
     EVENT: 'Event'
   },
   specializedServices: {
-    SERVICE: 'Service',
-    PUBLIC_SERVICE: 'Public service',
+    service: 'Service',
+    publicService: 'Public service',
   }
 };
 

--- a/libs/localization/src/lib/locales/nb/sections/common.ts
+++ b/libs/localization/src/lib/locales/nb/sections/common.ts
@@ -128,6 +128,10 @@ const common = {
     INFORMATION_MODEL: 'Informasjonsmodeller',
     SERVICE: 'Tjenester',
     EVENT: 'Hendelser'
+  },
+  specializedServices: {
+    service: 'Tjenester',
+    publicService: 'Offentlig tjenester',
   }
 };
 

--- a/libs/localization/src/lib/locales/nb/sections/common.ts
+++ b/libs/localization/src/lib/locales/nb/sections/common.ts
@@ -130,8 +130,8 @@ const common = {
     EVENT: 'Hendelser'
   },
   specializedServices: {
-    service: 'Tjenester',
-    publicService: 'Offentlig tjenester',
+    SERVICE: 'Tjenester',
+    PUBLIC_SERVICE: 'Offentlig tjenester',
   }
 };
 

--- a/libs/localization/src/lib/locales/nb/sections/common.ts
+++ b/libs/localization/src/lib/locales/nb/sections/common.ts
@@ -130,8 +130,8 @@ const common = {
     EVENT: 'Hendelser'
   },
   specializedServices: {
-    SERVICE: 'Tjenester',
-    PUBLIC_SERVICE: 'Offentlig tjenester',
+    service: 'Tjenester',
+    publicService: 'Offentlig tjenester',
   }
 };
 

--- a/libs/localization/src/lib/locales/nn/sections/common.ts
+++ b/libs/localization/src/lib/locales/nn/sections/common.ts
@@ -128,6 +128,10 @@ const common = {
     INFORMATION_MODEL: 'Informasjonsmodell',
     SERVICE: 'Tjenestar',
     EVENT: 'Hendelsar'
+  },
+  specializedServices: {
+    service: 'Tjenestar',
+    publicService: 'Offentlege tenester',
   }
 };
 

--- a/libs/localization/src/lib/locales/nn/sections/common.ts
+++ b/libs/localization/src/lib/locales/nn/sections/common.ts
@@ -130,8 +130,8 @@ const common = {
     EVENT: 'Hendelsar'
   },
   specializedServices: {
-    SERVICE: 'Tjenestar',
-    PUBLIC_SERVICE: 'Offentlege tenester',
+    service: 'Tjenestar',
+    publicService: 'Offentlege tenester',
   }
 };
 

--- a/libs/localization/src/lib/locales/nn/sections/common.ts
+++ b/libs/localization/src/lib/locales/nn/sections/common.ts
@@ -130,8 +130,8 @@ const common = {
     EVENT: 'Hendelsar'
   },
   specializedServices: {
-    service: 'Tjenestar',
-    publicService: 'Offentlege tenester',
+    SERVICE: 'Tjenestar',
+    PUBLIC_SERVICE: 'Offentlege tenester',
   }
 };
 

--- a/libs/ui/src/lib/entity-teaser/index.tsx
+++ b/libs/ui/src/lib/entity-teaser/index.tsx
@@ -1,6 +1,16 @@
 import React from 'react';
 import cn from 'classnames';
-import { Card, CardBlock, type CardProps, Heading, Link, Paragraph, Tag, Skeleton, Tooltip } from '@digdir/designsystemet-react';
+import {
+    Card,
+    CardBlock,
+    type CardProps,
+    Heading,
+    Link,
+    Paragraph,
+    Tag,
+    Skeleton,
+    Tooltip,
+} from '@digdir/designsystemet-react';
 import { TagList, HStack } from '@fellesdatakatalog/ui';
 import { AccessRightsCodes, EntityType, type SearchObject } from '@fellesdatakatalog/types';
 import AccessLevelTag from '../access-level-tag';
@@ -30,12 +40,11 @@ const EntityTeaser = ({ entity, className, locale, llm, ...rest }: EntityTeaserP
     const localization = getLocalization(locale).common;
     return (
         <Card
-            className={cn(styles.container, className, {[styles.llm]: llm})}
+            className={cn(styles.container, className, { [styles.llm]: llm })}
             {...rest}
         >
             <CardBlock>
-                {
-                    entity ?
+                {entity ? (
                     <div>
                         <OrgLogo
                             className={styles.orgLogo}
@@ -47,7 +56,8 @@ const EntityTeaser = ({ entity, className, locale, llm, ...rest }: EntityTeaserP
                                 {printLocaleValue(locale, entity.title)}
                             </Link>
                         </Heading>
-                    </div> : 
+                    </div>
+                ) : (
                     <HStack>
                         <Skeleton
                             width='1.5rem'
@@ -62,74 +72,61 @@ const EntityTeaser = ({ entity, className, locale, llm, ...rest }: EntityTeaserP
                             />
                         </Heading>
                     </HStack>
-                }
-                {
-                    entity ?
+                )}
+                {entity ? (
                     <TagList>
                         <Tag
                             data-color='info'
                             data-size='sm'
                         >
                             <Link href={`/${locale}/search/${setFragments[entity.searchType]}`}>
-                                {
-                                    // FDK search API may return specializedType values ("service", "publicService") outside the SDK enum union.
-                                    entity.searchType === EntityType.PUBLIC_SERVICE &&
-                                    (entity.specializedType as string | undefined | null) === 'publicService'
-                                        ? localization.specializedServices.publicService
-                                        : localization.entities[entity.searchType]
-                                }
+                                {entity.searchType === EntityType.PUBLIC_SERVICE &&
+                                (entity.specializedType as string | undefined | null) === 'publicService'
+                                    ? localization.specializedServices.publicService
+                                    : localization.entities[entity.searchType]}
                             </Link>
                         </Tag>
-                        {
-                            (entity.searchType === 'DATASET' || entity.searchType === 'DATA_SERVICE') &&
+                        {(entity.searchType === 'DATASET' || entity.searchType === 'DATA_SERVICE') && (
                             <AccessLevelTag
                                 data-size='sm'
                                 accessCode={entity.accessRights?.code as AccessRightsCodes}
                                 nonInteractive
                                 locale={locale}
                             />
-                        }
-                        {
-                            entity.isOpenData &&
+                        )}
+                        {entity.isOpenData && (
                             <Tag
                                 data-color='success'
                                 data-size='sm'
                             >
                                 Åpne data
                             </Tag>
-                        }
-                    </TagList> :
-                    <div style={{marginTop:'0.5rem',lineHeight:'1.75rem'}}>
+                        )}
+                    </TagList>
+                ) : (
+                    <div style={{ marginTop: '0.5rem', lineHeight: '1.75rem' }}>
                         <Skeleton
                             variant='text'
                             width={300}
                         />
                     </div>
-                }
-                {
-                    entity &&
+                )}
+                {entity && (
                     <Paragraph className={styles.description}>
-                        {
-                            desc ?
-                            desc.length > 500 ?
-                            `${desc.slice(0, 500)}...` :
-                            desc :
-                            'Mangler beskrivelse'
-                        }
+                        {desc ? (desc.length > 500 ? `${desc.slice(0, 500)}...` : desc) : 'Mangler beskrivelse'}
                     </Paragraph>
-                }
-                {
-                    entity &&
-                    <div className={styles.orgName}>
-                        {printLocaleValue(locale, entity.organization?.prefLabel)}
-                    </div>
-                }
-                {
-                    (entity && llm) &&
-                    <Tooltip content='Treff fra KI-søk' placement='top'>
+                )}
+                {entity && (
+                    <div className={styles.orgName}>{printLocaleValue(locale, entity.organization?.prefLabel)}</div>
+                )}
+                {entity && llm && (
+                    <Tooltip
+                        content='Treff fra KI-søk'
+                        placement='top'
+                    >
                         <SparklesFillIcon className={styles.llmIcon} />
                     </Tooltip>
-                }
+                )}
             </CardBlock>
         </Card>
     );

--- a/libs/ui/src/lib/entity-teaser/index.tsx
+++ b/libs/ui/src/lib/entity-teaser/index.tsx
@@ -71,7 +71,13 @@ const EntityTeaser = ({ entity, className, locale, llm, ...rest }: EntityTeaserP
                             data-size='sm'
                         >
                             <Link href={`/${locale}/search/${setFragments[entity.searchType]}`}>
-                                {localization.entities[entity.searchType]}
+                                {
+                                    // FDK search API may return specializedType values ("service", "publicService") outside the SDK enum union.
+                                    entity.searchType === EntityType.PUBLIC_SERVICE &&
+                                    (entity.specializedType as string | undefined | null) === 'publicService'
+                                        ? localization.specializedServices.publicService
+                                        : localization.entities[entity.searchType]
+                                }
                             </Link>
                         </Tag>
                         {

--- a/libs/ui/src/lib/entity-teaser/index.tsx
+++ b/libs/ui/src/lib/entity-teaser/index.tsx
@@ -81,8 +81,8 @@ const EntityTeaser = ({ entity, className, locale, llm, ...rest }: EntityTeaserP
                         >
                             <Link href={`/${locale}/search/${setFragments[entity.searchType]}`}>
                                 {entity.searchType === EntityType.PUBLIC_SERVICE &&
-                                (entity.specializedType as string | undefined | null) === 'publicService'
-                                    ? localization.specializedServices.publicService
+                                (entity.specializedType as string | undefined | null) === 'PUBLIC_SERVICE'
+                                    ? localization.specializedServices.PUBLIC_SERVICE
                                     : localization.entities[entity.searchType]}
                             </Link>
                         </Tag>

--- a/libs/ui/src/lib/entity-teaser/index.tsx
+++ b/libs/ui/src/lib/entity-teaser/index.tsx
@@ -81,8 +81,8 @@ const EntityTeaser = ({ entity, className, locale, llm, ...rest }: EntityTeaserP
                         >
                             <Link href={`/${locale}/search/${setFragments[entity.searchType]}`}>
                                 {entity.searchType === EntityType.PUBLIC_SERVICE &&
-                                (entity.specializedType as string | undefined | null) === 'PUBLIC_SERVICE'
-                                    ? localization.specializedServices.PUBLIC_SERVICE
+                                (entity.specializedType as string | undefined | null) === 'publicService'
+                                    ? localization.specializedServices.publicService
                                     : localization.entities[entity.searchType]}
                             </Link>
                         </Tag>

--- a/libs/ui/src/lib/entity-teaser/index.tsx
+++ b/libs/ui/src/lib/entity-teaser/index.tsx
@@ -81,7 +81,7 @@ const EntityTeaser = ({ entity, className, locale, llm, ...rest }: EntityTeaserP
                         >
                             <Link href={`/${locale}/search/${setFragments[entity.searchType]}`}>
                                 {entity.searchType === EntityType.PUBLIC_SERVICE &&
-                                (entity.specializedType as string | undefined | null) === 'publicService'
+                                (entity.specializedType as string | null) === 'publicService'
                                     ? localization.specializedServices.publicService
                                     : localization.entities[entity.searchType]}
                             </Link>


### PR DESCRIPTION
# Summary fixes #925

- Add `specializedServices` localization block (nb/nn/en) mapping `"service"` and `"publicService"` to display labels
- Search list items now show "Offentlig tjenester" when `specializedType === "publicService"`, "Tjenester" otherwise
- Service detail page header tag uses the same conditional via `dictionaries.common.specializedServices`