### PR TITLE
feat: show multiple dataset types on detail page

### DIFF
--- a/apps/data-norge/src/app/[lang]/datasets/mock/resource-service/datasett-for-test.json
+++ b/apps/data-norge/src/app/[lang]/datasets/mock/resource-service/datasett-for-test.json
@@ -75,16 +75,18 @@
       "uri": null
     }
   ],
-  "dctType": {
-    "code": "TEST_DATA",
-    "prefLabel": {
-      "en": "Test data",
-      "nb": "Testdata",
-      "nn": "Testdata",
-      "no": "Testdata"
-    },
-    "uri": "http://publications.europa.eu/resource/authority/dataset-type/TEST_DATA"
-  },
+  "dctType": [
+    {
+      "code": "TEST_DATA",
+      "prefLabel": {
+        "en": "Test data",
+        "nb": "Testdata",
+        "nn": "Testdata",
+        "no": "Testdata"
+      },
+      "uri": "http://publications.europa.eu/resource/authority/dataset-type/TEST_DATA"
+    }
+  ],
   "description": {
     "en": "This is a test dataset created via the registration solution and where all the fields in the form are filled in.\n\n---\n\n**Purpose:** Test the new dataset details page in the portal.\n\n**Extra text:**\n\n**Dataens nye drakt**\n\nI et rike av nuller og enere,\\\nder data.norge skinner i scener.\\\nMed åpne kilder og innsikt brett,\\\nligger der skjulte skatter – et datasett.\n\nPå detaljesiden finner du svar,\\\nstatistikk og fakta står alltid klar.\\\nEt nytt design, så friskt og lett,\\\nåpner for kunnskap i riktig nett.\n\nFra tall til trender, fra kode til kunst,\\\nher bygges fremtiden – bit for bit, med lyst.\n\nBy ChatGPT 😊\n",
     "nb": "Dette er et testdatasett som er opprettet via registreringsløsningen og der alle feltene i skjemaet er fylt ut.\n\n---\n\n**Formål:** Test den nye detaljesiden for datasett i portalen.\n\n**Ekstra tekst:**\n\n**Dataens nye drakt**\n\nI et rike av nuller og enere,\\\nder data.norge skinner i scener.\\\nMed åpne kilder og innsikt brett,\\\nligger der skjulte skatter – et datasett.\n\nPå detaljesiden finner du svar,\\\nstatistikk og fakta står alltid klar.\\\nEt nytt design, så friskt og lett,\\\nåpner for kunnskap i riktig nett.\n\nFra tall til trender, fra kode til kunst,\\\nher bygges fremtiden – bit for bit, med lyst.\n\nBy ChatGPT 😊\n",

--- a/apps/data-norge/src/app/components/details-page/details-tab/components/general-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/general-details/index.tsx
@@ -2,7 +2,6 @@ import { useContext } from "react";
 import { Heading, Link, Tag, type TagProps, Paragraph } from "@digdir/designsystemet-react";
 import { Hstack, PlaceholderText, ExternalLink, SmartList, Dlist, InputWithCopyButton } from "@fdk-frontend/ui";
 import { calculateMetadataScore, printLocaleValue } from "@fdk-frontend/utils";
-import { type DatasetType } from "@fellesdatakatalog/types";
 import { HelpText } from "@fellesdatakatalog/ui";
 import { DatasetDetailsProps, DatasetDetailsTabContext } from "../../";
 import { i18n } from "@fdk-frontend/localization";
@@ -10,6 +9,9 @@ import styles from "../../details-tab.module.scss";
 
 const GeneralDetails = ({ dataset, locale, dictionary, metadataScore }: DatasetDetailsProps) => {
   const { showEmptyRows } = useContext(DatasetDetailsTabContext);
+
+  // dctType may be a single object (not-yet-reparsed datasets) or a list — normalize to a list.
+  const dctTypes = [dataset.dctType ?? []].flat();
 
   const getMetadataQuality = (value: number) => {
     if (value < 25)
@@ -127,12 +129,12 @@ const GeneralDetails = ({ dataset, locale, dictionary, metadataScore }: DatasetD
             </dd>
           </>
         )}
-        {!dataset.dctType && !showEmptyRows ? null : (
+        {!dctTypes.length && !showEmptyRows ? null : (
           <>
             <dt>{dictionary.details.general.type}:</dt>
             <dd>
-              {dataset.dctType ? (
-                printLocaleValue(locale, (dataset.dctType as DatasetType)?.prefLabel)
+              {dctTypes.length ? (
+                dctTypes.map((type) => printLocaleValue(locale, type.prefLabel)).join(", ")
               ) : (
                 <PlaceholderText>{dictionary.details.noData}</PlaceholderText>
               )}

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@digdir/designsystemet-css": "^1.13.0",
     "@digdir/designsystemet-react": "^1.13.0",
     "@digdir/designsystemet-theme": "^1.11.0",
-    "@fellesdatakatalog/types": "^1.0.26",
+    "@fellesdatakatalog/types": "^1.0.28",
     "@fellesdatakatalog/ui": "^1.0.34",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,12 +2130,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fellesdatakatalog/types@npm:^1.0.26":
-  version: 1.0.26
-  resolution: "@fellesdatakatalog/types@npm:1.0.26"
+"@fellesdatakatalog/types@npm:^1.0.28":
+  version: 1.0.28
+  resolution: "@fellesdatakatalog/types@npm:1.0.28"
   dependencies:
     typescript: "npm:^6.0.2"
-  checksum: 10c0/bca4d7e93f342a4dbf2a29b7bb6808ad343389c9e7265292cc964c40326397b6a517c43a71a65be559760e18a96399c1b4296655cff6098e8a73e4edd7b58aab
+  checksum: 10c0/f38ca5ff0efcc7f87644f2123f604fea90475c464aeec48bd763b3b4107e62be3eef0787e133a37219436f8d67644d496c9edcc9e37997942ed20bf4f59bd9d5
   languageName: node
   linkType: hard
 
@@ -11146,7 +11146,7 @@ __metadata:
     "@digdir/designsystemet-css": "npm:^1.13.0"
     "@digdir/designsystemet-react": "npm:^1.13.0"
     "@digdir/designsystemet-theme": "npm:^1.11.0"
-    "@fellesdatakatalog/types": "npm:^1.0.26"
+    "@fellesdatakatalog/types": "npm:^1.0.28"
     "@fellesdatakatalog/ui": "npm:^1.0.34"
     "@mdx-js/loader": "npm:^3.1.1"
     "@mdx-js/react": "npm:^3.1.1"


### PR DESCRIPTION
# Summary

- Render dataset `dctType` as a list (0..n) on the detail page instead of a single value
- Bump `@fellesdatakatalog/types` to ^1.0.28 (`dctType: ReferenceDataCode[] | ReferenceDataCode`)
- Normalize both shapes to a list (`[dataset.dctType ?? []].flat()`) so not-yet-reparsed datasets (single object) and reparsed ones (list) both render
- Remove dead `DatasetType` import and cast; update mock to an array