### PR TITLE
docs: Update Altinn links to description of data.norge.no

### DIFF
--- a/apps/data-norge/public/content/docs/sharing-data/login-and-access/login-and-access.en.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/login-and-access/login-and-access.en.mdx
@@ -5,7 +5,7 @@ description: Information on how to get access to Data.norge.no's solutions.
 
 # How to get access to Data.norge.no's solutions
 
-1. Go to Altinn to [read about how to get/give access to Data.norge.no](https://info.altinn.no/en/forms-overview/the-norwegian-digitalisation-agency/Data.norge.no)
+1. Go to Altinn to [read about how to get/give access to Data.norge.no](https://info.altinn.no/en/forms-overview/the-norwegian-digitalisation-agency/datanorgeno/)
 2. Log in with ID-porten at [Data.norge.no publishing](https://data.norge.no/publishing)
 3. Terms of use must be accepted the first time your organization uses Data.norge.no. This requires access from the organization administrator. Read [terms of use](https://data.norge.no/publishing/terms-of-use)
 4. Now you are ready to register and/or harvest descriptions of your organization's data

--- a/apps/data-norge/public/content/docs/sharing-data/login-and-access/login-and-access.nb.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/login-and-access/login-and-access.nb.mdx
@@ -5,7 +5,7 @@ description: Informasjon om hvordan du får tilgang til Data.norge.no sine løsn
 
 # Hvordan få tilgang til Data.norge.no sine løsninger
 
-1. Gå til Altinn for å [lese om hvordan du får/gir tilgang til Data.norge.no](https://info.altinn.no/skjemaoversikt/digitaliseringsdirektoratet/Data.norge.no)
+1. Gå til Altinn for å [lese om hvordan du får/gir tilgang til Data.norge.no](https://info.altinn.no/skjemaoversikt/digitaliseringsdirektoratet/datanorgeno/)
 2. Logg inn med ID-porten på [Data.norge.no publisering](https://data.norge.no/publishing)
 3. Bruksvilkår må godtas første gang din virksomhet tar i bruk Data.norge.no. Dette krever tilgangen virksomhetsadministrator. Les [bruksvilkår](https://data.norge.no/publishing/terms-of-use)
 4. Nå er du klar til å registrere og/eller høste beskrivelser av virksomhetens data

--- a/apps/data-norge/public/content/docs/sharing-data/login-and-access/login-and-access.nn.mdx
+++ b/apps/data-norge/public/content/docs/sharing-data/login-and-access/login-and-access.nn.mdx
@@ -5,7 +5,7 @@ description: Informasjon om korleis du får tilgang til Data.norge.no sine løys
 
 # Korleis få tilgang til Data.norge.no sine løysingar
 
-1. Gå til Altinn for å [lese om korleis du får/gjev tilgang til Data.norge.no](https://info.altinn.no/nn/skjemaoversikt/digitaliseringsdirektoratet/Data.norge.no)
+1. Gå til Altinn for å [lese om korleis du får/gjev tilgang til Data.norge.no](https://info.altinn.no/nn/skjemaoversikt/digitaliseringsdirektoratet/datanorgeno/)
 2. Logg inn med ID-porten på [Data.norge.no publisering](https://data.norge.no/publishing)
 3. Bruksvilkår må godkjennast første gong verksemda di tek i bruk Data.norge.no. Dette krev tilgang frå verksemdsadministrator. Les [bruksvilkår](https://data.norge.no/publishing/terms-of-use)
 4. No er du klar til å registrere og/eller hauste beskrivingar av verksemda sine data


### PR DESCRIPTION
Update login and access documentation links:
- Bokmål: Data.norge.no → datanorgeno/
- Nynorsk: Data.norge.no → datanorgeno/
- English: Data.norge.no → datanorgeno/