### PR TITLE
feat: add transportportal profile header and menu

### DIFF
--- a/apps/data-norge/public/content/om-transportportal/hjelp-til-a-registrere/hjelp-til-a-registrere.en.mdx
+++ b/apps/data-norge/public/content/om-transportportal/hjelp-til-a-registrere/hjelp-til-a-registrere.en.mdx
@@ -1,0 +1,30 @@
+---
+title: Help with registration
+description: How to get access to your organisation's catalogues in the Norwegian data catalogue (FDK) and sign in to the registration solution.
+---
+
+# Help with registration
+
+## How to get access to your catalogues
+[Here you can find your organisation's catalogues in the Norwegian data catalogue (FDK).](https://registrering.fellesdatakatalog.digdir.no)
+
+You must be signed in to view and edit content. You can choose between two sign-in methods:
+
+- Sign in with ID-porten/Altinn
+- Sign in with Felles brukerhåndtering (Common user management)
+
+## Sign in with ID-porten/Altinn
+To get read, write or organisation administrator access to the registration solution in the Norwegian data catalogue (FDK), you must have the correct authorisation in Altinn. Access is granted through the rights "data.norge.no: Read access to the registration solution", "data.norge.no: Write access to the registration and harvesting solution" or "data.norge.no: Organisation administrator access to the registration and harvesting solution".
+
+You can find more information about the access levels and how authorisations are assigned in Altinn's form overview for the Data.norge.no service:
+https://info.altinn.no/skjemaoversikt/digitaliseringsdirektoratet/Data.norge.no
+
+## Sign in with Felles brukerhåndtering
+You can get read access to the FDK registration solution by registering with the Norwegian Digitalisation Agency's Felles brukerhåndtering (Common user management). We use your email address to identify you and connect you to the right organisation, so please use your work address when you register. Since Felles brukerhåndtering uses the email address as the username, we recommend that you enable two-factor authentication after you have registered. You do this from the [«Authenticator»](https://user.difi.no/auth/realms/difi/account/totp) menu option in Felles brukerhåndtering.
+
+You will receive an email from Felles brukerhåndtering after registering. Follow the instructions in the email.
+
+Once you have completed sign-in, you will have read access to your organisation's catalogues. If you need write access to the catalogues, we ask you to use Altinn.
+
+## Terms of use
+If this is the first time your organisation uses FDK, someone in the organisation with organisation administrator access to the FDK registration solution must accept the [terms of use](https://data.norge.no/publishing/terms-of-use) on behalf of the organisation. If they are not accepted, no catalogues will be created for your organisation.

--- a/apps/data-norge/public/content/om-transportportal/hjelp-til-a-registrere/hjelp-til-a-registrere.nb.mdx
+++ b/apps/data-norge/public/content/om-transportportal/hjelp-til-a-registrere/hjelp-til-a-registrere.nb.mdx
@@ -1,0 +1,30 @@
+---
+title: Hjelp til å registrere
+description: Slik får du tilgang til katalogene til virksomheten din i Felles datakatalog og logger inn i registreringsløsningen.
+---
+
+# Hjelp til å registrere
+
+## Hvordan få tilgang til dine kataloger
+[Her finner du katalogene til din virksomhet i Felles datakatalog (FDK).](https://registrering.fellesdatakatalog.digdir.no)
+
+For å se og redigere innhold må du være innlogget. Du kan velge mellom to innloggingsmetoder:
+
+- Innlogging med ID-porten/Altinn
+- Innlogging med Felles brukerhåndtering
+
+## Innlogging med ID-porten/Altinn
+For å få lese-, skrive- eller virksomhetsadministratortilgang til registreringsløsningen i Felles datakatalog (FDK), må du ha riktig fullmakt i Altinn. Tilgangen gis gjennom rettighetene «data.norge.no: Lesetilgang til registreringsløsningen», «data.norge.no: Skrivetilgang til registrerings- og høsteløsningen» eller «data.norge.no: Virksomhetsadministratortilgang til registrerings- og høsteløsningen».
+
+Du finner mer informasjon om tilgangene og om hvordan fullmakter tildeles på Altinns skjemaoversikt for tjenesten Data.norge.no:
+https://info.altinn.no/skjemaoversikt/digitaliseringsdirektoratet/Data.norge.no
+
+## Innlogging med Felles brukerhåndtering
+Du kan få lesetilgang til registreringsløsningen til FDK ved å registrere deg på Digitaliseringsdirektoratets Felles brukerhåndtering. Vi bruker e-postadressen til å identifisere deg og knytte deg til rett organisasjon. Bruk derfor jobbadressen din når du registrerer deg. Da Felles brukerhåndtering bruker e-postadresse som brukernavn, anbefaler vi at du aktiverer tofaktorautentisering etter at du har registrert deg. Dette gjør du fra menyvalget [«Autentikator»](https://user.difi.no/auth/realms/difi/account/totp) i Felles brukerhåndtering.
+
+Du vil motta en e-post fra Felles brukerhåndtering etter registering. Følg instruksen i e-posten.
+
+Etter å ha fullført innloggingen, vil du ha lesetilgang til katalogene til din virksomhet. Ved behov for skrivetilgang til katalogene ber vi deg om å benytte Altinn.
+
+## Bruksvilkår
+Hvis det er første gang din virksomhet tar i bruk FDK må noen i virksomheten som har virksomhetsadministratortilgang til registreringsløsningen til FDK akseptere [bruksvilkår](https://data.norge.no/publishing/terms-of-use) på vegne av virksomheten. Hvis de ikke aksepteres, vil det ikke opprettes kataloger for din virksomhet.

--- a/apps/data-norge/public/content/om-transportportal/hjelp-til-a-registrere/hjelp-til-a-registrere.nn.mdx
+++ b/apps/data-norge/public/content/om-transportportal/hjelp-til-a-registrere/hjelp-til-a-registrere.nn.mdx
@@ -1,0 +1,30 @@
+---
+title: Hjelp til å registrere
+description: Slik får du tilgang til katalogane til verksemda di i Felles datakatalog og loggar inn i registreringsløysinga.
+---
+
+# Hjelp til å registrere
+
+## Korleis få tilgang til katalogane dine
+[Her finn du katalogane til verksemda di i Felles datakatalog (FDK).](https://registrering.fellesdatakatalog.digdir.no)
+
+For å sjå og redigere innhald må du vere innlogga. Du kan velje mellom to innloggingsmetodar:
+
+- Innlogging med ID-porten/Altinn
+- Innlogging med Felles brukarhandtering
+
+## Innlogging med ID-porten/Altinn
+For å få lese-, skrive- eller verksemdsadministratortilgang til registreringsløysinga i Felles datakatalog (FDK), må du ha rett fullmakt i Altinn. Tilgangen blir gitt gjennom rettane «data.norge.no: Lesetilgang til registreringsløysinga», «data.norge.no: Skrivetilgang til registrerings- og haustingsløysinga» eller «data.norge.no: Verksemdsadministratortilgang til registrerings- og haustingsløysinga».
+
+Du finn meir informasjon om tilgangane og om korleis fullmakter blir tildelte på Altinn si skjemaoversikt for tenesta Data.norge.no:
+https://info.altinn.no/skjemaoversikt/digitaliseringsdirektoratet/Data.norge.no
+
+## Innlogging med Felles brukarhandtering
+Du kan få lesetilgang til registreringsløysinga til FDK ved å registrere deg på Digitaliseringsdirektoratet si Felles brukarhandtering. Vi bruker e-postadressa til å identifisere deg og knyte deg til rett organisasjon. Bruk difor jobbadressa di når du registrerer deg. Sidan Felles brukarhandtering bruker e-postadresse som brukarnamn, tilrår vi at du aktiverer tofaktorautentisering etter at du har registrert deg. Dette gjer du frå menyvalet [«Autentikator»](https://user.difi.no/auth/realms/difi/account/totp) i Felles brukarhandtering.
+
+Du vil få ein e-post frå Felles brukarhandtering etter registrering. Følg instruksen i e-posten.
+
+Etter å ha fullført innlogginga, vil du ha lesetilgang til katalogane til verksemda di. Ved behov for skrivetilgang til katalogane ber vi deg om å bruke Altinn.
+
+## Bruksvilkår
+Dersom det er første gong verksemda di tek i bruk FDK, må nokon i verksemda som har verksemdsadministratortilgang til registreringsløysinga til FDK akseptere [bruksvilkår](https://data.norge.no/publishing/terms-of-use) på vegner av verksemda. Dersom dei ikkje blir aksepterte, vil det ikkje bli oppretta katalogar for verksemda di.

--- a/apps/data-norge/src/app/[lang]/about/layout.tsx
+++ b/apps/data-norge/src/app/[lang]/about/layout.tsx
@@ -1,4 +1,4 @@
-import { NormalLayout } from "@fdk-frontend/ui";
+import SiteLayout from "../../components/site-layout";
 import { PropsWithChildren } from "react";
 import { LocaleCodes } from "@fdk-frontend/localization";
 
@@ -12,7 +12,7 @@ const AboutLayout = async ({
   params: Promise<{ lang: string }>;
 }) => {
   const typedParams = params as Promise<{ lang: LocaleCodes }>;
-  return <NormalLayout params={typedParams}>{children}</NormalLayout>;
+  return <SiteLayout params={typedParams}>{children}</SiteLayout>;
 };
 
 export default AboutLayout;

--- a/apps/data-norge/src/app/[lang]/contact/layout.tsx
+++ b/apps/data-norge/src/app/[lang]/contact/layout.tsx
@@ -1,4 +1,4 @@
-import { NormalLayout } from "@fdk-frontend/ui";
+import SiteLayout from "../../components/site-layout";
 import { PropsWithChildren } from "react";
 import { LocaleCodes } from "@fdk-frontend/localization";
 
@@ -12,7 +12,7 @@ const ContactLayout = async ({
   params: Promise<{ lang: string }>;
 }) => {
   const typedParams = params as Promise<{ lang: LocaleCodes }>;
-  return <NormalLayout params={typedParams}>{children}</NormalLayout>;
+  return <SiteLayout params={typedParams}>{children}</SiteLayout>;
 };
 
 export default ContactLayout;

--- a/apps/data-norge/src/app/[lang]/data-hunter/layout.tsx
+++ b/apps/data-norge/src/app/[lang]/data-hunter/layout.tsx
@@ -1,4 +1,4 @@
-import { NormalLayout } from "@fdk-frontend/ui";
+import SiteLayout from "../../components/site-layout";
 import { PropsWithChildren } from "react";
 import { LocaleCodes } from "@fdk-frontend/localization";
 
@@ -12,7 +12,7 @@ const DataHunterLayout = async ({
   params: Promise<{ lang: string }>;
 }) => {
   const typedParams = params as Promise<{ lang: LocaleCodes }>;
-  return <NormalLayout params={typedParams}>{children}</NormalLayout>;
+  return <SiteLayout params={typedParams}>{children}</SiteLayout>;
 };
 
 export default DataHunterLayout;

--- a/apps/data-norge/src/app/[lang]/data-services/[id]/layout.tsx
+++ b/apps/data-norge/src/app/[lang]/data-services/[id]/layout.tsx
@@ -1,4 +1,4 @@
-import { NormalLayout } from "@fdk-frontend/ui";
+import SiteLayout from "../../../components/site-layout";
 import { PropsWithChildren } from "react";
 import { LocaleCodes } from "@fdk-frontend/localization";
 
@@ -12,7 +12,7 @@ const DataServiceLayout = async ({
   params: Promise<{ lang: string; id: string }>;
 }) => {
   const typedParams = params as Promise<{ lang: LocaleCodes; id: string }>;
-  return <NormalLayout params={typedParams}>{children}</NormalLayout>;
+  return <SiteLayout params={typedParams}>{children}</SiteLayout>;
 };
 
 export default DataServiceLayout;

--- a/apps/data-norge/src/app/[lang]/datasets/[id]/layout.tsx
+++ b/apps/data-norge/src/app/[lang]/datasets/[id]/layout.tsx
@@ -1,4 +1,4 @@
-import { NormalLayout } from "@fdk-frontend/ui";
+import SiteLayout from "../../../components/site-layout";
 import { PropsWithChildren } from "react";
 import { LocaleCodes } from "@fdk-frontend/localization";
 
@@ -12,7 +12,7 @@ const DatasetLayout = async ({
   params: Promise<{ lang: string; id: string }>;
 }) => {
   const typedParams = params as Promise<{ lang: LocaleCodes; id: string }>;
-  return <NormalLayout params={typedParams}>{children}</NormalLayout>;
+  return <SiteLayout params={typedParams}>{children}</SiteLayout>;
 };
 
 export default DatasetLayout;

--- a/apps/data-norge/src/app/[lang]/docs/layout.tsx
+++ b/apps/data-norge/src/app/[lang]/docs/layout.tsx
@@ -1,4 +1,4 @@
-import { NormalLayout } from "@fdk-frontend/ui";
+import SiteLayout from "../../components/site-layout";
 import { PropsWithChildren } from "react";
 import { LocaleCodes } from "@fdk-frontend/localization";
 
@@ -12,7 +12,7 @@ const DocsLayout = async ({
   params: Promise<{ lang: string }>;
 }) => {
   const typedParams = params as Promise<{ lang: LocaleCodes }>;
-  return <NormalLayout params={typedParams}>{children}</NormalLayout>;
+  return <SiteLayout params={typedParams}>{children}</SiteLayout>;
 };
 
 export default DocsLayout;

--- a/apps/data-norge/src/app/[lang]/om-transportportal/layout.tsx
+++ b/apps/data-norge/src/app/[lang]/om-transportportal/layout.tsx
@@ -1,4 +1,4 @@
-import { NormalLayout } from "@fdk-frontend/ui";
+import SiteLayout from "../../components/site-layout";
 import { PropsWithChildren } from "react";
 import { LocaleCodes } from "@fdk-frontend/localization";
 
@@ -12,7 +12,7 @@ const TransportportalLayout = async ({
   params: Promise<{ lang: string }>;
 }) => {
   const typedParams = params as Promise<{ lang: LocaleCodes }>;
-  return <NormalLayout params={typedParams}>{children}</NormalLayout>;
+  return <SiteLayout params={typedParams}>{children}</SiteLayout>;
 };
 
 export default TransportportalLayout;

--- a/apps/data-norge/src/app/[lang]/page.tsx
+++ b/apps/data-norge/src/app/[lang]/page.tsx
@@ -3,6 +3,7 @@ import { type Metadata } from "next";
 import { unstable_noStore as noStore } from "next/cache";
 import { type Locale, getLocalization } from "@fdk-frontend/localization";
 import { Header, Footer } from "@fdk-frontend/ui";
+import { getProfile } from "@fdk-frontend/utils/server";
 import { FrontpageBanner } from "../components/frontpage/frontpage-banner";
 import { ShareDataBanner } from "../components/frontpage/share-data-banner";
 import CatalogsBanner from "../components/frontpage/catalogs-banner";
@@ -23,12 +24,14 @@ const Frontpage = async (props: FrontpageProps) => {
 
   const loc = getLocalization(params.lang);
   const frontpageDictionary = loc.frontpage;
+  const profile = await getProfile();
 
   return (
     <>
       <Header
         locale={params.lang}
         frontpage
+        profile={profile}
       />
       <main id="main">
         <FrontpageBanner

--- a/apps/data-norge/src/app/[lang]/search/layout.tsx
+++ b/apps/data-norge/src/app/[lang]/search/layout.tsx
@@ -1,4 +1,4 @@
-import { NormalLayout } from "@fdk-frontend/ui";
+import SiteLayout from "../../components/site-layout";
 import { type LocaleCodes } from "@fdk-frontend/localization";
 import SearchPageClient from "../../components/search-page/search-page-client";
 
@@ -9,9 +9,9 @@ const SearchLayout = async ({ params }: { params: Promise<{ lang: string }> }) =
   const resolved = await params;
   const locale = (resolved.lang ?? "nb") as LocaleCodes;
   return (
-    <NormalLayout params={Promise.resolve({ lang: locale })}>
+    <SiteLayout params={Promise.resolve({ lang: locale })}>
       <SearchPageClient lang={locale} />
-    </NormalLayout>
+    </SiteLayout>
   );
 };
 

--- a/apps/data-norge/src/app/[lang]/services/[id]/layout.tsx
+++ b/apps/data-norge/src/app/[lang]/services/[id]/layout.tsx
@@ -1,4 +1,4 @@
-import { NormalLayout } from "@fdk-frontend/ui";
+import SiteLayout from "../../../components/site-layout";
 import { PropsWithChildren } from "react";
 import { LocaleCodes } from "@fdk-frontend/localization";
 
@@ -12,7 +12,7 @@ const ServiceLayout = async ({
   params: Promise<{ lang: string; id: string }>;
 }) => {
   const typedParams = params as Promise<{ lang: LocaleCodes; id: string }>;
-  return <NormalLayout params={typedParams}>{children}</NormalLayout>;
+  return <SiteLayout params={typedParams}>{children}</SiteLayout>;
 };
 
 export default ServiceLayout;

--- a/apps/data-norge/src/app/[lang]/sparql/layout.tsx
+++ b/apps/data-norge/src/app/[lang]/sparql/layout.tsx
@@ -1,4 +1,4 @@
-import { NormalLayout } from "@fdk-frontend/ui";
+import SiteLayout from "../../components/site-layout";
 import { PropsWithChildren } from "react";
 import { LocaleCodes } from "@fdk-frontend/localization";
 
@@ -12,7 +12,7 @@ const SparqlLayout = async ({
   params: Promise<{ lang: string }>;
 }) => {
   const typedParams = params as Promise<{ lang: LocaleCodes }>;
-  return <NormalLayout params={typedParams}>{children}</NormalLayout>;
+  return <SiteLayout params={typedParams}>{children}</SiteLayout>;
 };
 
 export default SparqlLayout;

--- a/apps/data-norge/src/app/[lang]/technical/layout.tsx
+++ b/apps/data-norge/src/app/[lang]/technical/layout.tsx
@@ -1,4 +1,4 @@
-import { NormalLayout } from "@fdk-frontend/ui";
+import SiteLayout from "../../components/site-layout";
 import { PropsWithChildren } from "react";
 import { LocaleCodes } from "@fdk-frontend/localization";
 
@@ -12,7 +12,7 @@ const TechnicalLayout = async ({
   params: Promise<{ lang: string }>;
 }) => {
   const typedParams = params as Promise<{ lang: LocaleCodes }>;
-  return <NormalLayout params={typedParams}>{children}</NormalLayout>;
+  return <SiteLayout params={typedParams}>{children}</SiteLayout>;
 };
 
 export default TechnicalLayout;

--- a/apps/data-norge/src/app/[lang]/validator/layout.tsx
+++ b/apps/data-norge/src/app/[lang]/validator/layout.tsx
@@ -1,4 +1,4 @@
-import { NormalLayout } from "@fdk-frontend/ui";
+import SiteLayout from "../../components/site-layout";
 import { PropsWithChildren } from "react";
 import { LocaleCodes } from "@fdk-frontend/localization";
 
@@ -12,7 +12,7 @@ const ValidatorLayout = async ({
   params: Promise<{ lang: string }>;
 }) => {
   const typedParams = params as Promise<{ lang: LocaleCodes }>;
-  return <NormalLayout params={typedParams}>{children}</NormalLayout>;
+  return <SiteLayout params={typedParams}>{children}</SiteLayout>;
 };
 
 export default ValidatorLayout;

--- a/apps/data-norge/src/app/components/site-layout/index.tsx
+++ b/apps/data-norge/src/app/components/site-layout/index.tsx
@@ -1,0 +1,23 @@
+import { PropsWithChildren } from "react";
+import { NormalLayout } from "@fdk-frontend/ui";
+import { LocaleCodes } from "@fdk-frontend/localization";
+import { getProfile } from "@fdk-frontend/utils/server";
+
+type SiteLayoutProps = PropsWithChildren & {
+  params: Promise<{ lang: LocaleCodes }>;
+};
+
+const SiteLayout = async ({ children, params }: SiteLayoutProps) => {
+  const profile = await getProfile();
+
+  return (
+    <NormalLayout
+      params={params}
+      profile={profile}
+    >
+      {children}
+    </NormalLayout>
+  );
+};
+
+export default SiteLayout;

--- a/deploy/base/data-norge-frontend/data-norge-frontend-deployment.yaml
+++ b/deploy/base/data-norge-frontend/data-norge-frontend-deployment.yaml
@@ -129,3 +129,5 @@ spec:
                   key: ORGANIZATION_CATALOG_BASE_URI
             - name: SEARCH_PROTOTYPE_ENABLED
               value: "false"
+            - name: TRANSPORTPORTAL_HOSTS
+              value: "data.transportportal.no,transportportal.no"

--- a/deploy/staging/data-norge-frontend/env.yaml
+++ b/deploy/staging/data-norge-frontend/env.yaml
@@ -11,3 +11,5 @@ spec:
           env:
             - name: SEARCH_PROTOTYPE_ENABLED
               value: "true"
+            - name: TRANSPORTPORTAL_HOSTS
+              value: "nap.staging.fellesdatakatalog.digdir.no"

--- a/libs/localization/src/lib/locales/en/sections/common.ts
+++ b/libs/localization/src/lib/locales/en/sections/common.ts
@@ -12,6 +12,7 @@ const common = {
     menuButton: "Menu",
     shareDataButton: "Share data",
     skipToMain: "Skip to main content",
+    transportportalTagline: "National access point for road and transport data",
     alert: {
       message: "Planned maintenance Tuesday 6PM to 11PM.",
       linkText: "Read more at Datalandsbyen",
@@ -19,6 +20,21 @@ const common = {
   },
   mainMenu: {
     label: "Main menu",
+    transportportal: {
+      heading: "About Transportportal.no",
+      legalHeading: "Legal",
+      links: {
+        generalInfo: "General information",
+        rolesResponsibilities: "Roles and responsibilities",
+        itsDirective: "The ITS Directive and regulations",
+        news: "News",
+        offerData: "Offer data",
+        declarationOfCompliance: "Declaration of compliance",
+        registrationHelp: "Help with registration",
+        reports: "Reports",
+        community: "Datalandsbyen",
+      },
+    },
     about: {
       heading: "About data.norge.no",
       links: {

--- a/libs/localization/src/lib/locales/en/sections/docs.ts
+++ b/libs/localization/src/lib/locales/en/sections/docs.ts
@@ -6,6 +6,7 @@ const docs = {
     "/om-transportportal/nyheter": "News",
     "/om-transportportal/tilby-data": "Offer data",
     "/om-transportportal/samsvarserklaering": "Declaration of compliance",
+    "/om-transportportal/hjelp-til-a-registrere": "Help with registration",
     "/about": "About us",
     "/docs/catalogs": "Data catalogs",
     "/docs/catalogs/datasets": "Datasets",

--- a/libs/localization/src/lib/locales/nb/sections/common.ts
+++ b/libs/localization/src/lib/locales/nb/sections/common.ts
@@ -12,6 +12,7 @@ const common = {
     menuButton: "Meny",
     shareDataButton: "Del data",
     skipToMain: "Hopp til hovedinnhold",
+    transportportalTagline: "Nasjonalt tilgangspunkt for veg- og transportdata",
     alert: {
       message: "Planlagt vedlikehold tirsdag kl. 18:00–23:00.",
       linkText: "Les mer på Datalandsbyen",
@@ -19,6 +20,21 @@ const common = {
   },
   mainMenu: {
     label: "Hovedmeny",
+    transportportal: {
+      heading: "Om Transportportal.no",
+      legalHeading: "Juridisk",
+      links: {
+        generalInfo: "Generell informasjon",
+        rolesResponsibilities: "Roller og ansvar",
+        itsDirective: "ITS-direktivet og forordninger",
+        news: "Nyheter",
+        offerData: "Tilby data",
+        declarationOfCompliance: "Samsvarserklæring",
+        registrationHelp: "Hjelp til å registrere",
+        reports: "Rapporter",
+        community: "Datalandsbyen",
+      },
+    },
     about: {
       heading: "Om data.norge.no",
       links: {

--- a/libs/localization/src/lib/locales/nb/sections/docs.ts
+++ b/libs/localization/src/lib/locales/nb/sections/docs.ts
@@ -6,6 +6,7 @@ const docs = {
     "/om-transportportal/nyheter": "Nyheter",
     "/om-transportportal/tilby-data": "Tilby data",
     "/om-transportportal/samsvarserklaering": "Samsvarserklæring",
+    "/om-transportportal/hjelp-til-a-registrere": "Hjelp til å registrere",
     "/about": "Om oss",
     "/contact": "Kontakt oss",
     "/docs": "Brukerveiledning",

--- a/libs/localization/src/lib/locales/nn/sections/common.ts
+++ b/libs/localization/src/lib/locales/nn/sections/common.ts
@@ -12,6 +12,7 @@ const common = {
     menuButton: "Meny",
     shareDataButton: "Del data",
     skipToMain: "Hopp til hovudinnhald",
+    transportportalTagline: "Nasjonalt tilgangspunkt for veg- og transportdata",
     alert: {
       message: "Planlagt vedlikehald tysdag kl. 18:00–23:00.",
       linkText: "Les meir på Datalandsbyen",
@@ -19,6 +20,21 @@ const common = {
   },
   mainMenu: {
     label: "Hovudmeny",
+    transportportal: {
+      heading: "Om Transportportal.no",
+      legalHeading: "Juridisk",
+      links: {
+        generalInfo: "Generell informasjon",
+        rolesResponsibilities: "Roller og ansvar",
+        itsDirective: "ITS-direktivet og forordningar",
+        news: "Nyheiter",
+        offerData: "Tilby data",
+        declarationOfCompliance: "Samsvarserklæring",
+        registrationHelp: "Hjelp til å registrere",
+        reports: "Rapportar",
+        community: "Datalandsbyen",
+      },
+    },
     about: {
       heading: "Om data.norge.no",
       links: {

--- a/libs/localization/src/lib/locales/nn/sections/docs.ts
+++ b/libs/localization/src/lib/locales/nn/sections/docs.ts
@@ -6,6 +6,7 @@ const docs = {
     "/om-transportportal/nyheter": "Nyheiter",
     "/om-transportportal/tilby-data": "Tilby data",
     "/om-transportportal/samsvarserklaering": "Samsvarserklæring",
+    "/om-transportportal/hjelp-til-a-registrere": "Hjelp til å registrere",
     "/about": "Om oss",
     "/docs/catalogs": "Datakatalogar",
     "/docs/catalogs/datasets": "Datasett",

--- a/libs/ui/src/lib/header/header.module.scss
+++ b/libs/ui/src/lib/header/header.module.scss
@@ -31,6 +31,34 @@
     }
   }
 
+  &[data-profile="transportportal"] {
+    .headerInner {
+      background: #444f55;
+
+      .headerLogo:not(:hover) {
+        color: white !important;
+      }
+
+      .headerToolbar {
+        :global(.ds-button) {
+          color: white !important;
+
+          &:last-child {
+            color: white !important;
+
+            &:focus-visible,
+            &:not(:hover):not(:active) {
+              background: var(--fdk-color-blue);
+            }
+            &:hover {
+              background: var(--fdk-color-blue-dark);
+            }
+          }
+        }
+      }
+    }
+  }
+
   &.frontpageHeader {
     + main {
       padding-top: 0;

--- a/libs/ui/src/lib/header/index.tsx
+++ b/libs/ui/src/lib/header/index.tsx
@@ -10,15 +10,18 @@ import MainMenu from "../main-menu";
 import SearchInput from "../search-input";
 import styles from "./header.module.scss";
 
+export type HeaderProfile = "default" | "transportportal";
+
 export type HeaderProps = {
   locale: LocaleCodes;
   frontpage?: boolean;
   showSearchInput?: boolean;
+  profile?: HeaderProfile;
 };
 
 const MotionDiv: ForwardRefComponent<any, any> = motion.div;
 
-const Header = ({ locale, frontpage, showSearchInput }: HeaderProps) => {
+const Header = ({ locale, frontpage, showSearchInput, profile = "default" }: HeaderProps) => {
   const dictionary = getLocalization(locale).common;
   const headerRef = useRef<HTMLDivElement>(null);
   const [sticky, setSticky] = useState(false);
@@ -87,6 +90,7 @@ const Header = ({ locale, frontpage, showSearchInput }: HeaderProps) => {
       })}
       ref={headerRef}
       data-color-scheme={!showMenu && frontpage ? "dark" : "light"}
+      data-profile={profile}
     >
       <div
         className={cn(styles.headerOuter, {
@@ -124,6 +128,8 @@ const Header = ({ locale, frontpage, showSearchInput }: HeaderProps) => {
           <LogoLink
             className={styles.headerLogo}
             href={`/${locale}`}
+            profile={profile}
+            tagline={profile === "transportportal" ? dictionary.header.transportportalTagline : undefined}
           />
           {showSearchInput ? (
             <SearchInput
@@ -176,7 +182,10 @@ const Header = ({ locale, frontpage, showSearchInput }: HeaderProps) => {
               initial="hidden"
               animate="show"
             >
-              <MainMenu locale={locale} />
+              <MainMenu
+                locale={locale}
+                profile={profile}
+              />
             </MotionDiv>
           </div>
         )}

--- a/libs/ui/src/lib/layouts/header-layout/index.tsx
+++ b/libs/ui/src/lib/layouts/header-layout/index.tsx
@@ -2,13 +2,14 @@ import { PropsWithChildren } from "react";
 
 import Header, { type HeaderProps } from "../../header";
 
-const HeaderLayout = ({ children, locale, frontpage, showSearchInput }: HeaderProps & PropsWithChildren) => {
+const HeaderLayout = ({ children, locale, frontpage, showSearchInput, profile }: HeaderProps & PropsWithChildren) => {
   return (
     <>
       <Header
         locale={locale}
         frontpage={frontpage}
         showSearchInput={showSearchInput}
+        profile={profile}
       />
       {children}
     </>

--- a/libs/ui/src/lib/layouts/normal-layout/index.tsx
+++ b/libs/ui/src/lib/layouts/normal-layout/index.tsx
@@ -3,8 +3,13 @@ import { type RootLayoutProps } from "../root-layout";
 import HeaderLayout from "../header-layout";
 import FooterLayout from "../footer-layout";
 import FeedbackBanner from "../../feedback-banner";
+import { type HeaderProfile } from "../../header";
 
-const NormalLayout = async ({ children, params }: PropsWithChildren & RootLayoutProps) => {
+type NormalLayoutProps = RootLayoutProps & {
+  profile?: HeaderProfile;
+};
+
+const NormalLayout = async ({ children, params, profile }: PropsWithChildren & NormalLayoutProps) => {
   const { lang } = await params;
   const communityBaseUri = process.env.FDK_COMMUNITY_BASE_URI;
   const showSearchInput = process.env.SEARCH_PROTOTYPE_ENABLED === "true";
@@ -13,6 +18,7 @@ const NormalLayout = async ({ children, params }: PropsWithChildren & RootLayout
     <HeaderLayout
       locale={lang}
       showSearchInput={showSearchInput}
+      profile={profile}
     >
       <FooterLayout locale={lang}>
         <main id="main">

--- a/libs/ui/src/lib/logo/index.tsx
+++ b/libs/ui/src/lib/logo/index.tsx
@@ -8,25 +8,41 @@ import DpgBadge from "../core/svg/dpg-badge";
 
 import styles from "./logo.module.scss";
 
-const Logo = () => (
-  <div className={styles.logo}>
-    <DigdirEmblem />
-    <span>data.norge.no</span>
-  </div>
-);
+export type LogoProfile = "default" | "transportportal";
+
+export type LogoProps = {
+  profile?: LogoProfile;
+  tagline?: string;
+};
+
+const Logo = ({ profile = "default", tagline }: LogoProps) =>
+  profile === "transportportal" ? (
+    <div className={styles.transportportalLogo}>
+      <span className={styles.transportportalWordmark}>Transportportal.no</span>
+      {tagline ? <span className={styles.transportportalTagline}>{tagline}</span> : null}
+    </div>
+  ) : (
+    <div className={styles.logo}>
+      <DigdirEmblem />
+      <span>data.norge.no</span>
+    </div>
+  );
 
 export type LogoLinkProps = {
   baseUri?: string;
-};
+} & LogoProps;
 
-const LogoLink = ({ className, ...rest }: LogoLinkProps & Omit<LinkProps, "children">) => (
+const LogoLink = ({ className, profile, tagline, ...rest }: LogoLinkProps & Omit<LinkProps, "children">) => (
   <Link
     className={cn(styles.logoLink, "ds-button", className)}
     data-size="sm"
     data-variant="tertiary"
     {...rest}
   >
-    <Logo />
+    <Logo
+      profile={profile}
+      tagline={tagline}
+    />
   </Link>
 );
 

--- a/libs/ui/src/lib/logo/logo.module.scss
+++ b/libs/ui/src/lib/logo/logo.module.scss
@@ -39,3 +39,28 @@
   margin: -0.5rem;
   border-radius: 0.25rem;
 }
+
+.transportportalLogo {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.1rem;
+  line-height: 1.15;
+}
+
+.transportportalWordmark {
+  font-size: 1.33333rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.01em;
+  color: #58b02c;
+}
+
+.transportportalTagline {
+  font-size: 0.8125rem;
+  color: currentcolor;
+
+  @media (max-width: 650px) {
+    display: none;
+  }
+}

--- a/libs/ui/src/lib/main-menu/data/index.ts
+++ b/libs/ui/src/lib/main-menu/data/index.ts
@@ -1,6 +1,65 @@
 import { type Localization } from "@fdk-frontend/localization";
 
 const getMainMenuData = (dictionary: Localization, locale: string) => ({
+  transportportal: [
+    {
+      title: dictionary.mainMenu.transportportal.links.generalInfo,
+      href: `/${locale}/om-transportportal`,
+    },
+    {
+      title: dictionary.mainMenu.transportportal.links.rolesResponsibilities,
+      href: `/${locale}/om-transportportal/roller-og-ansvar`,
+    },
+    {
+      title: dictionary.mainMenu.transportportal.links.itsDirective,
+      href: `/${locale}/om-transportportal/its-direktiv-og-forordninger`,
+    },
+    {
+      title: dictionary.mainMenu.transportportal.links.news,
+      href: `/${locale}/om-transportportal/nyheter`,
+    },
+    {
+      title: dictionary.mainMenu.transportportal.links.offerData,
+      href: `/${locale}/om-transportportal/tilby-data`,
+    },
+  ],
+  transportportalHelp: [
+    {
+      title: dictionary.mainMenu.transportportal.links.registrationHelp,
+      href: `/${locale}/om-transportportal/hjelp-til-a-registrere`,
+    },
+    {
+      title: dictionary.mainMenu.transportportal.links.reports,
+      href: `https://transportportal.no/reports`,
+      external: true,
+    },
+    {
+      title: dictionary.mainMenu.transportportal.links.community,
+      href: `https://datalandsbyen.norge.no`,
+      external: true,
+    },
+  ],
+  transportportalLegal: [
+    {
+      title: dictionary.mainMenu.transportportal.links.declarationOfCompliance,
+      href: `/${locale}/om-transportportal/samsvarserklaering`,
+    },
+    {
+      title: dictionary.mainMenu.about.links.a11yStatement,
+      href: `https://uustatus.no/nb/erklaringer/publisert/8020b962-b706-4cdf-ab8b-cdb5f480a696`,
+      external: true,
+    },
+    {
+      title: dictionary.mainMenu.about.links.privacyPolicy,
+      href: `https://www.digdir.no/digdir/personvernerklaering/706`,
+      external: true,
+    },
+    {
+      title: dictionary.mainMenu.about.links.cookiePolicy,
+      href: `https://www.digdir.no/digdir/informasjonskapsler/707`,
+      external: true,
+    },
+  ],
   catalogs: [
     {
       key: "datasets",

--- a/libs/ui/src/lib/main-menu/index.tsx
+++ b/libs/ui/src/lib/main-menu/index.tsx
@@ -12,12 +12,13 @@ import getMainMenuData from "./data";
 
 type MainMenuProps = React.HTMLAttributes<HTMLDivElement> & {
   locale: LocaleCodes;
+  profile?: "default" | "transportportal";
   motionProps?: any;
 };
 
 const MotionNav: ForwardRefComponent<any, any> = motion.nav;
 
-const MainMenu = ({ className, locale, motionProps = {}, ...rest }: MainMenuProps) => {
+const MainMenu = ({ className, locale, profile = "default", motionProps = {}, ...rest }: MainMenuProps) => {
   const dictionary = getLocalization(locale).common;
   const data = getMainMenuData(dictionary, locale);
 
@@ -57,11 +58,98 @@ const MainMenu = ({ className, locale, motionProps = {}, ...rest }: MainMenuProp
       {...rest}
     >
       <div className={styles.links}>
-        <MotionNav
-          className={styles.linkSection}
-          variants={animations.section}
-          aria-labelledby="mainMenu.catalogs.heading"
-        >
+        {profile === "transportportal" && (
+          <>
+            <MotionNav
+              className={styles.linkSection}
+              variants={animations.section}
+              aria-labelledby="mainMenu.transportportal.heading"
+            >
+              <Heading
+                className={styles.linkSectionHeader}
+                level={2}
+                data-size="sm"
+                id="mainMenu.transportportal.heading"
+              >
+                {dictionary.mainMenu.transportportal.heading}
+              </Heading>
+              <ul>
+                {data.transportportal.map((item) => (
+                  <li key={item.href}>
+                    <Link href={item.href}>{item.title}</Link>
+                  </li>
+                ))}
+              </ul>
+            </MotionNav>
+            <MotionNav
+              className={styles.linkSection}
+              variants={animations.section}
+              aria-labelledby="mainMenu.transportportalHelp.heading"
+            >
+              <Heading
+                className={styles.linkSectionHeader}
+                level={2}
+                data-size="sm"
+                id="mainMenu.transportportalHelp.heading"
+              >
+                {dictionary.mainMenu.help.heading}
+              </Heading>
+              <ul>
+                {data.transportportalHelp.map((item) => (
+                  <li key={item.href}>
+                    {item.external ? (
+                      <ExternalLink
+                        href={item.href}
+                        locale={locale}
+                      >
+                        {item.title}
+                      </ExternalLink>
+                    ) : (
+                      <Link href={item.href}>{item.title}</Link>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </MotionNav>
+            <MotionNav
+              className={styles.linkSection}
+              variants={animations.section}
+              aria-labelledby="mainMenu.transportportalLegal.heading"
+            >
+              <Heading
+                className={styles.linkSectionHeader}
+                level={2}
+                data-size="sm"
+                id="mainMenu.transportportalLegal.heading"
+              >
+                {dictionary.mainMenu.transportportal.legalHeading}
+              </Heading>
+              <ul>
+                {data.transportportalLegal.map((item) => (
+                  <li key={item.href}>
+                    {item.external ? (
+                      <ExternalLink
+                        href={item.href}
+                        locale={locale}
+                      >
+                        {item.title}
+                      </ExternalLink>
+                    ) : (
+                      <Link href={item.href}>{item.title}</Link>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </MotionNav>
+          </>
+        )}
+        {profile !== "transportportal" && (
+          <>
+            <MotionNav
+              className={styles.linkSection}
+              variants={animations.section}
+              aria-labelledby="mainMenu.catalogs.heading"
+            >
           <Heading
             className={styles.linkSectionHeader}
             level={2}
@@ -156,6 +244,8 @@ const MainMenu = ({ className, locale, motionProps = {}, ...rest }: MainMenuProp
             ))}
           </ul>
         </MotionNav>
+          </>
+        )}
       </div>
     </MotionNav>
   );

--- a/libs/ui/src/lib/main-menu/main-menu.module.scss
+++ b/libs/ui/src/lib/main-menu/main-menu.module.scss
@@ -19,6 +19,7 @@
 
     .linkSectionHeader {
       margin-bottom: 1rem;
+      white-space: nowrap;
     }
 
     a {

--- a/libs/utils/src/lib/profile.ts
+++ b/libs/utils/src/lib/profile.ts
@@ -1,0 +1,20 @@
+import { headers } from "next/headers";
+
+export type Profile = "default" | "transportportal";
+
+const transportportalHosts = (process.env.TRANSPORTPORTAL_HOSTS ?? "data.transportportal.no,transportportal.no")
+  .split(",")
+  .map((host) => host.trim())
+  .filter(Boolean);
+
+export const getProfile = async (): Promise<Profile> => {
+  const headerList = await headers();
+
+  if (process.env.NODE_ENV !== "production" && headerList.get("x-fdk-profile") === "transportportal") {
+    return "transportportal";
+  }
+
+  const host = (headerList.get("x-forwarded-host") ?? headerList.get("host") ?? "").split(":")[0];
+
+  return transportportalHosts.includes(host) ? "transportportal" : "default";
+};

--- a/libs/utils/src/server.ts
+++ b/libs/utils/src/server.ts
@@ -1,1 +1,2 @@
 // Use this file to export React server components
+export * from "./lib/profile";


### PR DESCRIPTION
  # Summary
  
  - Add domain-triggered "transportportal" site profile (data.transportportal.no / transportportal.no / nap.staging...)
  - Branded header for the profile: green Transportportal.no wordmark + tagline, dark background
  - Split the menu drawer into "Om Transportportal.no" (6 info pages), "Hjelp og veiledning" (registration help, reports, community) and "Juridisk" (a11y/privacy/cookies)
  - Migrate the "Hjelp til å registrere" page from the old CMS into /om-transportportal
  - Add TRANSPORTPORTAL_HOSTS env var to deploy configs (base + staging)