### PR TITLE
feat: show produces isPartOf datasets on service page

### DIFF
--- a/apps/data-norge/src/app/[lang]/services/[id]/[slug]/page.tsx
+++ b/apps/data-norge/src/app/[lang]/services/[id]/[slug]/page.tsx
@@ -1,4 +1,10 @@
-import { getAllCommunityTopics, getOrgLogo, getService, searchConcepts } from "@fdk-frontend/data-access/server";
+import {
+  getAllCommunityTopics,
+  getOrgLogo,
+  getService,
+  searchConcepts,
+  searchDatasets,
+} from "@fdk-frontend/data-access/server";
 import { getLocalization, type LocaleCodes } from "@fdk-frontend/localization";
 import { getSlug, printLocaleValue } from "@fdk-frontend/utils";
 import { SearchObject, type CommunityTopic, type PublicService } from "@fellesdatakatalog/types";
@@ -26,6 +32,7 @@ const DetailsPageWrapper = async (props: DetailsPageWrapperProps) => {
   let orgLogo: string | null = null;
   let communityTopics: CommunityTopic[] = [];
   let concepts: SearchObject[] = [];
+  let producesDatasets: SearchObject[] = [];
 
   try {
     service = await getService(id);
@@ -68,10 +75,23 @@ const DetailsPageWrapper = async (props: DetailsPageWrapperProps) => {
     // Fail silently
   }
 
+  try {
+    const producesDatasetUris = [
+      ...new Set((service.produces ?? []).flatMap((output) => output.isPartOf ?? [])),
+    ];
+    if (producesDatasetUris.length) {
+      const results = await searchDatasets(producesDatasetUris);
+      producesDatasets = results?.hits ?? [];
+    }
+  } catch {
+    // Fail silently
+  }
+
   return (
     <ServiceDetailsPage
       baseUri={process.env.FDK_BASE_URI as string}
       concepts={concepts}
+      producesDatasets={producesDatasets}
       service={service}
       orgLogo={orgLogo}
       communityTopics={communityTopics}

--- a/apps/data-norge/src/app/components/details-page/service/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/service/index.tsx
@@ -35,6 +35,7 @@ export type ServiceDetailsPageType = {
   communityTopics?: CommunityTopic[];
   communityBaseUri: string;
   concepts: SearchObject[];
+  producesDatasets: SearchObject[];
   defaultActiveTab?: string;
   dictionaries: {
     common: Localization;
@@ -52,6 +53,7 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
     communityTopics,
     communityBaseUri,
     concepts,
+    producesDatasets,
     defaultActiveTab,
     dictionaries,
     locale,
@@ -126,6 +128,17 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
         contents.push({
           label: dictionaries.detailsPage.produces.language,
           value: output.language?.map((language) => printLocaleValue(locale, language.prefLabel)).filter(Boolean).join(", "),
+        });
+      }
+      if (output.isPartOf?.length || showEmptyRows) {
+        contents.push({
+          label: dictionaries.detailsPage.produces.isPartOf,
+          value: output.isPartOf
+            ?.map((uri) => {
+              const dataset = producesDatasets.find((hit) => hit.uri === uri);
+              return printLocaleValue(locale, dataset?.title) || uri;
+            })
+            .join(", "),
         });
       }
 

--- a/apps/data-norge/src/app/components/details-page/service/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/service/index.tsx
@@ -130,7 +130,7 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
           value: output.language?.map((language) => printLocaleValue(locale, language.prefLabel)).filter(Boolean).join(", "),
         });
       }
-      if (output.isPartOf?.length || showEmptyRows) {
+      if (output.isPartOf?.length) {
         contents.push({
           label: dictionaries.detailsPage.produces.isPartOf,
           value: output.isPartOf

--- a/libs/localization/src/lib/locales/en/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/en/sections/details-page.ts
@@ -103,6 +103,7 @@ const detailsPage = {
     placeholder: "This service has no service results.",
     description: "Description",
     language: "Language",
+    isPartOf: "Is part of",
   },
   apis: {
     title: "APIs providing this dataset",

--- a/libs/localization/src/lib/locales/nb/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/nb/sections/details-page.ts
@@ -103,6 +103,7 @@ const detailsPage = {
     placeholder: "Denne tjenesten har ingen tjenesteresultat.",
     description: "Beskrivelse",
     language: "Språk",
+    isPartOf: "Er del av",
   },
   apis: {
     title: "API-er som tilgjengeliggjør dette datasettet",

--- a/libs/localization/src/lib/locales/nn/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/nn/sections/details-page.ts
@@ -103,6 +103,7 @@ const detailsPage = {
     placeholder: "Denne tenesta har inga tenesteresultat.",
     description: "Beskriving",
     language: "Språk",
+    isPartOf: "Er del av",
   },
   apis: {
     title: "API-ar som tilbyr dette datasettet",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@digdir/designsystemet-css": "^1.13.0",
     "@digdir/designsystemet-react": "^1.13.0",
     "@digdir/designsystemet-theme": "^1.11.0",
-    "@fellesdatakatalog/types": "^1.0.24",
+    "@fellesdatakatalog/types": "^1.0.26",
     "@fellesdatakatalog/ui": "^1.0.34",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,12 +2130,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fellesdatakatalog/types@npm:^1.0.24":
-  version: 1.0.24
-  resolution: "@fellesdatakatalog/types@npm:1.0.24"
+"@fellesdatakatalog/types@npm:^1.0.26":
+  version: 1.0.26
+  resolution: "@fellesdatakatalog/types@npm:1.0.26"
   dependencies:
     typescript: "npm:^6.0.2"
-  checksum: 10c0/b3c9272554118cdd01924b8abf08c7308b153061417ea75faf2b97cff1c7f1dd7aa05547b527ab5295619268606c13892020ec59044cfabddba81d1800906b41
+  checksum: 10c0/bca4d7e93f342a4dbf2a29b7bb6808ad343389c9e7265292cc964c40326397b6a517c43a71a65be559760e18a96399c1b4296655cff6098e8a73e4edd7b58aab
   languageName: node
   linkType: hard
 
@@ -11155,7 +11155,7 @@ __metadata:
     "@digdir/designsystemet-css": "npm:^1.13.0"
     "@digdir/designsystemet-react": "npm:^1.13.0"
     "@digdir/designsystemet-theme": "npm:^1.11.0"
-    "@fellesdatakatalog/types": "npm:^1.0.24"
+    "@fellesdatakatalog/types": "npm:^1.0.26"
     "@fellesdatakatalog/ui": "npm:^1.0.34"
     "@mdx-js/loader": "npm:^3.1.1"
     "@mdx-js/react": "npm:^3.1.1"


### PR DESCRIPTION
# Summary

- Vis er del av (dct:isPartOf) datasett per tjenesteresultat på tjeneste-detaljsiden, i AccordionList (samme komponent som dokumentasjonskrav)
- Slå opp datasett-URI-ene server-side (searchDatasets) for visningsnavn
- Bump @fellesdatakatalog/types til ^1.0.26 (isPartOf på PublicServiceOutput)
- Ny lokaliseringsnøkkel produces.isPartOf (nb/nn/en)