### PR TITLE
feat: transportportal-versjon av søket

### DIFF
--- a/apps/data-norge/src/app/[lang]/search/layout.tsx
+++ b/apps/data-norge/src/app/[lang]/search/layout.tsx
@@ -1,5 +1,6 @@
 import SiteLayout from "../../components/site-layout";
 import { type LocaleCodes } from "@fdk-frontend/localization";
+import { getProfile } from "@fdk-frontend/utils/server";
 import SearchPageClient from "../../components/search-page/search-page-client";
 
 export const revalidate = 0;
@@ -8,9 +9,13 @@ export const dynamic = "force-dynamic";
 const SearchLayout = async ({ params }: { params: Promise<{ lang: string }> }) => {
   const resolved = await params;
   const locale = (resolved.lang ?? "nb") as LocaleCodes;
+  const profile = await getProfile();
   return (
     <SiteLayout params={Promise.resolve({ lang: locale })}>
-      <SearchPageClient lang={locale} />
+      <SearchPageClient
+        lang={locale}
+        profile={profile}
+      />
     </SiteLayout>
   );
 };

--- a/apps/data-norge/src/app/[lang]/search/search-summary.ts
+++ b/apps/data-norge/src/app/[lang]/search/search-summary.ts
@@ -53,11 +53,15 @@ export type SearchSummaryResponse = {
 export const SEARCH_SUMMARY_PAGE_SIZE = 10;
 export const SEARCH_SUMMARY_PAGE = 0;
 
+/** Search-service profile filter; scopes catalog results to the transportportal tag. */
+export const TRANSPORT_SEARCH_PROFILE = "TRANSPORT" as const;
+
 export type SearchApiOptions = {
   pagination: { size?: number; page?: number };
   query?: string;
   filters?: Record<string, unknown>;
   sort?: SearchSortBody;
+  profile?: typeof TRANSPORT_SEARCH_PROFILE;
 };
 
 export const buildSearchApiOptions = function (body: {

--- a/apps/data-norge/src/app/api/search/entity/route.ts
+++ b/apps/data-norge/src/app/api/search/entity/route.ts
@@ -1,9 +1,11 @@
 import { searchEntitiesByPath } from "@fdk-frontend/data-access/server";
+import { getProfile } from "@fdk-frontend/utils/server";
 
 import {
   buildSearchApiOptions,
   createEmptySearchSummarySlice,
   normalizeSearchSummarySlice,
+  TRANSPORT_SEARCH_PROFILE,
 } from "../../../[lang]/search/search-summary";
 
 export const POST = async function (request: Request) {
@@ -15,7 +17,11 @@ export const POST = async function (request: Request) {
       return Response.json({ error: "Missing path" }, { status: 400 });
     }
 
-    const searchOptions = buildSearchApiOptions(body);
+    const isTransportportal = (await getProfile()) === "transportportal";
+    const searchOptions = {
+      ...buildSearchApiOptions(body),
+      ...(isTransportportal ? { profile: TRANSPORT_SEARCH_PROFILE } : {}),
+    };
     const result = normalizeSearchSummarySlice(await searchEntitiesByPath(path, searchOptions));
 
     return Response.json(result);

--- a/apps/data-norge/src/app/api/search/suggestions/route.ts
+++ b/apps/data-norge/src/app/api/search/suggestions/route.ts
@@ -1,5 +1,9 @@
 import { getSearchSuggestions } from "@fdk-frontend/data-access/server";
 import { SEARCH_TAB_PATH_SEGMENTS } from "@fdk-frontend/ui/search-tabs/search-tab-config";
+import { getProfile } from "@fdk-frontend/utils/server";
+
+/** Search-service profile filter; scopes suggestions to the transportportal tag. */
+const TRANSPORT_SEARCH_PROFILE = "TRANSPORT";
 
 const VALID_ENTITY_PATHS = new Set<string>(SEARCH_TAB_PATH_SEGMENTS.filter((segment) => segment !== "docs"));
 
@@ -15,7 +19,9 @@ export const GET = async function (request: Request) {
   const entityPath = entityPathParam && VALID_ENTITY_PATHS.has(entityPathParam) ? entityPathParam : undefined;
 
   try {
-    const result = await getSearchSuggestions(query, entityPath);
+    const isTransportportal = (await getProfile()) === "transportportal";
+    const profile = isTransportportal ? TRANSPORT_SEARCH_PROFILE : undefined;
+    const result = await getSearchSuggestions(query, entityPath, profile);
     return Response.json(result, { status: 200, headers: { "Content-Type": "application/json" } });
   } catch (err) {
     console.warn("suggestions proxy error:", err);

--- a/apps/data-norge/src/app/api/search/summary/route.ts
+++ b/apps/data-norge/src/app/api/search/summary/route.ts
@@ -1,18 +1,24 @@
 import { searchEntitiesByPath } from "@fdk-frontend/data-access/server";
 import { SUMMARY_ENTITY_PATHS } from "@fdk-frontend/ui/search-tabs/search-tab-config";
+import { getProfile } from "@fdk-frontend/utils/server";
 
 import {
   buildSearchApiOptions,
   buildSearchSummaryResponse,
   createEmptySearchSummarySlice,
   normalizeSearchSummarySlice,
+  TRANSPORT_SEARCH_PROFILE,
   type SearchSummaryResponse,
 } from "../../../[lang]/search/search-summary";
 
 export const POST = async function (request: Request) {
   try {
     const body = await request.json().catch(() => ({}));
-    const searchOptions = buildSearchApiOptions(body);
+    const isTransportportal = (await getProfile()) === "transportportal";
+    const searchOptions = {
+      ...buildSearchApiOptions(body),
+      ...(isTransportportal ? { profile: TRANSPORT_SEARCH_PROFILE } : {}),
+    };
 
     const results = await Promise.all(
       SUMMARY_ENTITY_PATHS.map(async (path) => {

--- a/apps/data-norge/src/app/components/search-page/index.tsx
+++ b/apps/data-norge/src/app/components/search-page/index.tsx
@@ -37,6 +37,8 @@ export type SearchPageProps = {
   dataThemeAggregation?: AggregationKeyCount[];
   entityLoading?: boolean;
   llmLoading?: boolean;
+  /** Hide the KI (AI) tab and its result block, e.g. on the transportportal profile. */
+  hideKiTab?: boolean;
 };
 
 const SearchPage = ({
@@ -56,6 +58,7 @@ const SearchPage = ({
   dataThemeAggregation,
   entityLoading = false,
   llmLoading = false,
+  hideKiTab = false,
 }: SearchPageProps) => {
   const loc = getLocalization(lang);
   const dictionary = loc.searchPage;
@@ -99,6 +102,7 @@ const SearchPage = ({
           formatAggregation={formatAggregation}
           losThemeAggregation={losThemeAggregation}
           dataThemeAggregation={dataThemeAggregation}
+          hideKiTab={hideKiTab}
         />
         <div>
           {entityLoading && activeEntityTab !== undefined && activeEntityTab !== "docs" && (
@@ -110,7 +114,7 @@ const SearchPage = ({
             </div>
           )}
 
-          {!entityLoading && activeEntityTab === undefined && (
+          {!entityLoading && activeEntityTab === undefined && !hideKiTab && (
             <div className={styles.resultsSection}>
               {llmLoading ? (
                 <SearchResultsSkeleton

--- a/apps/data-norge/src/app/components/search-page/search-page-client.tsx
+++ b/apps/data-norge/src/app/components/search-page/search-page-client.tsx
@@ -1,18 +1,20 @@
 "use client";
 
-import { usePathname, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useReducer } from "react";
 import { type LocaleCodes } from "@fdk-frontend/localization";
+import { type Profile } from "@fdk-frontend/utils/server";
 import { parseSearchPageParam, parseSearchPageSizeParam } from "@fdk-frontend/ui/search-form";
 import { deriveActiveEntityTabFromPathname, deriveLangFromPathname } from "../../[lang]/search/search-route";
 import SearchPage, { type SearchPageProps } from "./index";
 import { loadEntitySearchState, loadLlmDocsSearchState } from "./search-fetch";
 import { initialSearchPageState, searchPageReducer } from "./search-page-state";
 
-export type SearchPageClientProps = Pick<SearchPageProps, "lang">;
+export type SearchPageClientProps = Pick<SearchPageProps, "lang"> & { profile?: Profile };
 
-const SearchPageClient = function ({ lang }: SearchPageClientProps) {
+const SearchPageClient = function ({ lang, profile = "default" }: SearchPageClientProps) {
   const pathname = usePathname();
+  const router = useRouter();
   const searchParams = useSearchParams();
 
   const langFromUrl = deriveLangFromPathname(pathname);
@@ -29,8 +31,17 @@ const SearchPageClient = function ({ lang }: SearchPageClientProps) {
   const pageParam = parseSearchPageParam(searchParams.get("page"));
   const sizeParam = parseSearchPageSizeParam(searchParams.get("size"));
   const locale = (lang ?? langFromUrl) as LocaleCodes;
+  const hideKiTab = profile === "transportportal";
 
   const [{ entityLoading, llmLoading, data }, dispatch] = useReducer(searchPageReducer, initialSearchPageState);
+
+  // The transportportal profile has no KI (AI) tab, so redirect its default landing
+  // (`/search` = KI) to the datasets tab, preserving any query and filters.
+  useEffect(() => {
+    if (!hideKiTab || activeEntityTab !== undefined) return;
+    const queryString = searchParams.toString();
+    router.replace(`/${locale}/search/datasets${queryString ? `?${queryString}` : ""}`);
+  }, [hideKiTab, activeEntityTab, locale, router, searchParams]);
 
   const orgAggregation =
     activeEntityTab && activeEntityTab !== "docs" ? data.orgAggregationsByTab?.[activeEntityTab] : undefined;
@@ -129,6 +140,7 @@ const SearchPageClient = function ({ lang }: SearchPageClientProps) {
       dataThemeAggregation={dataThemeAggregation}
       entityLoading={entityLoading}
       llmLoading={llmLoading}
+      hideKiTab={hideKiTab}
     />
   );
 };

--- a/libs/data-access/src/lib/search-service/api/index.ts
+++ b/libs/data-access/src/lib/search-service/api/index.ts
@@ -193,13 +193,15 @@ export const searchEntitiesByPath = async (
     query?: string;
     filters?: Record<string, unknown>;
     sort?: { field?: string; direction?: "ASC" | "DESC" };
+    profile?: string;
   } = {},
 ) => {
-  const { pagination, query, filters, sort } = options;
+  const { pagination, query, filters, sort, profile } = options;
   return await searchApi(`/search/${path}`, {
     pagination: pagination ?? {},
     ...(query !== undefined ? { query } : {}),
     ...(filters ? { filters } : {}),
     ...(sort ? { sort } : {}),
+    ...(profile ? { profile } : {}),
   });
 };

--- a/libs/data-access/src/lib/search-service/api/index.ts
+++ b/libs/data-access/src/lib/search-service/api/index.ts
@@ -9,14 +9,20 @@ const isSuggestionsResponse = (value: unknown): value is SearchSuggestionsRespon
 
 /**
  * Fetches search typeahead suggestions from the FDK search service, `entityPath` scopes suggestions
- * to a single entity type, omit it to search across all entities.
+ * to a single entity type, omit it to search across all entities. `profile` scopes suggestions to a
+ * search profile (e.g. `TRANSPORT` for transportportal), matching the filtered catalog search.
  */
-export const getSearchSuggestions = async (query: string, entityPath?: string): Promise<SearchSuggestionsResponse> => {
+export const getSearchSuggestions = async (
+  query: string,
+  entityPath?: string,
+  profile?: string,
+): Promise<SearchSuggestionsResponse> => {
   const trimmed = query.trim();
   if (!trimmed) return { suggestions: [] };
 
   const subPath = entityPath ? `/${encodeURIComponent(entityPath)}` : "";
-  const uri = `${process.env.FDK_SEARCH_SERVICE_BASE_URI}/suggestions${subPath}?q=${encodeURIComponent(trimmed)}`;
+  const profileQuery = profile ? `&profile=${encodeURIComponent(profile)}` : "";
+  const uri = `${process.env.FDK_SEARCH_SERVICE_BASE_URI}/suggestions${subPath}?q=${encodeURIComponent(trimmed)}${profileQuery}`;
 
   const response = await fetch(uri, {
     headers: { Accept: "application/json" },

--- a/libs/ui/src/lib/search-form/index.tsx
+++ b/libs/ui/src/lib/search-form/index.tsx
@@ -117,6 +117,8 @@ export type SearchFormProps = {
   defaultValue?: SearchTabsValue;
   onSearch?: (query: string, type: SearchTabsValue) => void;
   className?: string;
+  /** Hide the KI (AI) tab, e.g. on the transportportal profile. */
+  hideKiTab?: boolean;
 };
 
 const SearchForm = ({
@@ -134,6 +136,7 @@ const SearchForm = ({
   defaultValue = "ki",
   onSearch,
   className,
+  hideKiTab = false,
 }: SearchFormProps) => {
   const router = useRouter();
   const pathname = usePathname();
@@ -380,6 +383,7 @@ const SearchForm = ({
             onChange={handleTabChange}
             badgeCounts={badgeCounts}
             locale={locale}
+            hideKiTab={hideKiTab}
           />
           <>
             {showEntityToolbar && (

--- a/libs/ui/src/lib/search-tabs/index.tsx
+++ b/libs/ui/src/lib/search-tabs/index.tsx
@@ -16,6 +16,7 @@ export type SearchTabsProps = {
   /** Badge counts per tab value. `undefined` renders a loading placeholder. */
   badgeCounts?: Record<string, number | undefined>;
   locale?: LocaleCodes;
+  hideKiTab?: boolean;
 };
 
 export type SearchTabItem = {
@@ -66,7 +67,14 @@ const SearchTabBadge = ({ count, loadingAriaLabel }: { count: number | undefined
   );
 };
 
-const SearchTabs = ({ value, defaultValue = "ki", onChange, badgeCounts = {}, locale = "nb" }: SearchTabsProps) => {
+const SearchTabs = ({
+  value,
+  defaultValue = "ki",
+  onChange,
+  badgeCounts = {},
+  locale = "nb",
+  hideKiTab = false,
+}: SearchTabsProps) => {
   const isControlled = value !== undefined;
   const toggleValue = isControlled ? value : defaultValue;
   const userInitiatedChangeRef = useRef(false);
@@ -75,8 +83,10 @@ const SearchTabs = ({ value, defaultValue = "ki", onChange, badgeCounts = {}, lo
 
   // Hide tabs with 0 results. The KI tab and the currently active tab are always
   // kept; a count of `undefined` means results are still loading, so keep it shown.
+  // The KI tab is dropped entirely when `hideKiTab` is set (transportportal profile).
   const visibleItems = localizedItems.filter((item) => {
-    if (item.value === KI_TOGGLE_VALUE || item.value === toggleValue) return true;
+    if (item.value === KI_TOGGLE_VALUE) return !hideKiTab;
+    if (item.value === toggleValue) return true;
     return badgeCounts[item.value] !== 0;
   });
 

--- a/libs/ui/src/lib/search-tabs/index.tsx
+++ b/libs/ui/src/lib/search-tabs/index.tsx
@@ -81,11 +81,12 @@ const SearchTabs = ({
   const dict = getLocalization(locale).searchPage.searchTabs;
   const localizedItems = getLocalizedSearchTabItems(locale);
 
-  // Hide tabs with 0 results. The KI tab and the currently active tab are always
+  // Hide entity tabs with 0 results. The KI, docs, and currently active tabs are always
   // kept; a count of `undefined` means results are still loading, so keep it shown.
   // The KI tab is dropped entirely when `hideKiTab` is set (transportportal profile).
   const visibleItems = localizedItems.filter((item) => {
     if (item.value === KI_TOGGLE_VALUE) return !hideKiTab;
+    if (item.value === "docs") return true;
     if (item.value === toggleValue) return true;
     return badgeCounts[item.value] !== 0;
   });


### PR DESCRIPTION
# Summary 

- Katalogsøket sender nå profil-filteret `TRANSPORT` til search-service når man er på Transportportal, slik at treff og fanetall kun viser transportportal-taggede ressurser
- Søkeforslag (typeahead) filtreres også med `profile=TRANSPORT`, så de ikke lenger foreslår ikke-transport-datasett som gir 0 treff
- KI-fanen skjules på Transportportal, og standard-landingen (`/search`) omdirigeres til datasett-fanen med query og filtre bevart
- Dokumentasjon-fanen vises nå alltid (som KI-fanen), uansett treff-antall, på begge profiler
- Dokumentasjon-fanen viser kun transportportal-dokumenter på Transportportal (dekket av #961)
- Løser #945