### PR TITLE
feat: add sensitive data disclaimer to LLM search

### DIFF
--- a/apps/data-norge/src/app/components/frontpage/llm-search/index.tsx
+++ b/apps/data-norge/src/app/components/frontpage/llm-search/index.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { Textfield, Button, Spinner, ValidationMessage } from '@digdir/designsystemet-react';
-import { SparklesIcon } from '@navikt/aksel-icons';
+import { ShieldLockIcon, SparklesIcon } from '@navikt/aksel-icons';
 import { type Localization, type LocaleCodes } from '@fdk-frontend/localization';
 import { llmSearch, type LlmSearchResponse } from '@fdk-frontend/data-access';
 import { AdvancedSearchPrompt } from './components/advanced-search-prompt';
@@ -97,38 +97,55 @@ const LlmSearch = ({ endpoint, dictionary, locale }: LlmSearchProps) => {
     return (
         <div className={styles.llmSearch}>
             <form onSubmit={submitQuery}>
+                <label
+                    htmlFor='llm-search-input'
+                    id='llm-search-label'
+                    className={styles.llmInputLabel}
+                >
+                    {dictionary.aiBanner.prompt.label}
+                </label>
                 <div className={styles.llmSearchBox}>
-                    <Textfield
-                        className={styles.llmInputTextfield}
-                        label={<span className={styles.llmInputLabel}>{dictionary.aiBanner.prompt.label}</span>}
-                        placeholder={dictionary.aiBanner.prompt.placeholder}
-                        data-size='lg'
-                        value={query}
-                        error={error !== undefined}
-                        onChange={(e) => setQuery(e.target.value)}
-                        autoComplete='off'
-                        data-color-scheme='dark'
-                    />
-                    <Button
-                        className={styles.llmSearchButton}
-                        type='submit'
-                        data-size='sm'
-                    >
-                        {loading ? (
-                            <Spinner
-                                aria-label={dictionary.aiBanner.prompt.loading}
-                                data-size='xs'
-                            />
-                        ) : (
-                            <>
-                                <SparklesIcon
-                                    className={styles.llmSearchIcon}
-                                    aria-hidden
+                    <div className={styles.inputRow}>
+                        <Textfield
+                            id='llm-search-input'
+                            aria-labelledby='llm-search-label'
+                            className={styles.llmInputTextfield}
+                            placeholder={dictionary.aiBanner.prompt.placeholder}
+                            data-size='lg'
+                            value={query}
+                            error={error !== undefined}
+                            onChange={(e) => setQuery(e.target.value)}
+                            autoComplete='off'
+                            data-color-scheme='dark'
+                        />
+                        <Button
+                            className={styles.llmSearchButton}
+                            type='submit'
+                            data-size='sm'
+                        >
+                            {loading ? (
+                                <Spinner
+                                    aria-label={dictionary.aiBanner.prompt.loading}
+                                    data-size='xs'
                                 />
-                                <span>{dictionary.aiBanner.prompt.button}</span>
-                            </>
-                        )}
-                    </Button>
+                            ) : (
+                                <>
+                                    <SparklesIcon
+                                        className={styles.llmSearchIcon}
+                                        aria-hidden
+                                    />
+                                    <span>{dictionary.aiBanner.prompt.button}</span>
+                                </>
+                            )}
+                        </Button>
+                    </div>
+                    <p className={styles.disclaimer}>
+                        <ShieldLockIcon
+                            className={styles.disclaimerIcon}
+                            aria-hidden
+                        />
+                        {dictionary.aiBanner.prompt.disclaimer}
+                    </p>
                 </div>
             </form>
             {!error && !loading && (

--- a/apps/data-norge/src/app/components/frontpage/llm-search/llm-search.module.scss
+++ b/apps/data-norge/src/app/components/frontpage/llm-search/llm-search.module.scss
@@ -6,6 +6,25 @@
 .llmSearchBox {
     position: relative;
     margin-bottom: 0.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.75);
+    border-radius: 0.5rem;
+    background-color: rgba(0, 0, 0, 0.33333);
+
+    &:focus-within {
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.75);
+    }
+
+    &:has(input[aria-invalid]) {
+        border-color: var(--fdk-color-red);
+
+        &:focus-within {
+            box-shadow: inset 0 0 0 1px var(--fdk-color-red);
+        }
+    }
+}
+
+.inputRow {
+    position: relative;
 }
 
 .llmSearchButton {
@@ -44,28 +63,19 @@
     }
 
     input {
-        background-color: rgba(0, 0, 0, 0.33333);
+        background-color: transparent;
+        border-color: transparent;
         color: white;
         padding-right: 7rem;
         font-size: 1.25rem;
 
-        &:not([aria-invalid]) {
-            border-color: rgba(255, 255, 255, 0.75);
-        }
-
         &:focus,
-        &:hover {
-            border-color: rgba(255, 255, 255, 0.75);
-            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.75);
-        }
-
+        &:focus-visible,
+        &:hover,
         &[aria-invalid] {
-            border-color: var(--fdk-color-red);
-
-            &:focus,
-            &:hover {
-                box-shadow: inset 0 0 0 1px var(--fdk-color-red);
-            }
+            outline: none;
+            border-color: transparent;
+            box-shadow: none;
         }
     }
 
@@ -79,8 +89,25 @@
 
 .llmInputLabel {
     display: block;
+    margin-bottom: 0.5rem;
     color: white;
     text-align: center;
+}
+
+.disclaimer {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0.625rem 1rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.15);
+    font-size: 0.8125rem;
+    color: var(--fdk-color-cyan);
+}
+
+.disclaimerIcon {
+    font-size: 1rem;
+    flex-shrink: 0;
 }
 
 .llmResults {

--- a/libs/localization/src/lib/locales/en/sections/frontpage.ts
+++ b/libs/localization/src/lib/locales/en/sections/frontpage.ts
@@ -11,6 +11,7 @@ const frontpage = {
         },
         prompt: {
             button: "Ask",
+            disclaimer: "Do not enter personal or other sensitive information.",
             errors: {
                 generic: "An error occurred. Please try again later.",
                 queryTooShort: "The query must have at least three characters. Please try again.",

--- a/libs/localization/src/lib/locales/nb/sections/frontpage.ts
+++ b/libs/localization/src/lib/locales/nb/sections/frontpage.ts
@@ -11,6 +11,7 @@ const frontpage = {
         },
         prompt: {
             button: "Spør",
+            disclaimer: "Ikke legg inn personopplysninger eller annen sensitiv informasjon.",
             errors: {
                 generic: "En feil oppstod. Vennligst prøv igjen senere.",
                 queryTooShort: "Spørringen må inneholde minst tre tegn. Prøv igjen.",

--- a/libs/localization/src/lib/locales/nn/sections/frontpage.ts
+++ b/libs/localization/src/lib/locales/nn/sections/frontpage.ts
@@ -11,6 +11,7 @@ const frontpage = {
         },
         prompt: {
             button: "Spør",
+            disclaimer: "Ikkje legg inn personopplysningar eller anna sensitiv informasjon.",
             errors: {
                 generic: "Ein feil oppstod. Ver venleg å prøv igjen seinare.",
                 queryTooShort: "Spurnaden må innehalde minst tre teikn. Prøv igjen.",


### PR DESCRIPTION
# Summary fixes #887

- Add `disclaimer` i18n key to nb, nn, and en frontpage dictionaries
- Render disclaimer with ShieldLock icon inside the search container
- Integrate disclaimer visually into the input box (shared border, divider row)
- Move border/background to wrapper; suppress input's own focus ring so only one border shows on focus
- Extract label outside the bordered container to avoid it being enclosed