### PR TITLE
fix: restore metadata quality score link to organization dashboard

### DIFF
--- a/apps/data-norge/src/app/components/details-page/details-tab/components/general-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/general-details/index.tsx
@@ -6,6 +6,7 @@ import { type DatasetType } from '@fellesdatakatalog/types';
 import { HelpText } from '@fellesdatakatalog/ui';
 import { DatasetDetailsProps, DatasetDetailsTabContext } from '../../';
 import { i18n } from '@fdk-frontend/localization';
+import styles from '../../details-tab.module.scss';
 
 const GeneralDetails = ({ dataset, locale, dictionary, metadataScore }: DatasetDetailsProps) => {
     const { showEmptyRows } = useContext(DatasetDetailsTabContext);
@@ -158,13 +159,15 @@ const GeneralDetails = ({ dataset, locale, dictionary, metadataScore }: DatasetD
                         </HelpText>
                     </Hstack>
                 </dt>
-                <dd>
-                    <Tag
-                        data-size='sm'
-                        data-color={metadataQuality.color as TagProps['color']}
-                    >
-                        {metadataQuality.label}
-                    </Tag>
+                <dd className={styles.metadataQualityLink}>
+                    <Link href={`/organizations/${dataset.publisher?.id}/datasets/${dataset.id}`}>
+                        <Tag
+                            data-size='sm'
+                            data-color={metadataQuality.color as TagProps['color']}
+                        >
+                            {metadataQuality.label}
+                        </Tag>
+                    </Link>
                 </dd>
                 <dt>URI:</dt>
                 <dd>

--- a/apps/data-norge/src/app/components/details-page/details-tab/details-tab.module.scss
+++ b/apps/data-norge/src/app/components/details-page/details-tab/details-tab.module.scss
@@ -35,3 +35,18 @@
     padding: 0.75rem 0.75rem;
     background: #fafafa;
 }
+
+.metadataQualityLink {
+    :global(a) {
+        :global(button),
+        :global(span) {
+            border: 2px solid currentColor !important;
+            padding: 2px 4px !important;
+            border-radius: 3px !important;
+        }
+    }
+
+    :global(a:hover) {
+        opacity: 0.85;
+    }
+}

--- a/apps/data-norge/src/app/components/details-page/details-tab/details-tab.module.scss
+++ b/apps/data-norge/src/app/components/details-page/details-tab/details-tab.module.scss
@@ -38,15 +38,23 @@
 
 .metadataQualityLink {
     :global(a) {
+        text-decoration: none;
+
         :global(button),
         :global(span) {
-            border: 2px solid currentColor !important;
-            padding: 2px 4px !important;
-            border-radius: 3px !important;
+            outline: 2px solid transparent;
+            outline-offset: 1px;
+            transition: outline-color 0.1s;
         }
     }
 
-    :global(a:hover) {
+    :global(a:hover),
+    :global(a:focus-visible) {
         opacity: 0.85;
+
+        :global(button),
+        :global(span) {
+            outline-color: currentColor;
+        }
     }
 }


### PR DESCRIPTION
## Description
Restores the metadata quality score link on the dataset details page. This functionality existed before the details page redesign but was accidentally removed. Users can now click on the quality score to navigate to the organization dashboard where they can see detailed quality criteria and individual scores that sum up to the total score.

Fix: #461 

## Changes
- Wraps the metadata quality `<Tag>` in a `<Link>` component
- Points to: `/organizations/{publisher-id}/datasets/{dataset-id}`

## Example
- From: https://data.norge.no/nb/datasets/d136f2f6-a62e-373b-9337-77407a07b647/kommune-los?tab=details
- To: https://data.norge.no/organizations/991825827/datasets/d136f2f6-a62e-373b-9337-77407a07b647

Users can now see the individual quality scores that contribute to the total score.