### PR TITLE
fix: restore padding for non-linking tags

### DIFF
--- a/libs/ui/src/lib/access-level-tag/index.tsx
+++ b/libs/ui/src/lib/access-level-tag/index.tsx
@@ -32,7 +32,13 @@ const AccessLevelTag = ({ accessCode, nonInteractive, locale, ...props }: Access
         label
       ) : (
         <>
-          <TagLink href={`/datasets?accessrights=${accessCode}`}>{label}</TagLink>&nbsp;
+          <TagLink
+            className={styles.innerTag}
+            href={`/datasets?accessrights=${accessCode}`}
+          >
+            {label}
+          </TagLink>
+          &nbsp;
           <HelpText aria-label={dictionary.accessRights.helpTextTitle}>
             <Paragraph data-size="sm">{helpText}</Paragraph>
             <Paragraph data-size="sm">

--- a/libs/ui/src/lib/access-level-tag/styles.module.scss
+++ b/libs/ui/src/lib/access-level-tag/styles.module.scss
@@ -1,4 +1,9 @@
 .tag {
   height: calc(var(--ds-size-8) - var(--ds-border-width-default) * 2);
-  padding-left: 0;
+}
+
+.innerTag {
+  margin-left: calc(-1 * (var(--ds-size-2)));
+  padding: 0 var(--ds-size-2);
+  line-height: var(--ds-size-8);
 }


### PR DESCRIPTION
Fixes slight padding issue introduced in https://github.com/Informasjonsforvaltning/fdk-frontend/pull/977 where tags displaying access service and not linking anywhere would lose left padding. See example:
<img width="406" height="100" alt="bilde" src="https://github.com/user-attachments/assets/7ac3acfa-b898-40bb-9ff4-bb9990f757a2" />

