### PR TITLE
feat: display language on service produces

### DIFF
--- a/apps/data-norge/src/app/components/details-page/service/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/service/index.tsx
@@ -113,6 +113,28 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
       };
     }) || [];
 
+  const producesList: DetailsEntry[] =
+    service.produces?.map((output) => {
+      const contents: ContentRow[] = [];
+      if (output.description || showEmptyRows) {
+        contents.push({
+          label: dictionaries.detailsPage.produces.description,
+          value: printLocaleValue(locale, output.description),
+        });
+      }
+      if (output.language?.length || showEmptyRows) {
+        contents.push({
+          label: dictionaries.detailsPage.produces.language,
+          value: output.language?.map((language) => printLocaleValue(locale, language.prefLabel)).filter(Boolean).join(", "),
+        });
+      }
+
+      return {
+        title: printLocaleValue(locale, output.name) || dictionaries.detailsPage.produces.nameless,
+        content: contents,
+      };
+    }) || [];
+
   return (
     <div className={styles.detailsPage}>
       <ServiceStructuredData
@@ -240,27 +262,10 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
               </Hstack>
             </Heading>
             {sumArrayLengths(service.produces) > 0 ? (
-              <Dlist>
-                {service.produces?.map((output, index) => (
-                  <Fragment key={`${output.identifier}-${index}`}>
-                    <dt className={styles.producesDt}>
-                      {printLocaleValue(locale, output.name) || dictionaries.detailsPage.produces.nameless}
-                    </dt>
-                    <dd>
-                      {printLocaleValue(locale, output.description)}
-                      {output.language?.length ? (
-                        <div className={styles.producesLanguage}>
-                          <strong>{dictionaries.detailsPage.produces.language}: </strong>
-                          {output.language
-                            .map((language) => printLocaleValue(locale, language.prefLabel))
-                            .filter(Boolean)
-                            .join(", ")}
-                        </div>
-                      ) : null}
-                    </dd>
-                  </Fragment>
-                ))}
-              </Dlist>
+              <AccordionList
+                entries={producesList}
+                noDataText={dictionaries.detailsPage.details.noData}
+              />
             ) : (
               <PlaceholderBox>{dictionaries.detailsPage.produces.placeholder}</PlaceholderBox>
             )}

--- a/apps/data-norge/src/app/components/details-page/service/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/service/index.tsx
@@ -246,7 +246,18 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
                     <dt className={styles.producesDt}>
                       {printLocaleValue(locale, output.name) || dictionaries.detailsPage.produces.nameless}
                     </dt>
-                    <dd>{printLocaleValue(locale, output.description)}</dd>
+                    <dd>
+                      {printLocaleValue(locale, output.description)}
+                      {output.language?.length ? (
+                        <div className={styles.producesLanguage}>
+                          <strong>{dictionaries.detailsPage.produces.language}: </strong>
+                          {output.language
+                            .map((language) => printLocaleValue(locale, language.prefLabel))
+                            .filter(Boolean)
+                            .join(", ")}
+                        </div>
+                      ) : null}
+                    </dd>
                   </Fragment>
                 ))}
               </Dlist>

--- a/apps/data-norge/src/app/components/details-page/service/service.module.scss
+++ b/apps/data-norge/src/app/components/details-page/service/service.module.scss
@@ -43,13 +43,3 @@
   clear: both; // for toggleButton
 }
 
-// undo element styling from Dlist
-dt.producesDt {
-  white-space: initial;
-  overflow: initial;
-  text-overflow: initial;
-}
-
-.producesLanguage {
-  margin-top: 0.5rem;
-}

--- a/apps/data-norge/src/app/components/details-page/service/service.module.scss
+++ b/apps/data-norge/src/app/components/details-page/service/service.module.scss
@@ -49,3 +49,7 @@ dt.producesDt {
   overflow: initial;
   text-overflow: initial;
 }
+
+.producesLanguage {
+  margin-top: 0.5rem;
+}

--- a/libs/localization/src/lib/locales/en/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/en/sections/details-page.ts
@@ -101,6 +101,7 @@ const detailsPage = {
     title: "Service results",
     nameless: "Nameless service result",
     placeholder: "This service has no service results.",
+    language: "Language",
   },
   apis: {
     title: "APIs providing this dataset",

--- a/libs/localization/src/lib/locales/en/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/en/sections/details-page.ts
@@ -101,6 +101,7 @@ const detailsPage = {
     title: "Service results",
     nameless: "Nameless service result",
     placeholder: "This service has no service results.",
+    description: "Description",
     language: "Language",
   },
   apis: {

--- a/libs/localization/src/lib/locales/nb/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/nb/sections/details-page.ts
@@ -101,6 +101,7 @@ const detailsPage = {
     title: "Tjenesteresultat",
     nameless: "Navnløst tjenesteresultat",
     placeholder: "Denne tjenesten har ingen tjenesteresultat.",
+    description: "Beskrivelse",
     language: "Språk",
   },
   apis: {

--- a/libs/localization/src/lib/locales/nb/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/nb/sections/details-page.ts
@@ -101,6 +101,7 @@ const detailsPage = {
     title: "Tjenesteresultat",
     nameless: "Navnløst tjenesteresultat",
     placeholder: "Denne tjenesten har ingen tjenesteresultat.",
+    language: "Språk",
   },
   apis: {
     title: "API-er som tilgjengeliggjør dette datasettet",

--- a/libs/localization/src/lib/locales/nn/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/nn/sections/details-page.ts
@@ -101,6 +101,7 @@ const detailsPage = {
     title: "Tenesteresultat",
     nameless: "Namnlaust tenesteresultat",
     placeholder: "Denne tenesta har inga tenesteresultat.",
+    description: "Beskriving",
     language: "Språk",
   },
   apis: {

--- a/libs/localization/src/lib/locales/nn/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/nn/sections/details-page.ts
@@ -101,6 +101,7 @@ const detailsPage = {
     title: "Tenesteresultat",
     nameless: "Namnlaust tenesteresultat",
     placeholder: "Denne tenesta har inga tenesteresultat.",
+    language: "Språk",
   },
   apis: {
     title: "API-ar som tilbyr dette datasettet",


### PR DESCRIPTION
# Summary

- Vis språk per tjenesteresultat på tjeneste-detaljsiden
- Legg til lokaliseringsnøkkel produces.language (nb/nn/en)