### PR TITLE
chore: fix uuid moderate security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "yaml@^2.0.0": "^2.8.3",
         "yaml@2.8.0": "2.8.3",
         "fast-uri": "^3.1.2",
+        "uuid@^8.3.2": "^11.1.1",
         "@babel/plugin-transform-modules-systemjs": "^7.29.4",
         "@ungap/structured-clone": "^1.3.1",
         "tmp": "^0.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20189,12 +20189,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
+"uuid@npm:^11.1.1":
+  version: 11.1.1
+  resolution: "uuid@npm:11.1.1"
   bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
+    uuid: dist/esm/bin/uuid
+  checksum: 10c0/9e3af58eba872ece5a5e76f4773a94fc78a0ef2c2444c38dbe6b42f41dadf76c01850fd783604f27986f6195e6286aef064d45987d401b2a33127b98ddf7c0c5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

- Adds yarn resolution to force `uuid@^8.3.2` → `^11.1.1` (GHSA-w5hq-g745-h8pq)
- Vulnerability was introduced via `sockjs` (webpack-dev-server dep), dev-only
- `sockjs` only uses `uuid.v4()` which remains compatible in v11