### PR TITLE
Feat/ksk/search page styling

### DIFF
--- a/apps/data-norge/src/app/components/search-page/index.tsx
+++ b/apps/data-norge/src/app/components/search-page/index.tsx
@@ -11,11 +11,11 @@ import {
 import { type SearchObject } from "@fellesdatakatalog/types";
 import { Alert, Heading } from "@digdir/designsystemet-react";
 import { type LlmSearchResponse } from "@fdk-frontend/data-access";
-import { getPrimarySearchTypeForTab, type SearchSetSegment } from "@fdk-frontend/ui/search-tabs/search-tab-config";
+import { type SearchSetSegment } from "@fdk-frontend/ui/search-tabs/search-tab-config";
 import { mapLlmHitToSearchObject } from "../../[lang]/search/search-tab-helpers";
 
 import styles from "./search-page.module.scss";
-import { computeSearchPageDisplay, getDisplayCount, resolveSearchTabBadgeCounts } from "./search-page-display";
+import { computeSearchPageDisplay, resolveSearchTabBadgeCounts } from "./search-page-display";
 import SearchPagination from "./search-pagination";
 import SearchResultsSkeleton from "./search-results-skeleton";
 import { type DocsSearchResult } from "./search-page-types";
@@ -58,7 +58,6 @@ const SearchPage = ({
   llmLoading = false,
 }: SearchPageProps) => {
   const loc = getLocalization(lang);
-  const commonDictionary = loc.common;
   const dictionary = loc.searchPage;
 
   const breadcrumbLabel = query
@@ -66,7 +65,7 @@ const SearchPage = ({
     : dictionary.breadcrumb.label;
   const breadcrumbList = [{ text: breadcrumbLabel }];
 
-  const { llmHitsCount, docsHitsCount, badgeCounts, totalResults } = computeSearchPageDisplay({
+  const { llmHitsCount, docsHitsCount, badgeCounts } = computeSearchPageDisplay({
     activeEntityTab,
     llmResults,
     docsResults,
@@ -80,21 +79,6 @@ const SearchPage = ({
   });
   const entityTabHits = entityTabResults?.hits ?? [];
   const entityTabPage = entityTabResults?.page;
-  const displayCount = getDisplayCount({
-    activeEntityTab,
-    llmHitsCount,
-    filteredHits: entityTabHits,
-    tabBadgeCounts,
-    entityTabPage,
-  });
-
-  const mainHeading = entityLoading
-    ? query
-      ? interpolate(dictionary.heading.loadingWithQuery, { query })
-      : dictionary.heading.loading
-    : query
-      ? interpolate(dictionary.heading.resultsWithQuery, { count: totalResults, query })
-      : interpolate(dictionary.heading.results, { count: totalResults });
 
   return (
     <div className={styles.searchPage}>
@@ -103,7 +87,6 @@ const SearchPage = ({
         breadcrumbList={breadcrumbList}
       />
       <div className={styles.mainContent}>
-        <Heading data-size="md">{mainHeading}</Heading>
         <SearchForm
           lang={lang}
           activeEntityTab={activeEntityTab}
@@ -164,13 +147,6 @@ const SearchPage = ({
             <div className={styles.resultsSection}>
               {entityTabHits.length > 0 ? (
                 <>
-                  <Heading
-                    data-size="sm"
-                    className={styles.sectionHeading}
-                  >
-                    {commonDictionary.entities[getPrimarySearchTypeForTab(activeEntityTab) ?? ""]}{" "}
-                    {interpolate(dictionary.entitySearch.hitsCountLabel, { count: displayCount })}
-                  </Heading>
                   <ul className="fdk-box-list">
                     {entityTabHits.map((hit: SearchObject, i: number) => {
                       const hitId = hit.id ?? hit.uri ?? "";

--- a/libs/localization/src/lib/locales/en/sections/common.ts
+++ b/libs/localization/src/lib/locales/en/sections/common.ts
@@ -5,6 +5,7 @@ const common = {
   },
   footer: {
     digdirCredit: "a service from",
+    languageToggleGroup: "select language",
   },
   header: {
     findDataButton: "Find data",

--- a/libs/localization/src/lib/locales/en/sections/search-page.ts
+++ b/libs/localization/src/lib/locales/en/sections/search-page.ts
@@ -37,6 +37,7 @@ const searchPage = {
   },
   searchTabs: {
     loadingBadgeAriaLabel: "Loading result count",
+    searchTabsAriaLabel: "choose search type",
     ki: "AI",
     datasets: "Datasets",
     dataServices: "APIs",

--- a/libs/localization/src/lib/locales/nb/sections/common.ts
+++ b/libs/localization/src/lib/locales/nb/sections/common.ts
@@ -5,6 +5,7 @@ const common = {
   },
   footer: {
     digdirCredit: "en tjeneste fra",
+    languageToggleGroup: "velg språk",
   },
   header: {
     findDataButton: "Finn data",

--- a/libs/localization/src/lib/locales/nb/sections/common.ts
+++ b/libs/localization/src/lib/locales/nb/sections/common.ts
@@ -130,13 +130,13 @@ const common = {
     DATASET: "Datasett",
     DATA_SERVICE: "API",
     CONCEPT: "Begrep",
-    INFORMATION_MODEL: "Informasjonsmodeller",
-    SERVICE: "Tjenester",
-    EVENT: "Hendelser",
+    INFORMATION_MODEL: "Informasjonsmodell",
+    SERVICE: "Tjeneste",
+    EVENT: "Hendelse",
   },
   specializedServices: {
     service: "Tjenester",
-    publicService: "Offentlig tjenester",
+    publicService: "Offentlig tjeneste",
   },
   teaser: {
     openData: "Åpne data",

--- a/libs/localization/src/lib/locales/nb/sections/search-page.ts
+++ b/libs/localization/src/lib/locales/nb/sections/search-page.ts
@@ -37,6 +37,7 @@ const searchPage = {
   },
   searchTabs: {
     loadingBadgeAriaLabel: "Laster antall treff",
+    searchTabsAriaLabel: "velg søketype",
     ki: "KI",
     datasets: "Datasett",
     dataServices: "API",

--- a/libs/localization/src/lib/locales/nn/sections/common.ts
+++ b/libs/localization/src/lib/locales/nn/sections/common.ts
@@ -5,6 +5,7 @@ const common = {
   },
   footer: {
     digdirCredit: "ei teneste frå",
+    languageToggleGroup: "vel språk",
   },
   header: {
     findDataButton: "Finn data",

--- a/libs/localization/src/lib/locales/nn/sections/common.ts
+++ b/libs/localization/src/lib/locales/nn/sections/common.ts
@@ -131,12 +131,12 @@ const common = {
     DATA_SERVICE: "API",
     CONCEPT: "Begrep",
     INFORMATION_MODEL: "Informasjonsmodell",
-    SERVICE: "Tjenestar",
-    EVENT: "Hendelsar",
+    SERVICE: "Teneste",
+    EVENT: "Hending",
   },
   specializedServices: {
-    service: "Tjenestar",
-    publicService: "Offentlege tenester",
+    service: "Tenestar",
+    publicService: "Offentleg teneste",
   },
   teaser: {
     openData: "Opne data",

--- a/libs/localization/src/lib/locales/nn/sections/search-page.ts
+++ b/libs/localization/src/lib/locales/nn/sections/search-page.ts
@@ -37,6 +37,7 @@ const searchPage = {
   },
   searchTabs: {
     loadingBadgeAriaLabel: "Lastar antal treff",
+    searchTabsAriaLabel: "vel søkjetype",
     ki: "KI",
     datasets: "Datasett",
     dataServices: "API",

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.module.scss
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.module.scss
@@ -2,7 +2,7 @@
   margin: 0 -2rem;
   background: #f8f8f8;
 
-  @media (max-width: 400px) {
+  @media (max-width: 500px) {
     margin: 0 -1.5rem;
   }
 }

--- a/libs/ui/src/lib/entity-teaser/index.tsx
+++ b/libs/ui/src/lib/entity-teaser/index.tsx
@@ -44,73 +44,75 @@ const EntityTeaser = ({ entity, className, locale, llm, ...rest }: EntityTeaserP
       {...rest}
     >
       <CardBlock>
-        {entity ? (
-          <div>
-            <OrgLogo
-              className={styles.orgLogo}
-              orgNr={entity.organization?.id}
-              title={printLocaleValue(locale, entity.organization?.prefLabel)}
-            />
-            <Heading>
-              <Link href={`/${locale}/${setFragments[entity.searchType]}/${entity.id}`}>
-                {printLocaleValue(locale, entity.title)}
-              </Link>
-            </Heading>
-          </div>
-        ) : (
-          <HStack>
-            <Skeleton
-              width="1.5rem"
-              height="1.5rem"
-              variant="circle"
-            />
-            <Heading data-size="sm">
+        <div className={styles.entityHeader}>
+          {entity ? (
+            <div>
+              <OrgLogo
+                className={styles.orgLogo}
+                orgNr={entity.organization?.id}
+                title={printLocaleValue(locale, entity.organization?.prefLabel)}
+              />
+              <Heading>
+                <Link href={`/${locale}/${setFragments[entity.searchType]}/${entity.id}`}>
+                  {printLocaleValue(locale, entity.title)}
+                </Link>
+              </Heading>
+            </div>
+          ) : (
+            <HStack>
               <Skeleton
-                variant="rectangle"
+                width="1.5rem"
                 height="1.5rem"
-                width="300px"
+                variant="circle"
               />
-            </Heading>
-          </HStack>
-        )}
-        {entity ? (
-          <TagList>
-            <Tag
-              data-color="info"
-              data-size="sm"
-            >
-              <Link href={`/${locale}/search/${setFragments[entity.searchType]}`}>
-                {entity.searchType === EntityType.PUBLIC_SERVICE &&
-                (entity.specializedType as string | null) === "publicService"
-                  ? localization.specializedServices.publicService
-                  : localization.entities[entity.searchType]}
-              </Link>
-            </Tag>
-            {(entity.searchType === "DATASET" || entity.searchType === "DATA_SERVICE") && (
-              <AccessLevelTag
-                data-size="sm"
-                accessCode={entity.accessRights?.code as AccessRightsCodes}
-                nonInteractive
-                locale={locale}
-              />
-            )}
-            {entity.isOpenData && (
+              <Heading data-size="sm">
+                <Skeleton
+                  variant="rectangle"
+                  height="1.5rem"
+                  width="300px"
+                />
+              </Heading>
+            </HStack>
+          )}
+          {entity ? (
+            <TagList>
               <Tag
-                data-color="success"
+                data-color="info"
                 data-size="sm"
               >
-                {localization.teaser.openData}
+                <Link href={`/${locale}/search/${setFragments[entity.searchType]}`}>
+                  {entity.searchType === EntityType.PUBLIC_SERVICE &&
+                  (entity.specializedType as string | null) === "publicService"
+                    ? localization.specializedServices.publicService
+                    : localization.entities[entity.searchType]}
+                </Link>
               </Tag>
-            )}
-          </TagList>
-        ) : (
-          <div style={{ marginTop: "0.5rem", lineHeight: "1.75rem" }}>
-            <Skeleton
-              variant="text"
-              width={300}
-            />
-          </div>
-        )}
+              {(entity.searchType === "DATASET" || entity.searchType === "DATA_SERVICE") && (
+                <AccessLevelTag
+                  data-size="sm"
+                  accessCode={entity.accessRights?.code as AccessRightsCodes}
+                  nonInteractive
+                  locale={locale}
+                />
+              )}
+              {entity.isOpenData && (
+                <Tag
+                  data-color="success"
+                  data-size="sm"
+                >
+                  {localization.teaser.openData}
+                </Tag>
+              )}
+            </TagList>
+          ) : (
+            <div style={{ marginTop: "0.5rem", lineHeight: "1.75rem" }}>
+              <Skeleton
+                variant="text"
+                width={300}
+              />
+            </div>
+          )}
+        </div>
         {entity && (
           <Paragraph className={styles.description}>
             {desc ? (desc.length > 500 ? `${desc.slice(0, 500)}...` : desc) : localization.teaser.missingDescription}

--- a/libs/ui/src/lib/entity-teaser/styles.module.scss
+++ b/libs/ui/src/lib/entity-teaser/styles.module.scss
@@ -33,6 +33,9 @@
 .orgName {
   font-size: 0.9em;
   opacity: 0.75;
+  @media (max-width: 600px) {
+    display: none;
+  }
 }
 
 .orgButton {
@@ -43,4 +46,24 @@
 .keywords {
   font-size: 0.9em;
   opacity: 0.75;
+}
+
+.entityHeader {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-size-3);
+  @media (max-width: 600px) {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+}
+
+.description {
+  @media (max-width: 600px) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 3; // how many lines to show
+    -webkit-box-orient: vertical;
+  }
 }

--- a/libs/ui/src/lib/footer/index.tsx
+++ b/libs/ui/src/lib/footer/index.tsx
@@ -25,7 +25,7 @@ const Footer = ({ locale }: FooterProps) => {
             initial: "show",
           }}
         />
-        <LanguageSwitcher locale={locale} />
+        <LanguageSwitcher loc={locale} />
       </div>
       <div className={styles.bottom}>
         <div className={styles.bottomInner}>

--- a/libs/ui/src/lib/footer/index.tsx
+++ b/libs/ui/src/lib/footer/index.tsx
@@ -25,7 +25,7 @@ const Footer = ({ locale }: FooterProps) => {
             initial: "show",
           }}
         />
-        <LanguageSwitcher />
+        <LanguageSwitcher locale={locale} />
       </div>
       <div className={styles.bottom}>
         <div className={styles.bottomInner}>

--- a/libs/ui/src/lib/header/header.module.scss
+++ b/libs/ui/src/lib/header/header.module.scss
@@ -150,6 +150,7 @@
 
     @media (max-width: 650px) {
       padding: 1rem 1.5rem;
+      gap: 2rem;
 
       .headerToolbar {
         a:last-child {

--- a/libs/ui/src/lib/language-switcher/index.tsx
+++ b/libs/ui/src/lib/language-switcher/index.tsx
@@ -4,11 +4,15 @@ import { useRouter, usePathname } from "next/navigation";
 import React from "react";
 import { ToggleGroup } from "@digdir/designsystemet-react";
 
-import { i18n, LocaleCodes } from "@fdk-frontend/localization";
+import { getLocalization, i18n, LocaleCodes } from "@fdk-frontend/localization";
 
 import styles from "./language-switcher.module.scss";
 
-const LanguageSwitcher = (props: React.HTMLAttributes<HTMLElement>) => {
+type LanguageSwitcherProps = {
+  locale?: LocaleCodes;
+} & React.HTMLAttributes<HTMLDivElement>;
+
+const LanguageSwitcher = ({ locale, ...props }: LanguageSwitcherProps) => {
   const router = useRouter();
   const pathName = usePathname();
 
@@ -23,15 +27,13 @@ const LanguageSwitcher = (props: React.HTMLAttributes<HTMLElement>) => {
   };
 
   return (
-    <nav
-      aria-label="Select language"
-      {...props}
-    >
+    <nav {...props}>
       <ToggleGroup
         className={styles.languageSwitcher}
         defaultValue={defaultCode}
         onChange={(code) => onLanguageSelect(code as LocaleCodes)}
         data-size="sm"
+        data-toggle-group={locale ? getLocalization(locale).common.footer.languageToggleGroup : "select language"}
       >
         {i18n.locales.map((locale) => (
           <ToggleGroup.Item

--- a/libs/ui/src/lib/language-switcher/index.tsx
+++ b/libs/ui/src/lib/language-switcher/index.tsx
@@ -9,10 +9,10 @@ import { getLocalization, i18n, LocaleCodes } from "@fdk-frontend/localization";
 import styles from "./language-switcher.module.scss";
 
 type LanguageSwitcherProps = {
-  locale?: LocaleCodes;
+  loc?: LocaleCodes;
 } & React.HTMLAttributes<HTMLDivElement>;
 
-const LanguageSwitcher = ({ locale, ...props }: LanguageSwitcherProps) => {
+const LanguageSwitcher = ({ loc, ...props }: LanguageSwitcherProps) => {
   const router = useRouter();
   const pathName = usePathname();
 
@@ -33,7 +33,7 @@ const LanguageSwitcher = ({ locale, ...props }: LanguageSwitcherProps) => {
         defaultValue={defaultCode}
         onChange={(code) => onLanguageSelect(code as LocaleCodes)}
         data-size="sm"
-        data-toggle-group={locale ? getLocalization(locale).common.footer.languageToggleGroup : "select language"}
+        data-toggle-group={loc ? getLocalization(loc).common.footer.languageToggleGroup : "select language"}
       >
         {i18n.locales.map((locale) => (
           <ToggleGroup.Item

--- a/libs/ui/src/lib/language-switcher/language-switcher.stories.tsx
+++ b/libs/ui/src/lib/language-switcher/language-switcher.stories.tsx
@@ -22,7 +22,7 @@ export const Primary: Story = {
         <LanguageSwitcher />
       </div>
       <div style={{ background: "black", padding: "1rem" }}>
-        <LanguageSwitcher inverted />
+        <LanguageSwitcher />
       </div>
     </>
   ),

--- a/libs/ui/src/lib/logo/logo.module.scss
+++ b/libs/ui/src/lib/logo/logo.module.scss
@@ -17,6 +17,9 @@
     font-size: 1.33333rem;
     color: currentcolor;
     line-height: 1.33333rem;
+    @media (max-width: 650px) {
+      display: none;
+    }
   }
 }
 

--- a/libs/ui/src/lib/search-form/index.tsx
+++ b/libs/ui/src/lib/search-form/index.tsx
@@ -475,107 +475,109 @@ const SearchForm = ({
               </HStack>
             )}
             <HStack className={styles.chipsToolbar}>
-              <FilterChips
-                selectedFilters={selectedOrgPaths}
-                onChipRemove={handleOrgPathsChange}
-                chipLabels={orgPathLabels}
-              />
-              <FilterChips
-                selectedFilters={selectedLosThemes}
-                onChipRemove={handleLosThemeChange}
-                chipLabels={losThemeLabels}
-              />
-              <FilterChips
-                selectedFilters={selectedDataThemes}
-                onChipRemove={handleDataThemeChange}
-                chipLabels={dataThemeLabels}
-              />
-              <FilterChips
-                selectedFilters={selectedAccess}
-                onChipRemove={handleAccessChange}
-                chipLabels={accessLabels}
-              />
-              <FilterChips
-                selectedFilters={selectedFormats}
-                onChipRemove={handleFormatChange}
-                chipLabels={formatLabels}
-              />
-              <FilterChips
-                selectedFilters={selectedSpatial}
-                onChipRemove={handleSpatialChange}
-                chipLabels={spatialLabels}
-              />
-              <FilterChips
-                selectedFilters={selectedProvenance}
-                onChipRemove={handleProvenanceChange}
-                chipLabels={provenanceLabels}
-              />
-              {hasFilter && (
-                <Chip.Button
-                  onClick={() => clearFilters()}
-                  data-size="sm"
-                >
-                  {dict.searchForm.clearAllFilters}
-                </Chip.Button>
-              )}
               {showEntityToolbar && (
-                <HStack className={styles.rightToolbar}>
-                  <Dropdown.TriggerContext>
-                    <Dropdown.Trigger
+                <>
+                  <FilterChips
+                    selectedFilters={selectedOrgPaths}
+                    onChipRemove={handleOrgPathsChange}
+                    chipLabels={orgPathLabels}
+                  />
+                  <FilterChips
+                    selectedFilters={selectedLosThemes}
+                    onChipRemove={handleLosThemeChange}
+                    chipLabels={losThemeLabels}
+                  />
+                  <FilterChips
+                    selectedFilters={selectedDataThemes}
+                    onChipRemove={handleDataThemeChange}
+                    chipLabels={dataThemeLabels}
+                  />
+                  <FilterChips
+                    selectedFilters={selectedAccess}
+                    onChipRemove={handleAccessChange}
+                    chipLabels={accessLabels}
+                  />
+                  <FilterChips
+                    selectedFilters={selectedFormats}
+                    onChipRemove={handleFormatChange}
+                    chipLabels={formatLabels}
+                  />
+                  <FilterChips
+                    selectedFilters={selectedSpatial}
+                    onChipRemove={handleSpatialChange}
+                    chipLabels={spatialLabels}
+                  />
+                  <FilterChips
+                    selectedFilters={selectedProvenance}
+                    onChipRemove={handleProvenanceChange}
+                    chipLabels={provenanceLabels}
+                  />
+                  {hasFilter && (
+                    <Chip.Button
+                      onClick={() => clearFilters()}
                       data-size="sm"
-                      variant="tertiary"
                     >
-                      {interpolate(dict.searchForm.resultsCount, { count: selectedSize })} <ChevronDownIcon />
-                    </Dropdown.Trigger>
-                    <Dropdown
-                      className={styles.orderbyDropdown}
-                      placement="bottom-end"
-                      data-size="sm"
-                    >
-                      <Dropdown.List>
-                        {SEARCH_PAGE_SIZE_OPTIONS.map((option) => (
-                          <Dropdown.Item key={option}>
-                            <Dropdown.Button
-                              aria-pressed={selectedSize === option}
-                              onClick={() => navigateToSearch({ size: option })}
-                            >
-                              {selectedSize === option && <CheckmarkIcon />}
-                              {interpolate(dict.searchForm.resultsPerPage, { count: option })}
-                            </Dropdown.Button>
-                          </Dropdown.Item>
-                        ))}
-                      </Dropdown.List>
-                    </Dropdown>
-                  </Dropdown.TriggerContext>
-                  <Dropdown.TriggerContext>
-                    <Dropdown.Trigger
-                      data-size="sm"
-                      variant="tertiary"
-                    >
-                      <SortDownIcon />
-                      {getSortLabel(selectedSort)}
-                    </Dropdown.Trigger>
-                    <Dropdown
-                      className={styles.orderbyDropdown}
-                      placement="bottom-end"
-                      data-size="sm"
-                    >
-                      <Dropdown.List>
-                        {SEARCH_SORT_OPTION_LIST.map((option) => (
-                          <Dropdown.Item key={option}>
-                            <Dropdown.Button
-                              aria-pressed={selectedSort === option}
-                              onClick={() => handleSortChange(option)}
-                            >
-                              {selectedSort === option && <CheckmarkIcon />}
-                              {getSortLabel(option)}
-                            </Dropdown.Button>
-                          </Dropdown.Item>
-                        ))}
-                      </Dropdown.List>
-                    </Dropdown>
-                  </Dropdown.TriggerContext>
-                </HStack>
+                      {dict.searchForm.clearAllFilters}
+                    </Chip.Button>
+                  )}
+                  <HStack className={styles.rightToolbar}>
+                    <Dropdown.TriggerContext>
+                      <Dropdown.Trigger
+                        data-size="sm"
+                        variant="tertiary"
+                      >
+                        {interpolate(dict.searchForm.resultsCount, { count: selectedSize })} <ChevronDownIcon />
+                      </Dropdown.Trigger>
+                      <Dropdown
+                        className={styles.orderbyDropdown}
+                        placement="bottom-end"
+                        data-size="sm"
+                      >
+                        <Dropdown.List>
+                          {SEARCH_PAGE_SIZE_OPTIONS.map((option) => (
+                            <Dropdown.Item key={option}>
+                              <Dropdown.Button
+                                aria-pressed={selectedSize === option}
+                                onClick={() => navigateToSearch({ size: option })}
+                              >
+                                {selectedSize === option && <CheckmarkIcon />}
+                                {interpolate(dict.searchForm.resultsPerPage, { count: option })}
+                              </Dropdown.Button>
+                            </Dropdown.Item>
+                          ))}
+                        </Dropdown.List>
+                      </Dropdown>
+                    </Dropdown.TriggerContext>
+                    <Dropdown.TriggerContext>
+                      <Dropdown.Trigger
+                        data-size="sm"
+                        variant="tertiary"
+                      >
+                        <SortDownIcon />
+                        {getSortLabel(selectedSort)}
+                      </Dropdown.Trigger>
+                      <Dropdown
+                        className={styles.orderbyDropdown}
+                        placement="bottom-end"
+                        data-size="sm"
+                      >
+                        <Dropdown.List>
+                          {SEARCH_SORT_OPTION_LIST.map((option) => (
+                            <Dropdown.Item key={option}>
+                              <Dropdown.Button
+                                aria-pressed={selectedSort === option}
+                                onClick={() => handleSortChange(option)}
+                              >
+                                {selectedSort === option && <CheckmarkIcon />}
+                                {getSortLabel(option)}
+                              </Dropdown.Button>
+                            </Dropdown.Item>
+                          ))}
+                        </Dropdown.List>
+                      </Dropdown>
+                    </Dropdown.TriggerContext>
+                  </HStack>
+                </>
               )}
             </HStack>
           </>

--- a/libs/ui/src/lib/search-input/search-input.module.scss
+++ b/libs/ui/src/lib/search-input/search-input.module.scss
@@ -39,5 +39,8 @@
     position: absolute;
     right: 1rem;
     pointer-events: none;
+    @media (max-width: 800px) {
+      display: none;
+    }
   }
 }

--- a/libs/ui/src/lib/search-tabs/index.tsx
+++ b/libs/ui/src/lib/search-tabs/index.tsx
@@ -92,6 +92,7 @@ const SearchTabs = ({ value, defaultValue = "ki", onChange, badgeCounts = {}, lo
       }}
       className={styles.tabs}
       variant="secondary"
+      data-toggle-group={dict.searchTabsAriaLabel}
     >
       {localizedItems.map((item) => {
         const count = badgeCounts[item.value];

--- a/libs/ui/src/lib/search-tabs/styles.module.scss
+++ b/libs/ui/src/lib/search-tabs/styles.module.scss
@@ -24,6 +24,7 @@
 
     @media (max-width: 460px) {
       width: stretch;
+      flex: none;
     }
   }
 

--- a/libs/ui/src/lib/search-tabs/styles.module.scss
+++ b/libs/ui/src/lib/search-tabs/styles.module.scss
@@ -6,11 +6,11 @@
   display: flex;
   flex-wrap: wrap;
   flex-direction: row;
-  justify-content: space-between;
 
   .tab {
     display: flex;
     flex-direction: column;
+    flex: 1;
     padding-bottom: 0;
     padding-top: var(--ds-size-1);
     gap: var(--ds-size-2);


### PR DESCRIPTION
Several small fixes to search page

- Fix the width on individual tabs in toggle group
- Add names to toggle group (fixes accessibility + excessive console warnings)
- Remove redundant page headings
- Hide filter chips when user is on AI or documentation tabs
- Responsive design for search page
  - Reduce enitity teaser (resource preview) size for small viewports (mobile units). Hide publisher name, limit how much of the description is shown, display tags on the same line as title, etc.
  - Adjust header styling for different breakpoints. Hide keyboard-specific information on smaller viewports, only show data.norge logo (not data.norge.no text) on very narrow viewports
- Fix some vocabulary texts




