### PR TITLE
feat: show produces type on service page

### DIFF
--- a/apps/data-norge/src/app/components/details-page/service/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/service/index.tsx
@@ -141,6 +141,12 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
             .join(", "),
         });
       }
+      if (output.type?.length || showEmptyRows) {
+        contents.push({
+          label: dictionaries.detailsPage.produces.type,
+          value: output.type?.map((type) => printLocaleValue(locale, type.prefLabel)).filter(Boolean).join(", "),
+        });
+      }
 
       return {
         title: printLocaleValue(locale, output.name) || dictionaries.detailsPage.produces.nameless,

--- a/apps/data-norge/src/app/components/details-page/service/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/service/index.tsx
@@ -141,7 +141,7 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
             .join(", "),
         });
       }
-      if (output.type?.length || showEmptyRows) {
+      if (output.type?.length) {
         contents.push({
           label: dictionaries.detailsPage.produces.type,
           value: output.type?.map((type) => printLocaleValue(locale, type.prefLabel)).filter(Boolean).join(", "),

--- a/apps/data-norge/src/app/components/details-page/service/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/service/index.tsx
@@ -124,7 +124,7 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
           value: printLocaleValue(locale, output.description),
         });
       }
-      if (output.language?.length || showEmptyRows) {
+      if (output.language?.length) {
         contents.push({
           label: dictionaries.detailsPage.produces.language,
           value: output.language?.map((language) => printLocaleValue(locale, language.prefLabel)).filter(Boolean).join(", "),

--- a/libs/localization/src/lib/locales/en/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/en/sections/details-page.ts
@@ -104,6 +104,7 @@ const detailsPage = {
     description: "Description",
     language: "Language",
     isPartOf: "Is part of",
+    type: "Type",
   },
   apis: {
     title: "APIs providing this dataset",

--- a/libs/localization/src/lib/locales/nb/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/nb/sections/details-page.ts
@@ -104,6 +104,7 @@ const detailsPage = {
     description: "Beskrivelse",
     language: "Språk",
     isPartOf: "Er del av",
+    type: "Type",
   },
   apis: {
     title: "API-er som tilgjengeliggjør dette datasettet",

--- a/libs/localization/src/lib/locales/nn/sections/details-page.ts
+++ b/libs/localization/src/lib/locales/nn/sections/details-page.ts
@@ -104,6 +104,7 @@ const detailsPage = {
     description: "Beskriving",
     language: "Språk",
     isPartOf: "Er del av",
+    type: "Type",
   },
   apis: {
     title: "API-ar som tilbyr dette datasettet",


### PR DESCRIPTION
# Summary

- Vis type (dct:type) per tjenesteresultat på tjeneste-detaljsiden, i AccordionList
- Ny lokaliseringsnøkkel produces.type (nb/nn/en)
