### PR TITLE
docs: Update European Data Portal link on metadata quality page

### DIFF
--- a/apps/data-norge/public/content/docs/metadata-quality/metadata-quality.en.mdx
+++ b/apps/data-norge/public/content/docs/metadata-quality/metadata-quality.en.mdx
@@ -35,4 +35,4 @@ Norway is also compared to other European data catalogs, where one of the criter
 
 The calculation of metadata quality is based on a range of criteria divided into categories according to the [FAIR principles](https://www.go-fair.org/fair-principles/).
 
-We have also referred to the European Data Portal's [methodology](https://www.europeandataportal.eu/mqa/methodology?locale=en) for assessing metadata quality.
+We have also referred to the European Data Portal's [methodology](https://data.europa.eu/mqa/methodology?locale=en) for assessing metadata quality.

--- a/apps/data-norge/public/content/docs/metadata-quality/metadata-quality.nb.mdx
+++ b/apps/data-norge/public/content/docs/metadata-quality/metadata-quality.nb.mdx
@@ -35,4 +35,4 @@ Norge blir også målt mot andre europeiske datakataloger, der et av kriteriene 
 
 Utregning av metadatakvalitet baserer seg på en rekke kriterier som er delt inn ulike kategorier i henhold til [FAIR-prinsippene](https://www.go-fair.org/fair-principles/).
 
-Vi har også sett til European Data Portal sin [metode](https://www.europeandataportal.eu/mqa/methodology?locale=en) for å vurdere metadatakvalitet.
+Vi har også sett til European Data Portal sin [metode](https://data.europa.eu/mqa/methodology?locale=en) for å vurdere metadatakvalitet.

--- a/apps/data-norge/public/content/docs/metadata-quality/metadata-quality.nn.mdx
+++ b/apps/data-norge/public/content/docs/metadata-quality/metadata-quality.nn.mdx
@@ -35,4 +35,4 @@ Noreg blir også målt mot andre europeiske datakatalogar, der eit av kriteriane
 
 Utrekning av metadatakvalitet baserer seg på ei rekke kriterium som er delt inn i ulike kategoriar i samsvar med [FAIR-prinsippa](https://www.go-fair.org/fair-principles/).
 
-Vi har også sett til European Data Portal sin [metode](https://www.europeandataportal.eu/mqa/methodology?locale=en) for å vurdere metadatakvalitet.
+Vi har også sett til European Data Portal sin [metode](https://data.europa.eu/mqa/methodology?locale=en) for å vurdere metadatakvalitet.


### PR DESCRIPTION
Replace broken europeandataportal.eu link with data.europa.eu across all language variants (nb, en, nn).