### PR TITLE
feat: search tabs width

### DIFF
--- a/libs/ui/src/lib/search-tabs/index.tsx
+++ b/libs/ui/src/lib/search-tabs/index.tsx
@@ -48,6 +48,7 @@ const SearchTabBadge = ({ count }: { count: number | undefined }) => {
     <Badge
       count={count}
       variant="tinted"
+      className={styles.badge}
     />
   );
 };
@@ -83,10 +84,13 @@ const SearchTabs = ({ value, defaultValue = "ki", onChange, badgeCounts = {} }: 
           <ToggleGroup.Item
             key={item.value}
             value={item.value}
+            className={styles.tab}
           >
-            {item.icon}
-            {item.label}
             <SearchTabBadge count={count} />
+            <div>
+              {item.icon}
+              {item.label}
+            </div>
           </ToggleGroup.Item>
         );
       })}

--- a/libs/ui/src/lib/search-tabs/styles.module.scss
+++ b/libs/ui/src/lib/search-tabs/styles.module.scss
@@ -1,5 +1,23 @@
 .tabs {
   min-width: 0;
+  max-width: 1000px;
+  height: fit-content;
+  gap: 0;
+
+  .tab {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    padding-top: 0;
+    padding-bottom: var(--ds-size-1);
+    gap: 2px;
+    div {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: var(--ds-size-1);
+    }
+  }
 
   svg {
     color: var(--fdk-color-interactive);
@@ -14,11 +32,20 @@
   .badgeLoading {
     display: inline-block;
     width: 1.75rem;
-    height: 1.25rem;
-    border-radius: var(--ds-border-radius-full, 999px);
+    height: 1rem;
+    border-radius: var(--ds-border-radius-xl);
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
     flex-shrink: 0;
     background: rgba(255, 255, 255, 0.75);
     animation: search-tab-badge-loading 1.2s ease-in-out infinite;
+  }
+
+  .badge::before {
+    border-radius: var(--ds-border-radius-xl);
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    padding: 0 calc(var(--ds-size-1) * 2);
   }
 
   label {


### PR DESCRIPTION
fixes https://github.com/Informasjonsforvaltning/fdk-frontend/issues/925

- Fikser bredden på søke-fanene så horisontal scroll ikke alltid er tilstede. 

Før:
<img width="1075" height="80" alt="bilde" src="https://github.com/user-attachments/assets/0b64dffa-5093-46b2-b488-25d677c989e2" />

Med endringer:
<img width="1050" height="68" alt="bilde" src="https://github.com/user-attachments/assets/37c358dc-e04a-4610-8ca0-09a1933c53f2" />
