### PR TITLE
Fix: consistent tag/link elements

### DIFF
--- a/apps/data-norge/src/app/components/details-page/data-service/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/data-service/index.tsx
@@ -4,8 +4,17 @@ import { useState } from "react";
 import { type Localization, type LocaleCodes } from "@fdk-frontend/localization";
 import { type DataService, type CommunityTopic, type SearchObject } from "@fellesdatakatalog/types";
 import { printLocaleValue } from "@fdk-frontend/utils";
-import { AccessLevelTag, Badge, Breadcrumbs, ScrollShadows, OrgButton, TagList, UseApiPopover } from "@fdk-frontend/ui";
-import { Heading, Tabs, TabsList, TabsTab, TabsPanel, Tag, Link } from "@digdir/designsystemet-react";
+import {
+  AccessLevelTag,
+  Badge,
+  Breadcrumbs,
+  ScrollShadows,
+  OrgButton,
+  TagList,
+  UseApiPopover,
+  TagLink,
+} from "@fdk-frontend/ui";
+import { Heading, Tabs, TabsList, TabsTab, TabsPanel } from "@digdir/designsystemet-react";
 import MetadataTab from "../metadata-tab";
 import CommunityTab from "../community-tab";
 import DataServiceDetailsTab from "./data-service-details-tab";
@@ -86,12 +95,13 @@ export default function DataServiceDetailsPage({
             />
           </div>
           <TagList className={headerStyles.headerTags}>
-            <Tag
+            <TagLink
               data-color="info"
               data-size="md"
+              href="/data-services"
             >
-              <Link href="/data-services">{dictionaries.detailsPage.header.dataServicesTagLink}</Link>
-            </Tag>
+              {dictionaries.detailsPage.header.dataServicesTagLink}
+            </TagLink>
             <AccessLevelTag
               accessCode={resource.accessRights?.code}
               locale={locale}

--- a/apps/data-norge/src/app/components/details-page/dataset-header/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/dataset-header/index.tsx
@@ -13,7 +13,7 @@ import {
   TagList,
   TagLink,
 } from "@fdk-frontend/ui";
-import { Heading, Link, Tag } from "@digdir/designsystemet-react";
+import { Heading } from "@digdir/designsystemet-react";
 import styles from "./dataset-header.module.scss";
 
 type DatasetHeaderProps = {

--- a/apps/data-norge/src/app/components/details-page/dataset-header/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/dataset-header/index.tsx
@@ -11,6 +11,7 @@ import {
   AccessLevelTag,
   UseDatasetPopover,
   TagList,
+  TagLink,
 } from "@fdk-frontend/ui";
 import { Heading, Link, Tag } from "@digdir/designsystemet-react";
 import styles from "./dataset-header.module.scss";
@@ -73,12 +74,13 @@ const DatasetHeader = ({
         />
       </div>
       <TagList className={styles.headerTags}>
-        <Tag
+        <TagLink
           data-color="info"
           data-size="md"
+          href="/datasets"
         >
-          <Link href="/datasets">{dictionaries.detailsPage.header.datasetsTagLink}</Link>
-        </Tag>
+          {dictionaries.detailsPage.header.datasetsTagLink}
+        </TagLink>
         <AccessLevelTag
           accessCode={dataset.accessRights?.code}
           locale={locale}

--- a/apps/data-norge/src/app/components/details-page/dataset-tags/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/dataset-tags/index.tsx
@@ -2,8 +2,7 @@ import React from "react";
 import { type Dataset } from "@fellesdatakatalog/types";
 import { printLocaleValue } from "@fdk-frontend/utils";
 import { type LocaleCodes } from "@fdk-frontend/localization";
-import { Tag, Link } from "@digdir/designsystemet-react";
-import { TagList } from "@fdk-frontend/ui";
+import { TagList, TagLink } from "@fdk-frontend/ui";
 
 type DatasetTagsProps = {
   locale: LocaleCodes;
@@ -14,20 +13,20 @@ const DatasetTags = ({ locale, dataset }: DatasetTagsProps & React.HTMLAttribute
   return (
     <TagList>
       {dataset.theme?.map((theme: any) => (
-        <Link
+        <TagLink
           key={theme.code}
           href={`/datasets?theme=${theme.code}`}
         >
-          <Tag data-size="sm">{printLocaleValue(locale, theme.title) || theme.code}</Tag>
-        </Link>
+          {printLocaleValue(locale, theme.title) || theme.code}
+        </TagLink>
       ))}
       {dataset.losTheme?.map((theme: any) => (
-        <Link
+        <TagLink
           key={theme.code}
           href={`/datasets?losTheme=${theme.code}`}
         >
-          <Tag data-size="sm">{printLocaleValue(locale, theme.name) || theme.code}</Tag>
-        </Link>
+          {printLocaleValue(locale, theme.name) || theme.code}
+        </TagLink>
       ))}
     </TagList>
   );

--- a/apps/data-norge/src/app/components/details-page/details-tab/components/general-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/general-details/index.tsx
@@ -1,11 +1,18 @@
 import { useContext } from "react";
 import { Heading, Link, Tag, type TagProps, Paragraph } from "@digdir/designsystemet-react";
-import { Hstack, PlaceholderText, ExternalLink, SmartList, Dlist, InputWithCopyButton } from "@fdk-frontend/ui";
+import {
+  Hstack,
+  PlaceholderText,
+  ExternalLink,
+  SmartList,
+  Dlist,
+  InputWithCopyButton,
+  TagLink,
+} from "@fdk-frontend/ui";
 import { calculateMetadataScore, printLocaleValue } from "@fdk-frontend/utils";
 import { HelpText } from "@fellesdatakatalog/ui";
 import { DatasetDetailsProps, DatasetDetailsTabContext } from "../../";
 import { i18n } from "@fdk-frontend/localization";
-import styles from "../../details-tab.module.scss";
 
 const GeneralDetails = ({ dataset, locale, dictionary, metadataScore }: DatasetDetailsProps) => {
   const { showEmptyRows } = useContext(DatasetDetailsTabContext);
@@ -134,7 +141,9 @@ const GeneralDetails = ({ dataset, locale, dictionary, metadataScore }: DatasetD
             <dt>{dictionary.details.general.type}:</dt>
             <dd>
               {dctTypes.length ? (
-                dctTypes.map((type) => printLocaleValue(locale, type.prefLabel)).join(", ")
+                dctTypes
+                  .map((type) => printLocaleValue(locale, typeof type === "string" ? type : type.prefLabel))
+                  .join(", ")
               ) : (
                 <PlaceholderText>{dictionary.details.noData}</PlaceholderText>
               )}
@@ -156,15 +165,14 @@ const GeneralDetails = ({ dataset, locale, dictionary, metadataScore }: DatasetD
             </HelpText>
           </Hstack>
         </dt>
-        <dd className={styles.metadataQualityLink}>
-          <Link href={`/organizations/${dataset.publisher?.id}/datasets/${dataset.id}`}>
-            <Tag
-              data-size="sm"
-              data-color={metadataQuality.color as TagProps["color"]}
-            >
-              {metadataQuality.label}
-            </Tag>
-          </Link>
+        <dd>
+          <TagLink
+            href={`/organizations/${dataset.publisher?.id}/datasets/${dataset.id}`}
+            data-size="sm"
+            data-color={metadataQuality.color as TagProps["color"]}
+          >
+            {metadataQuality.label}
+          </TagLink>
         </dd>
         <dt>URI:</dt>
         <dd>

--- a/apps/data-norge/src/app/components/details-page/details-tab/components/general-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/general-details/index.tsx
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { Heading, Link, Tag, type TagProps, Paragraph } from "@digdir/designsystemet-react";
+import { Heading, Link, type TagProps, Paragraph } from "@digdir/designsystemet-react";
 import {
   Hstack,
   PlaceholderText,

--- a/apps/data-norge/src/app/components/details-page/details-tab/details-tab.module.scss
+++ b/apps/data-norge/src/app/components/details-page/details-tab/details-tab.module.scss
@@ -35,26 +35,3 @@
   padding: 0.75rem 0.75rem;
   background: #fafafa;
 }
-
-.metadataQualityLink {
-  :global(a) {
-    text-decoration: none;
-
-    :global(button),
-    :global(span) {
-      outline: 2px solid transparent;
-      outline-offset: 1px;
-      transition: outline-color 0.1s;
-    }
-  }
-
-  :global(a:hover),
-  :global(a:focus-visible) {
-    opacity: 0.85;
-
-    :global(button),
-    :global(span) {
-      outline-color: currentColor;
-    }
-  }
-}

--- a/apps/data-norge/src/app/components/details-page/details-tab/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, createContext } from "react";
-import { Heading, Link, Tag, Button } from "@digdir/designsystemet-react";
+import { Heading, Tag, Button } from "@digdir/designsystemet-react";
 import { EyeSlashIcon, EyeIcon } from "@navikt/aksel-icons";
 import {
   type DatasetWithIdentifier,
@@ -9,7 +9,7 @@ import {
 } from "@fellesdatakatalog/types";
 import { type PopulatedDatasetReference } from "@fdk-frontend/types";
 import { type LocaleCodes, type Localization } from "@fdk-frontend/localization";
-import { PlaceholderBox, PlaceholderText, TagList, Dlist, ExternalLink, SmartList } from "@fdk-frontend/ui";
+import { PlaceholderBox, PlaceholderText, TagList, Dlist, ExternalLink, SmartList, TagLink } from "@fdk-frontend/ui";
 import GeneralDetails from "./components/general-details";
 import ContactDetails from "./components/contact-details";
 import ContentDetails from "./components/content-details";
@@ -216,18 +216,18 @@ const DatasetDetailsTab = ({
               {dictionary.details.keywords}
             </Heading>
             {dataset.keyword && dataset.keyword.filter((keyword: any) => keyword[locale]).length ? (
-              <div style={{ display: "flex", flexWrap: "wrap", gap: "0.5rem" }}>
+              <TagList>
                 {dataset.keyword
                   .filter((keyword: any) => keyword[locale])
                   .map((keyword: any, i: number) => (
-                    <Link
+                    <TagLink
                       key={`keyword-${i}`}
                       href={`/datasets?q=${keyword[locale]}`}
                     >
-                      <Tag data-size="sm">{keyword[locale]}</Tag>
-                    </Link>
+                      {keyword[locale]}
+                    </TagLink>
                   ))}
-              </div>
+              </TagList>
             ) : (
               <PlaceholderText>{dictionary.details.noData}</PlaceholderText>
             )}

--- a/apps/data-norge/src/app/components/details-page/service/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/service/index.tsx
@@ -21,8 +21,9 @@ import {
   OrgButton,
   TagList,
   StatusTag,
+  TagLink,
 } from "@fdk-frontend/ui";
-import { Card, Heading, Tabs, TabsList, TabsTab, TabsPanel, Button, Link, Tag } from "@digdir/designsystemet-react";
+import { Card, Heading, Tabs, TabsList, TabsTab, TabsPanel, Button, Link } from "@digdir/designsystemet-react";
 import MetadataTab from "../metadata-tab";
 import CommunityTab from "../community-tab";
 import styles from "./service.module.scss";
@@ -127,7 +128,10 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
       if (output.language?.length) {
         contents.push({
           label: dictionaries.detailsPage.produces.language,
-          value: output.language?.map((language) => printLocaleValue(locale, language.prefLabel)).filter(Boolean).join(", "),
+          value: output.language
+            ?.map((language) => printLocaleValue(locale, language.prefLabel))
+            .filter(Boolean)
+            .join(", "),
         });
       }
       if (output.isPartOf?.length) {
@@ -144,7 +148,10 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
       if (output.type?.length) {
         contents.push({
           label: dictionaries.detailsPage.produces.type,
-          value: output.type?.map((type) => printLocaleValue(locale, type.prefLabel)).filter(Boolean).join(", "),
+          value: output.type
+            ?.map((type) => printLocaleValue(locale, type.prefLabel))
+            .filter(Boolean)
+            .join(", "),
         });
       }
 
@@ -184,13 +191,14 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
             {printLocaleValue(locale, service.title) || dictionaries.detailsPage.header.namelessService}
           </Heading>
           <TagList>
-            <Tag
+            <TagLink
               data-color="info"
               data-size="md"
+              href="/public-services-and-events"
             >
-              <Link href="/public-services-and-events">{dictionaries.detailsPage.header.servicesTagLink}</Link>
-            </Tag>
-            {service.admsStatus && (
+              {dictionaries.detailsPage.header.servicesTagLink}
+            </TagLink>
+            {service.admsStatus && service.admsStatus && (
               <StatusTag
                 locale={locale}
                 status={service.admsStatus}
@@ -640,12 +648,13 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
                 {service.dctType?.length ? (
                   <TagList>
                     {service.dctType.map((theme) => (
-                      <Link
+                      <TagLink
                         key={theme.code}
                         href={`/public-services-and-events?mainActivities=${theme.code}`}
+                        data-size="sm"
                       >
-                        <Tag data-size="sm">{printLocaleValue(locale, theme.prefLabel) || theme.code}</Tag>
-                      </Link>
+                        {printLocaleValue(locale, theme.prefLabel) || theme.code}
+                      </TagLink>
                     ))}
                   </TagList>
                 ) : (
@@ -666,21 +675,23 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
                 {service.eurovocThemes?.length || service.losThemes?.length ? (
                   <TagList>
                     {service.eurovocThemes?.map((theme) => (
-                      <Link
+                      <TagLink
                         key={theme.code}
                         href={`/public-services-and-events?eurovocTheme=${theme.code}`}
+                        data-size="sm"
                       >
-                        <Tag data-size="sm">{printLocaleValue(locale, theme.label) || theme.code}</Tag>
-                      </Link>
+                        {printLocaleValue(locale, theme.label) || theme.code}
+                      </TagLink>
                     ))}
 
                     {service.losThemes?.map((theme) => (
-                      <Link
+                      <TagLink
                         key={theme.code}
                         href={`/public-services-and-events?losTheme=${theme.code}`}
+                        data-size="sm"
                       >
-                        <Tag data-size="sm">{printLocaleValue(locale, theme.name) || theme.code}</Tag>
-                      </Link>
+                        {printLocaleValue(locale, theme.name) || theme.code}
+                      </TagLink>
                     ))}
                   </TagList>
                 ) : (

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -121,6 +121,7 @@ export { default as SmartList } from "./lib/smart-list";
 export * from "./lib/smart-list";
 export { default as StarButton } from "./lib/star-button";
 export * from "./lib/star-button";
+export { default as TagLink } from "./lib/tag-link";
 export { default as TagList } from "./lib/tag-list";
 export * from "./lib/tag-list";
 export * from "./lib/typography";

--- a/libs/ui/src/lib/access-level-tag/index.tsx
+++ b/libs/ui/src/lib/access-level-tag/index.tsx
@@ -2,6 +2,8 @@ import { Link, Tag, TagProps, Paragraph } from "@digdir/designsystemet-react";
 import { type LocaleCodes, getLocalization } from "@fdk-frontend/localization";
 import { AccessRightsCodes } from "@fellesdatakatalog/types";
 import { HelpText } from "@fellesdatakatalog/ui";
+import TagLink from "../tag-link";
+import styles from "./styles.module.scss";
 
 type AccessLevelTagProps = {
   accessCode?: AccessRightsCodes | string;
@@ -22,6 +24,7 @@ const AccessLevelTag = ({ accessCode, nonInteractive, locale, ...props }: Access
 
   return (
     <Tag
+      className={styles.tag}
       data-color={color as TagProps["color"]}
       {...props}
     >
@@ -29,7 +32,7 @@ const AccessLevelTag = ({ accessCode, nonInteractive, locale, ...props }: Access
         label
       ) : (
         <>
-          <Link href={`/datasets?accessrights=${accessCode}`}>{label}</Link>&nbsp;
+          <TagLink href={`/datasets?accessrights=${accessCode}`}>{label}</TagLink>&nbsp;
           <HelpText aria-label={dictionary.accessRights.helpTextTitle}>
             <Paragraph data-size="sm">{helpText}</Paragraph>
             <Paragraph data-size="sm">

--- a/libs/ui/src/lib/access-level-tag/styles.module.scss
+++ b/libs/ui/src/lib/access-level-tag/styles.module.scss
@@ -1,0 +1,4 @@
+.tag {
+  height: calc(var(--ds-size-8) - var(--ds-border-width-default) * 2);
+  padding-left: 0;
+}

--- a/libs/ui/src/lib/status-tag/index.tsx
+++ b/libs/ui/src/lib/status-tag/index.tsx
@@ -21,7 +21,8 @@ type StatusTagProps = {
 const StatusTag = (props: StatusTagProps) => {
   const { locale, status } = props;
   const color = statusColorMap?.[status.code as StatusCode] || "neutral";
-  return <Tag data-color={color}>{printLocaleValue(locale, status.prefLabel)}</Tag>;
+  const label = printLocaleValue(locale, status.prefLabel);
+  return !label ? undefined : <Tag data-color={color}>{printLocaleValue(locale, status.prefLabel)}</Tag>;
 };
 
 export default StatusTag;

--- a/libs/ui/src/lib/tag-link/index.tsx
+++ b/libs/ui/src/lib/tag-link/index.tsx
@@ -1,0 +1,16 @@
+import { Link, LinkProps } from "@digdir/designsystemet-react";
+import styles from "./styles.module.scss";
+
+// Link component from Designsystemet, styled as a link variant of the Tag component (also from Designsystemet)
+const TagLink = ({ children, ...props }: LinkProps) => {
+  return (
+    <Link
+      className={styles.link + " ds-tag"}
+      {...props}
+    >
+      {children}
+    </Link>
+  );
+};
+
+export default TagLink;

--- a/libs/ui/src/lib/tag-link/styles.module.scss
+++ b/libs/ui/src/lib/tag-link/styles.module.scss
@@ -1,0 +1,3 @@
+.link:not(:hover) {
+  text-decoration: none;
+}


### PR DESCRIPTION
fixes https://github.com/Informasjonsforvaltning/fdk-frontend/issues/898

- New component LinkTag, combining a link and tag. In essence just combining the functionality and logic of Designsystemet's Link component with some styling from their Tag component, while keeping the text decoration and color from Link component
- Use LinkTag to display resource (dataset, API, service) details that already used both Tag and Link components