### PR TITLE
feat: fjern teknologi-spørsmål fra KI-søk-forslag

### DIFF
--- a/libs/localization/src/lib/locales/en/sections/frontpage.ts
+++ b/libs/localization/src/lib/locales/en/sections/frontpage.ts
@@ -34,7 +34,6 @@ const frontpage = {
         "How do Norwegian schools perform?",
         "How much forest does Norway have?",
         "How is digitalization progressing in Norway?",
-        "Which technologies are most used in Norway?",
       ],
       prefix: "Try for example:",
     },

--- a/libs/localization/src/lib/locales/nb/sections/frontpage.ts
+++ b/libs/localization/src/lib/locales/nb/sections/frontpage.ts
@@ -34,7 +34,6 @@ const frontpage = {
         "Hvordan presterer norske skoler?",
         "Hvor mye skog har Norge?",
         "Hvordan går det med digitalisering i Norge?",
-        "Hvilke teknologier er mest brukt i Norge?",
       ],
       prefix: "Prøv f.eks.",
     },

--- a/libs/localization/src/lib/locales/nn/sections/frontpage.ts
+++ b/libs/localization/src/lib/locales/nn/sections/frontpage.ts
@@ -34,7 +34,6 @@ const frontpage = {
         "Korleis presterer norske skular?",
         "Kor mykje skog har Noreg?",
         "Korleis går det med digitalisering i Noreg?",
-        "Kva for teknologiar er mest brukte i Noreg?",
       ],
       prefix: "Prøv t.d.",
     },


### PR DESCRIPTION
# Summary 

- Fjernet eksempel-spørsmålet «Hvilke teknologier er mest brukt i Norge?» fra KI-søk-forslagene (nb/nn/en)
- Spørsmålet ga ingen relevante treff
- Løser #886