### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/deploy-prod&demo.yaml
+++ b/.github/workflows/deploy-prod&demo.yaml
@@ -18,7 +18,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
               with:
                   # We need to fetch all branches and commits so that Nx affected has a base to compare against.
                   fetch-depth: 0
@@ -30,13 +30,13 @@ jobs:
                   git submodule foreach --recursive git checkout origin/main
 
             - name: Set SHAs
-              uses: nrwl/nx-set-shas@v4
+              uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1  # v5.0.1
 
             - name: Enable corepack
               run: corepack enable
 
             - name: Use Node.js 22.14.0
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
               with:
                   node-version: 22.14.0
                   cache: 'yarn'
@@ -47,7 +47,7 @@ jobs:
                   yarn install --immutable
 
             - name: Caching Nx
-              uses: actions/cache@v5
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
               with:
                   path: node_modules/.cache
                   key: cache-nx-${{ hashFiles('yarn.lock') }}
@@ -61,7 +61,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
               with:
                   # We need to fetch all branches and commits so that Nx affected has a base to compare against.
                   fetch-depth: 0
@@ -73,13 +73,13 @@ jobs:
                   git submodule foreach --recursive git checkout origin/main
 
             - name: Set SHAs
-              uses: nrwl/nx-set-shas@v4
+              uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1  # v5.0.1
 
             - name: Enable corepack
               run: corepack enable
 
             - name: Use Node.js 22.14.0
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
               with:
                   node-version: 22.14.0
                   cache: 'yarn'
@@ -89,7 +89,7 @@ jobs:
                   yarn install --no-immutable
 
             - name: Caching Nx
-              uses: actions/cache@v5
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
               with:
                   path: node_modules/.cache
                   key: cache-nx-${{ hashFiles('yarn.lock') }}
@@ -99,7 +99,7 @@ jobs:
             - run: yarn nx build data-norge --configuration=ci
 
             - name: Caching Dist Folder
-              uses: actions/cache@v5
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
               with:
                   path: ./dist
                   key: cache-dist-${{ github.sha }}-data-norge

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -19,7 +19,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
               with:
                   # We need to fetch all branches and commits so that Nx affected has a base to compare against.
                   fetch-depth: 0
@@ -31,13 +31,13 @@ jobs:
                   git submodule foreach --recursive git checkout origin/main
 
             - name: Set SHAs
-              uses: nrwl/nx-set-shas@v4
+              uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1  # v5.0.1
 
             - name: Enable corepack
               run: corepack enable
 
             - name: Use Node.js 22.14.0
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
               with:
                   node-version: 22.14.0
                   cache: 'yarn'
@@ -47,7 +47,7 @@ jobs:
                   yarn install --no-immutable
 
             - name: Caching Nx
-              uses: actions/cache@v5
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
               with:
                   path: node_modules/.cache
                   key: cache-nx-${{ hashFiles('yarn.lock') }}
@@ -61,7 +61,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
               with:
                   # We need to fetch all branches and commits so that Nx affected has a base to compare against.
                   fetch-depth: 0
@@ -73,13 +73,13 @@ jobs:
                   git submodule foreach --recursive git checkout origin/main
 
             - name: Set SHAs
-              uses: nrwl/nx-set-shas@v4
+              uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1  # v5.0.1
 
             - name: Enable corepack
               run: corepack enable
 
             - name: Use Node.js 22.14.0
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
               with:
                   node-version: 22.14.0
                   cache: 'yarn'
@@ -89,7 +89,7 @@ jobs:
                   yarn install --no-immutable
 
             - name: Caching Nx
-              uses: actions/cache@v5
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
               with:
                   path: node_modules/.cache
                   key: cache-nx-${{ hashFiles('yarn.lock') }}
@@ -99,7 +99,7 @@ jobs:
             - run: yarn nx build data-norge --configuration=ci
 
             - name: Caching Dist Folder
-              uses: actions/cache@v5
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
               with:
                   path: ./dist
                   key: cache-dist-${{ github.sha }}-data-norge


### PR DESCRIPTION
# Summary

- Pin all third-party GitHub Actions to immutable commit SHAs in deploy-prod&demo.yaml and deploy-staging.yaml
- Update nrwl/nx-set-shas from v4 to v5.0.1 (v4 uses deprecated Node.js runtime)
- Original version tags preserved as inline comments for readability