### PR TITLE
fix: search filter selection sync

### DIFF
--- a/libs/ui/src/lib/search-form/access-filter.tsx
+++ b/libs/ui/src/lib/search-form/access-filter.tsx
@@ -14,15 +14,16 @@ export type AccessFilterProps = {
 };
 
 const AccessFilter = ({ aggregation = [], value, onChange }: AccessFilterProps) => {
-  const { selected, onChange: handleChange } = useSyncedAccessSelection(value, onChange);
+  const { checkboxValue, checkboxKey, onChange: handleChange } = useSyncedAccessSelection(value, onChange);
   const options = useMemo(() => buildAccessFilterOptions(aggregation), [aggregation]);
 
   if (!shouldShowAccessFilter(aggregation) || options.length === 0) return null;
 
   return (
     <CheckboxGroup
+      key={checkboxKey}
       options={options}
-      value={selected}
+      value={checkboxValue}
       onChange={handleChange}
     />
   );

--- a/libs/ui/src/lib/search-form/access/use-synced-selection.ts
+++ b/libs/ui/src/lib/search-form/access/use-synced-selection.ts
@@ -24,9 +24,9 @@ export const useSyncedAccessSelection = function (
 
   const handleChange = useCallback(
     (next: string[]) => {
-      setSelected(next);
       pendingSelectionKeyRef.current = accessKeysToQueryParam(next);
       onChange?.(next);
+      setSelected(next);
     },
     [onChange, pendingSelectionKeyRef, setSelected],
   );

--- a/libs/ui/src/lib/search-form/access/use-synced-selection.ts
+++ b/libs/ui/src/lib/search-form/access/use-synced-selection.ts
@@ -13,9 +13,14 @@ export const useSyncedAccessSelection = function (
   onChange?: (value: string[]) => void,
 ): {
   selected: string[];
+  checkboxValue: string[];
+  checkboxKey: string;
   onChange: (value: string[]) => void;
 } {
-  const { selected, setSelected, pendingSelectionKeyRef } = useSyncedSelection(value, accessKeysToQueryParam);
+  const { selected, setSelected, pendingSelectionKeyRef, checkboxValue, checkboxKey } = useSyncedSelection(
+    value,
+    accessKeysToQueryParam,
+  );
 
   const handleChange = useCallback(
     (next: string[]) => {
@@ -26,5 +31,5 @@ export const useSyncedAccessSelection = function (
     [onChange, pendingSelectionKeyRef, setSelected],
   );
 
-  return { selected, onChange: handleChange };
+  return { selected, checkboxValue, checkboxKey, onChange: handleChange };
 };

--- a/libs/ui/src/lib/search-form/format-filter.tsx
+++ b/libs/ui/src/lib/search-form/format-filter.tsx
@@ -23,12 +23,12 @@ export type FormatFilterProps = {
 };
 
 const FormatFilter = ({ aggregation = [], value, onChange }: FormatFilterProps) => {
-  const { selected, onChange: handleChange } = useSyncedFormatSelection(value, onChange);
+  const { checkboxValue, checkboxKey, onChange: handleChange } = useSyncedFormatSelection(value, onChange);
   const fileTypeOptions = useMemo(() => buildFileTypeFilterOptions(aggregation), [aggregation]);
   const mediaFormatOptions = useMemo(() => buildMediaFormatFilterOptions(aggregation), [aggregation]);
 
-  const selectedFileTypes = useMemo(() => selected.filter(isFileTypeKey), [selected]);
-  const selectedMediaFormats = useMemo(() => selected.filter(isMediaTypeKey), [selected]);
+  const selectedFileTypes = useMemo(() => checkboxValue.filter(isFileTypeKey), [checkboxValue]);
+  const selectedMediaFormats = useMemo(() => checkboxValue.filter(isMediaTypeKey), [checkboxValue]);
 
   const handleFileTypeChange = (nextFileTypes: string[]) => {
     handleChange([...nextFileTypes, ...selectedMediaFormats]);
@@ -58,6 +58,7 @@ const FormatFilter = ({ aggregation = [], value, onChange }: FormatFilterProps) 
           <VStack>
             <Box className={styles.box}>
               <CheckboxGroup
+                key={`${checkboxKey}-media`}
                 options={mediaFormatOptions}
                 value={selectedMediaFormats}
                 onChange={handleMediaFormatChange}
@@ -74,6 +75,7 @@ const FormatFilter = ({ aggregation = [], value, onChange }: FormatFilterProps) 
           <VStack>
             <Box className={styles.box}>
               <CheckboxGroup
+                key={`${checkboxKey}-file`}
                 options={fileTypeOptions}
                 value={selectedFileTypes}
                 onChange={handleFileTypeChange}

--- a/libs/ui/src/lib/search-form/format/use-synced-selection.ts
+++ b/libs/ui/src/lib/search-form/format/use-synced-selection.ts
@@ -24,9 +24,9 @@ export const useSyncedFormatSelection = function (
 
   const handleChange = useCallback(
     (next: string[]) => {
-      setSelected(next);
       pendingSelectionKeyRef.current = formatKeysToQueryParam(next);
       onChange?.(next);
+      setSelected(next);
     },
     [onChange, pendingSelectionKeyRef, setSelected],
   );

--- a/libs/ui/src/lib/search-form/format/use-synced-selection.ts
+++ b/libs/ui/src/lib/search-form/format/use-synced-selection.ts
@@ -13,9 +13,14 @@ export const useSyncedFormatSelection = function (
   onChange?: (value: string[]) => void,
 ): {
   selected: string[];
+  checkboxValue: string[];
+  checkboxKey: string;
   onChange: (value: string[]) => void;
 } {
-  const { selected, setSelected, pendingSelectionKeyRef } = useSyncedSelection(value, formatKeysToQueryParam);
+  const { selected, setSelected, pendingSelectionKeyRef, checkboxValue, checkboxKey } = useSyncedSelection(
+    value,
+    formatKeysToQueryParam,
+  );
 
   const handleChange = useCallback(
     (next: string[]) => {
@@ -26,5 +31,5 @@ export const useSyncedFormatSelection = function (
     [onChange, pendingSelectionKeyRef, setSelected],
   );
 
-  return { selected, onChange: handleChange };
+  return { selected, checkboxValue, checkboxKey, onChange: handleChange };
 };

--- a/libs/ui/src/lib/search-form/index.tsx
+++ b/libs/ui/src/lib/search-form/index.tsx
@@ -164,13 +164,13 @@ const SearchForm = ({
 
   const navigateToSearch = useCallback(
     ({
-      orgPaths = selectedOrgPaths,
-      access = selectedAccess,
-      provenance = selectedProvenance,
-      spatial = selectedSpatial,
-      formats = selectedFormats,
-      losThemes = selectedLosThemes,
-      dataThemes = selectedDataThemes,
+      orgPaths,
+      access,
+      provenance,
+      spatial,
+      formats,
+      losThemes,
+      dataThemes,
       tab = activeTab,
     }: {
       orgPaths?: string[];
@@ -182,34 +182,34 @@ const SearchForm = ({
       dataThemes?: string[];
       tab?: SearchTabsValue;
     } = {}) => {
-      router.replace(
-        buildSearchPageUrl({
-          locale,
-          tab,
-          query: getQueryForUrl(),
-          orgPaths,
-          access,
-          provenance,
-          spatial,
-          formats,
-          losThemes,
-          dataThemes,
-        }),
-      );
+      const resolvedOrgPaths = orgPaths ?? parseOrgPathQueryParam(searchParams.get("orgPath"));
+      const resolvedAccess = access ?? parseAccessQueryParam(searchParams.get("access"));
+      const resolvedProvenance = provenance ?? parseProvenanceQueryParam(searchParams.get("provenance"));
+      const resolvedSpatial = spatial ?? parseSpatialQueryParam(searchParams.get("spatial"));
+      const resolvedFormats = formats ?? parseFormatQueryParam(searchParams.get("format"));
+      const resolvedLosThemes = losThemes ?? parseLosThemeQueryParam(searchParams.get("losTheme"));
+      const resolvedDataThemes = dataThemes ?? parseDataThemeQueryParam(searchParams.get("dataTheme"));
+
+      const nextUrl = buildSearchPageUrl({
+        locale,
+        tab,
+        query: getQueryForUrl(),
+        orgPaths: resolvedOrgPaths,
+        access: resolvedAccess,
+        provenance: resolvedProvenance,
+        spatial: resolvedSpatial,
+        formats: resolvedFormats,
+        losThemes: resolvedLosThemes,
+        dataThemes: resolvedDataThemes,
+      });
+
+      const currentQueryString = searchParams.toString();
+      const currentUrl = currentQueryString ? `${pathname}?${currentQueryString}` : pathname;
+      if (nextUrl === currentUrl) return;
+
+      router.replace(nextUrl);
     },
-    [
-      locale,
-      activeTab,
-      getQueryForUrl,
-      router,
-      selectedOrgPaths,
-      selectedAccess,
-      selectedProvenance,
-      selectedSpatial,
-      selectedFormats,
-      selectedLosThemes,
-      selectedDataThemes,
-    ],
+    [locale, activeTab, getQueryForUrl, router, searchParams, pathname],
   );
 
   const handleTabChange = useCallback(

--- a/libs/ui/src/lib/search-form/org-filter.tsx
+++ b/libs/ui/src/lib/search-form/org-filter.tsx
@@ -70,11 +70,11 @@ export type OrgFilterProps = {
 };
 
 const OrgFilter = ({ locale = "nb", aggregation = [], value, onChange }: OrgFilterProps) => {
-  const { selected, onToggle } = useSyncedOrgPathSelection(value, onChange);
+  const { checkboxValue, onToggle } = useSyncedOrgPathSelection(value, onChange);
   const labels = useOrgPathLabels(locale);
   const displayAggregation = useMemo(
-    () => enrichAggregationWithSelection(aggregation, selected),
-    [aggregation, selected],
+    () => enrichAggregationWithSelection(aggregation, checkboxValue),
+    [aggregation, checkboxValue],
   );
 
   if (displayAggregation.length === 0) return null;
@@ -84,7 +84,7 @@ const OrgFilter = ({ locale = "nb", aggregation = [], value, onChange }: OrgFilt
       aggregation={displayAggregation}
       parentKey=""
       depth={1}
-      selected={selected}
+      selected={checkboxValue}
       labels={labels}
       onToggle={onToggle}
     />

--- a/libs/ui/src/lib/search-form/org-path/use-synced-selection.ts
+++ b/libs/ui/src/lib/search-form/org-path/use-synced-selection.ts
@@ -14,9 +14,13 @@ export const useSyncedOrgPathSelection = function (
   onChange?: (value: string[]) => void,
 ): {
   selected: string[];
+  checkboxValue: string[];
   onToggle: (key: string, checked: boolean) => void;
 } {
-  const { selected, setSelected, pendingSelectionKeyRef } = useSyncedSelection(value, orgPathKeysToQueryParam);
+  const { selected, setSelected, pendingSelectionKeyRef, checkboxValue } = useSyncedSelection(
+    value,
+    orgPathKeysToQueryParam,
+  );
 
   const onToggle = useCallback(
     (key: string, checked: boolean) => {
@@ -31,5 +35,5 @@ export const useSyncedOrgPathSelection = function (
     [onChange, pendingSelectionKeyRef, setSelected],
   );
 
-  return { selected, onToggle };
+  return { selected, checkboxValue, onToggle };
 };

--- a/libs/ui/src/lib/search-form/org-path/use-synced-selection.ts
+++ b/libs/ui/src/lib/search-form/org-path/use-synced-selection.ts
@@ -27,9 +27,9 @@ export const useSyncedOrgPathSelection = function (
       let next: string[] = [];
       setSelected((currentSelected) => {
         next = computeNextOrgPathSelection(currentSelected, key, checked);
-        pendingSelectionKeyRef.current = orgPathKeysToQueryParam(next);
         return next;
       });
+      pendingSelectionKeyRef.current = orgPathKeysToQueryParam(next);
       onChange?.(next);
     },
     [onChange, pendingSelectionKeyRef, setSelected],

--- a/libs/ui/src/lib/search-form/provenance-filter.tsx
+++ b/libs/ui/src/lib/search-form/provenance-filter.tsx
@@ -14,15 +14,16 @@ export type ProvenanceFilterProps = {
 };
 
 const ProvenanceFilter = ({ aggregation = [], value, onChange }: ProvenanceFilterProps) => {
-  const { selected, onChange: handleChange } = useSyncedProvenanceSelection(value, onChange);
+  const { checkboxValue, checkboxKey, onChange: handleChange } = useSyncedProvenanceSelection(value, onChange);
   const options = useMemo(() => buildProvenanceFilterOptions(aggregation), [aggregation]);
 
   if (!shouldShowProvenanceFilter(aggregation) || options.length === 0) return null;
 
   return (
     <CheckboxGroup
+      key={checkboxKey}
       options={options}
-      value={selected}
+      value={checkboxValue}
       onChange={handleChange}
     />
   );

--- a/libs/ui/src/lib/search-form/provenance/use-synced-selection.ts
+++ b/libs/ui/src/lib/search-form/provenance/use-synced-selection.ts
@@ -24,9 +24,9 @@ export const useSyncedProvenanceSelection = function (
 
   const handleChange = useCallback(
     (next: string[]) => {
-      setSelected(next);
       pendingSelectionKeyRef.current = provenanceKeysToQueryParam(next);
       onChange?.(next);
+      setSelected(next);
     },
     [onChange, pendingSelectionKeyRef, setSelected],
   );

--- a/libs/ui/src/lib/search-form/provenance/use-synced-selection.ts
+++ b/libs/ui/src/lib/search-form/provenance/use-synced-selection.ts
@@ -13,9 +13,14 @@ export const useSyncedProvenanceSelection = function (
   onChange?: (value: string[]) => void,
 ): {
   selected: string[];
+  checkboxValue: string[];
+  checkboxKey: string;
   onChange: (value: string[]) => void;
 } {
-  const { selected, setSelected, pendingSelectionKeyRef } = useSyncedSelection(value, provenanceKeysToQueryParam);
+  const { selected, setSelected, pendingSelectionKeyRef, checkboxValue, checkboxKey } = useSyncedSelection(
+    value,
+    provenanceKeysToQueryParam,
+  );
 
   const handleChange = useCallback(
     (next: string[]) => {
@@ -26,5 +31,5 @@ export const useSyncedProvenanceSelection = function (
     [onChange, pendingSelectionKeyRef, setSelected],
   );
 
-  return { selected, onChange: handleChange };
+  return { selected, checkboxValue, checkboxKey, onChange: handleChange };
 };

--- a/libs/ui/src/lib/search-form/spatial-filter.tsx
+++ b/libs/ui/src/lib/search-form/spatial-filter.tsx
@@ -14,15 +14,16 @@ export type SpatialFilterProps = {
 };
 
 const SpatialFilter = ({ aggregation = [], value, onChange }: SpatialFilterProps) => {
-  const { selected, onChange: handleChange } = useSyncedSpatialSelection(value, onChange);
+  const { checkboxValue, checkboxKey, onChange: handleChange } = useSyncedSpatialSelection(value, onChange);
   const options = useMemo(() => buildSpatialFilterOptions(aggregation), [aggregation]);
 
   if (!shouldShowSpatialFilter(aggregation) || options.length === 0) return null;
 
   return (
     <CheckboxGroup
+      key={checkboxKey}
       options={options}
-      value={selected}
+      value={checkboxValue}
       onChange={handleChange}
     />
   );

--- a/libs/ui/src/lib/search-form/spatial/use-synced-selection.ts
+++ b/libs/ui/src/lib/search-form/spatial/use-synced-selection.ts
@@ -13,9 +13,14 @@ export const useSyncedSpatialSelection = function (
   onChange?: (value: string[]) => void,
 ): {
   selected: string[];
+  checkboxValue: string[];
+  checkboxKey: string;
   onChange: (value: string[]) => void;
 } {
-  const { selected, setSelected, pendingSelectionKeyRef } = useSyncedSelection(value, spatialKeysToQueryParam);
+  const { selected, setSelected, pendingSelectionKeyRef, checkboxValue, checkboxKey } = useSyncedSelection(
+    value,
+    spatialKeysToQueryParam,
+  );
 
   const handleChange = useCallback(
     (next: string[]) => {
@@ -26,5 +31,5 @@ export const useSyncedSpatialSelection = function (
     [onChange, pendingSelectionKeyRef, setSelected],
   );
 
-  return { selected, onChange: handleChange };
+  return { selected, checkboxValue, checkboxKey, onChange: handleChange };
 };

--- a/libs/ui/src/lib/search-form/spatial/use-synced-selection.ts
+++ b/libs/ui/src/lib/search-form/spatial/use-synced-selection.ts
@@ -24,9 +24,9 @@ export const useSyncedSpatialSelection = function (
 
   const handleChange = useCallback(
     (next: string[]) => {
-      setSelected(next);
       pendingSelectionKeyRef.current = spatialKeysToQueryParam(next);
       onChange?.(next);
+      setSelected(next);
     },
     [onChange, pendingSelectionKeyRef, setSelected],
   );

--- a/libs/ui/src/lib/search-form/theme-filter.tsx
+++ b/libs/ui/src/lib/search-form/theme-filter.tsx
@@ -32,7 +32,10 @@ const ThemeFilter = ({
   onLosThemeChange,
   onDataThemeChange,
 }: ThemeFilterProps) => {
-  const { selected, onChange: handleDataThemeChange } = useSyncedDataThemeSelection(dataThemeValue, onDataThemeChange);
+  const { checkboxValue, checkboxKey, onChange: handleDataThemeChange } = useSyncedDataThemeSelection(
+    dataThemeValue,
+    onDataThemeChange,
+  );
   const dataThemeLabels = useDataThemeLabels(locale);
   const dataThemeOptions = useMemo(
     () => buildDataThemeFilterOptions(dataThemeAggregation, dataThemeLabels),
@@ -76,8 +79,9 @@ const ThemeFilter = ({
           <VStack>
             <Box className={styles.box}>
               <CheckboxGroup
+                key={checkboxKey}
                 options={dataThemeOptions}
-                value={selected}
+                value={checkboxValue}
                 onChange={handleDataThemeChange}
               />
             </Box>

--- a/libs/ui/src/lib/search-form/theme/data-theme/use-synced-selection.ts
+++ b/libs/ui/src/lib/search-form/theme/data-theme/use-synced-selection.ts
@@ -13,9 +13,14 @@ export const useSyncedDataThemeSelection = function (
   onChange?: (value: string[]) => void,
 ): {
   selected: string[];
+  checkboxValue: string[];
+  checkboxKey: string;
   onChange: (value: string[]) => void;
 } {
-  const { selected, setSelected, pendingSelectionKeyRef } = useSyncedSelection(value, dataThemeKeysToQueryParam);
+  const { selected, setSelected, pendingSelectionKeyRef, checkboxValue, checkboxKey } = useSyncedSelection(
+    value,
+    dataThemeKeysToQueryParam,
+  );
 
   const handleChange = useCallback(
     (next: string[]) => {
@@ -26,5 +31,5 @@ export const useSyncedDataThemeSelection = function (
     [onChange, pendingSelectionKeyRef, setSelected],
   );
 
-  return { selected, onChange: handleChange };
+  return { selected, checkboxValue, checkboxKey, onChange: handleChange };
 };

--- a/libs/ui/src/lib/search-form/theme/data-theme/use-synced-selection.ts
+++ b/libs/ui/src/lib/search-form/theme/data-theme/use-synced-selection.ts
@@ -24,9 +24,9 @@ export const useSyncedDataThemeSelection = function (
 
   const handleChange = useCallback(
     (next: string[]) => {
-      setSelected(next);
       pendingSelectionKeyRef.current = dataThemeKeysToQueryParam(next);
       onChange?.(next);
+      setSelected(next);
     },
     [onChange, pendingSelectionKeyRef, setSelected],
   );

--- a/libs/ui/src/lib/search-form/theme/los-theme/los-theme-tree-filter.tsx
+++ b/libs/ui/src/lib/search-form/theme/los-theme/los-theme-tree-filter.tsx
@@ -66,11 +66,11 @@ export type LosThemeTreeFilterProps = {
 };
 
 const LosThemeTreeFilter = ({ locale = "nb", aggregation = [], value, onChange }: LosThemeTreeFilterProps) => {
-  const { selected, onToggle } = useSyncedLosThemeSelection(value, onChange);
+  const { checkboxValue, onToggle } = useSyncedLosThemeSelection(value, onChange);
   const labels = useLosThemeLabels(locale);
   const displayAggregation = useMemo(
-    () => enrichLosThemeAggregationWithSelection(aggregation, selected),
-    [aggregation, selected],
+    () => enrichLosThemeAggregationWithSelection(aggregation, checkboxValue),
+    [aggregation, checkboxValue],
   );
 
   if (displayAggregation.length === 0) return null;
@@ -80,7 +80,7 @@ const LosThemeTreeFilter = ({ locale = "nb", aggregation = [], value, onChange }
       aggregation={displayAggregation}
       parentKey=""
       depth={1}
-      selected={selected}
+      selected={checkboxValue}
       labels={labels}
       onToggle={onToggle}
     />

--- a/libs/ui/src/lib/search-form/theme/los-theme/use-synced-selection.ts
+++ b/libs/ui/src/lib/search-form/theme/los-theme/use-synced-selection.ts
@@ -27,9 +27,9 @@ export const useSyncedLosThemeSelection = function (
       let next: string[] = [];
       setSelected((currentSelected) => {
         next = computeNextLosThemeSelection(currentSelected, key, checked);
-        pendingSelectionKeyRef.current = losThemeKeysToQueryParam(next);
         return next;
       });
+      pendingSelectionKeyRef.current = losThemeKeysToQueryParam(next);
       onChange?.(next);
     },
     [onChange, pendingSelectionKeyRef, setSelected],

--- a/libs/ui/src/lib/search-form/theme/los-theme/use-synced-selection.ts
+++ b/libs/ui/src/lib/search-form/theme/los-theme/use-synced-selection.ts
@@ -14,9 +14,13 @@ export const useSyncedLosThemeSelection = function (
   onChange?: (value: string[]) => void,
 ): {
   selected: string[];
+  checkboxValue: string[];
   onToggle: (key: string, checked: boolean) => void;
 } {
-  const { selected, setSelected, pendingSelectionKeyRef } = useSyncedSelection(value, losThemeKeysToQueryParam);
+  const { selected, setSelected, pendingSelectionKeyRef, checkboxValue } = useSyncedSelection(
+    value,
+    losThemeKeysToQueryParam,
+  );
 
   const onToggle = useCallback(
     (key: string, checked: boolean) => {
@@ -31,5 +35,5 @@ export const useSyncedLosThemeSelection = function (
     [onChange, pendingSelectionKeyRef, setSelected],
   );
 
-  return { selected, onToggle };
+  return { selected, checkboxValue, onToggle };
 };

--- a/libs/ui/src/lib/search-form/use-synced-selection.ts
+++ b/libs/ui/src/lib/search-form/use-synced-selection.ts
@@ -1,13 +1,14 @@
 "use client";
 
-import { useEffect, useRef, useState, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
+import { useRef, useState, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
 
 /**
  * Core hook for URL-synced checkbox selection.
  *
- * Syncs local selection with a controlled `value` from the URL. Ignores URL
- * updates until they match the selection we just emitted, avoiding a feedback
- * loop between optimistic local state and router-driven value.
+ * Syncs local selection with a controlled `value` from the URL. While a
+ * dropdown change is in flight, keeps optimistic `selected` until the URL
+ * catches up. External URL changes (chip removal, clear all, browser
+ * navigation) sync immediately during render.
  */
 export const useSyncedSelection = function (
   value: string[] | undefined,
@@ -16,23 +17,32 @@ export const useSyncedSelection = function (
   selected: string[];
   setSelected: Dispatch<SetStateAction<string[]>>;
   pendingSelectionKeyRef: MutableRefObject<string | null>;
+  checkboxValue: string[];
+  checkboxKey: string;
 } {
   const [selected, setSelected] = useState<string[]>(value ?? []);
   const pendingSelectionKeyRef = useRef<string | null>(null);
   const valueKey = value === undefined ? undefined : serialize(value);
+  const [prevValueKey, setPrevValueKey] = useState(valueKey);
 
-  useEffect(() => {
-    if (value === undefined || valueKey === undefined) return;
+  if (value !== undefined && valueKey !== undefined && valueKey !== prevValueKey) {
+    setPrevValueKey(valueKey);
 
-    if (pendingSelectionKeyRef.current !== null) {
-      if (pendingSelectionKeyRef.current === valueKey) {
+    const pending = pendingSelectionKeyRef.current;
+    if (pending !== null && pending === valueKey) {
+      pendingSelectionKeyRef.current = null;
+    } else {
+      if (pending !== null) {
         pendingSelectionKeyRef.current = null;
       }
-      return;
+      setSelected(value);
     }
+  }
 
-    setSelected((current) => (serialize(current) === valueKey ? current : value));
-  }, [value, valueKey, serialize]);
+  const pending = pendingSelectionKeyRef.current;
+  const isOptimistic = pending !== null && valueKey !== undefined && pending !== valueKey;
+  const checkboxValue = value === undefined ? selected : isOptimistic ? selected : value;
+  const checkboxKey = value === undefined ? serialize(selected) : valueKey;
 
-  return { selected, setSelected, pendingSelectionKeyRef };
+  return { selected, setSelected, pendingSelectionKeyRef, checkboxValue, checkboxKey };
 };

--- a/libs/ui/src/lib/search-form/use-synced-selection.ts
+++ b/libs/ui/src/lib/search-form/use-synced-selection.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
+import { useEffect, useRef, useState, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
 
 /**
  * Core hook for URL-synced checkbox selection.
@@ -8,7 +8,7 @@ import { useRef, useState, type Dispatch, type MutableRefObject, type SetStateAc
  * Syncs local selection with a controlled `value` from the URL. While a
  * dropdown change is in flight, keeps optimistic `selected` until the URL
  * catches up. External URL changes (chip removal, clear all, browser
- * navigation) sync immediately during render.
+ * navigation) sync from `value` via effect.
  */
 export const useSyncedSelection = function (
   value: string[] | undefined,
@@ -23,26 +23,38 @@ export const useSyncedSelection = function (
   const [selected, setSelected] = useState<string[]>(value ?? []);
   const pendingSelectionKeyRef = useRef<string | null>(null);
   const valueKey = value === undefined ? undefined : serialize(value);
-  const [prevValueKey, setPrevValueKey] = useState(valueKey);
+  const checkboxKeyRef = useRef(valueKey ?? serialize(value ?? []));
 
-  if (value !== undefined && valueKey !== undefined && valueKey !== prevValueKey) {
-    setPrevValueKey(valueKey);
+  useEffect(() => {
+    if (value === undefined || valueKey === undefined) return;
 
     const pending = pendingSelectionKeyRef.current;
-    if (pending !== null && pending === valueKey) {
-      pendingSelectionKeyRef.current = null;
-    } else {
-      if (pending !== null) {
+    if (pending !== null) {
+      if (pending === valueKey) {
         pendingSelectionKeyRef.current = null;
+        return;
       }
-      setSelected(value);
+      pendingSelectionKeyRef.current = null;
     }
-  }
+
+    setSelected((current) => (serialize(current) === valueKey ? current : value));
+  }, [value, valueKey, serialize]);
 
   const pending = pendingSelectionKeyRef.current;
   const isOptimistic = pending !== null && valueKey !== undefined && pending !== valueKey;
   const checkboxValue = value === undefined ? selected : isOptimistic ? selected : value;
-  const checkboxKey = value === undefined ? serialize(selected) : valueKey;
 
-  return { selected, setSelected, pendingSelectionKeyRef, checkboxValue, checkboxKey };
+  if (value === undefined) {
+    checkboxKeyRef.current = serialize(selected);
+  } else if (!isOptimistic && valueKey !== undefined) {
+    checkboxKeyRef.current = valueKey;
+  }
+
+  return {
+    selected,
+    setSelected,
+    pendingSelectionKeyRef,
+    checkboxValue,
+    checkboxKey: checkboxKeyRef.current,
+  };
 };


### PR DESCRIPTION
Fikser to bugs

Fjerning av filtervalg via chips fjerna ikke alltid valget fra dropdown, oppdaterer derfor sync mellom url-verdier og dropdown-verdier

Av og til, ofte rett etter page reload, initerte ikke endring av filter en faktisk oppdatering av søkeresultat. Så ufiltrert liste ble vist med filter tilsynelatende aktivert. Var problem i hvordan den synca verdier ved render, så dårlig timing av filterendring resulterte i at det ikke ble fanga opp. Potensielt at dette er noe jeg innførte via første commit :)