### PR TITLE
fix: bump nx and brace-expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "js-yaml@^4.1.0": "^4.3.0",
     "js-yaml@^4.1.1": "^4.3.0",
     "brace-expansion@^1.1.7": "^1.1.16",
-    "brace-expansion@^2.0.2": "^2.1.2",
+    "brace-expansion@^2.0.2": "^2.1.3",
     "brace-expansion@5.0.2": "^5.0.8",
     "brace-expansion@^5.0.2": "^5.0.8",
     "brace-expansion@^5.0.6": "^5.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4203,15 +4203,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nx/cypress@npm:22.7.0":
-  version: 22.7.0
-  resolution: "@nx/cypress@npm:22.7.0"
+"@nx/cypress@npm:22.7.8":
+  version: 22.7.8
+  resolution: "@nx/cypress@npm:22.7.8"
   dependencies:
-    "@nx/devkit": "npm:22.7.0"
-    "@nx/eslint": "npm:22.7.0"
-    "@nx/js": "npm:22.7.0"
-    "@phenomnomnominal/tsquery": "npm:~6.1.4"
-    detect-port: "npm:^1.5.1"
+    "@nx/devkit": "npm:22.7.8"
+    "@nx/eslint": "npm:22.7.8"
+    "@nx/js": "npm:22.7.8"
+    "@phenomnomnominal/tsquery": "npm:~6.2.0"
+    detect-port: "npm:^2.1.0"
     semver: "npm:^7.6.3"
     tree-kill: "npm:1.2.2"
     tslib: "npm:^2.3.0"
@@ -4220,39 +4220,39 @@ __metadata:
   peerDependenciesMeta:
     cypress:
       optional: true
-  checksum: 10c0/12bdff4bec6ef355e1c5f84467e61a47cb36df58377aed5b903e027cfae65c703108c906242c343cfc6ad61698ca9dd8b2625b65b524b462cdc0c3bbafafa201
+  checksum: 10c0/fb8843fc8390fc6085aaf14a9c5ba2832d4c7723534a82e68c29eb52078429150be2b26dfab359ddeda75e77a42ff6203e916d1dafc60c93167670fbfefea341
   languageName: node
   linkType: hard
 
-"@nx/devkit@npm:22.7.0, @nx/devkit@npm:^22.7.0":
-  version: 22.7.0
-  resolution: "@nx/devkit@npm:22.7.0"
+"@nx/devkit@npm:22.7.8, @nx/devkit@npm:^22.7.0":
+  version: 22.7.8
+  resolution: "@nx/devkit@npm:22.7.8"
   dependencies:
     "@zkochan/js-yaml": "npm:0.0.7"
     ejs: "npm:5.0.1"
     enquirer: "npm:~2.3.6"
-    minimatch: "npm:10.2.4"
+    minimatch: "npm:10.2.5"
     semver: "npm:^7.6.3"
     tslib: "npm:^2.3.0"
     yargs-parser: "npm:21.1.1"
   peerDependencies:
     nx: ">= 21 <= 23 || ^22.0.0-0"
-  checksum: 10c0/b6293b9505bc771dbfe330f5877f55a3d475b77ce929978450d43006c6fc1ba80e1408ae689fb97e3205f69ef0e793597a194bf6594def80e499bdfc540a3e7f
+  checksum: 10c0/ebdbad5ffb11f7a1ed642226c2e2e3e350c620c8437a1410ac8819421f6a4835d3c0785e2f54593d628b5a45e60c56722f8f56c61801afb4fe3aff731b7f4d27
   languageName: node
   linkType: hard
 
 "@nx/eslint-plugin@npm:^22.7.0":
-  version: 22.7.0
-  resolution: "@nx/eslint-plugin@npm:22.7.0"
+  version: 22.7.8
+  resolution: "@nx/eslint-plugin@npm:22.7.8"
   dependencies:
-    "@nx/devkit": "npm:22.7.0"
-    "@nx/js": "npm:22.7.0"
-    "@phenomnomnominal/tsquery": "npm:~6.1.4"
+    "@nx/devkit": "npm:22.7.8"
+    "@nx/js": "npm:22.7.8"
+    "@phenomnomnominal/tsquery": "npm:~6.2.0"
     "@typescript-eslint/type-utils": "npm:^8.0.0"
     "@typescript-eslint/utils": "npm:^8.0.0"
     chalk: "npm:^4.1.0"
     confusing-browser-globals: "npm:^1.0.9"
-    globals: "npm:^15.9.0"
+    globals: "npm:^17.0.0"
     jsonc-eslint-parser: "npm:^2.1.0"
     semver: "npm:^7.6.3"
     tslib: "npm:^2.3.0"
@@ -4262,21 +4262,21 @@ __metadata:
   peerDependenciesMeta:
     eslint-config-prettier:
       optional: true
-  checksum: 10c0/a7438cf8e0b9c0236750d622965dff76e62e043c1a93cf9123d521c547e931954cedb331c240ccfeab4eb12df4b50745cd5600e6f0fa8d983857be24360793d3
+  checksum: 10c0/f3333f0b514459f9fc880c9589d9228a85d49d56d37734649f9f08b3f9e8f1bb9f0cbb27f7ec681ae3dd0e1e4d3a3cabe29caa9906cefeaeae4d9ae46c231f87
   languageName: node
   linkType: hard
 
-"@nx/eslint@npm:22.7.0, @nx/eslint@npm:^22.7.0":
-  version: 22.7.0
-  resolution: "@nx/eslint@npm:22.7.0"
+"@nx/eslint@npm:22.7.8, @nx/eslint@npm:^22.7.0":
+  version: 22.7.8
+  resolution: "@nx/eslint@npm:22.7.8"
   dependencies:
-    "@nx/devkit": "npm:22.7.0"
-    "@nx/js": "npm:22.7.0"
+    "@nx/devkit": "npm:22.7.8"
+    "@nx/js": "npm:22.7.8"
     semver: "npm:^7.6.3"
     tslib: "npm:^2.3.0"
     typescript: "npm:~5.9.2"
   peerDependencies:
-    "@nx/jest": 22.7.0
+    "@nx/jest": 22.7.8
     "@zkochan/js-yaml": 0.0.7
     eslint: ^8.0.0 || ^9.0.0 || ^10.0.0
   peerDependenciesMeta:
@@ -4284,36 +4284,36 @@ __metadata:
       optional: true
     "@zkochan/js-yaml":
       optional: true
-  checksum: 10c0/801c30112cf2784491923e8712fbbf1247c86bce19ede20eac82525448867499c17a31e0cc8140780e934a9fcfc28ef5d54f17aae65d1eab87f3ea3f1939c412
+  checksum: 10c0/fa8d6d903bbcd1a8c2cb8610aeaf9eea79d89d84d3f5a8d86406c1ef8cda040de6443dce08569be191e3c6bb282868f21688ea8df0c0d4453b141a2e06ccfed9
   languageName: node
   linkType: hard
 
 "@nx/jest@npm:^22.7.0":
-  version: 22.7.0
-  resolution: "@nx/jest@npm:22.7.0"
+  version: 22.7.8
+  resolution: "@nx/jest@npm:22.7.8"
   dependencies:
     "@jest/reporters": "npm:^30.0.2"
     "@jest/test-result": "npm:^30.0.2"
-    "@nx/devkit": "npm:22.7.0"
-    "@nx/js": "npm:22.7.0"
-    "@phenomnomnominal/tsquery": "npm:~6.1.4"
+    "@nx/devkit": "npm:22.7.8"
+    "@nx/js": "npm:22.7.8"
+    "@phenomnomnominal/tsquery": "npm:~6.2.0"
     identity-obj-proxy: "npm:3.0.0"
     jest-config: "npm:^30.0.2"
     jest-resolve: "npm:^30.0.2"
     jest-util: "npm:^30.0.2"
-    minimatch: "npm:10.2.4"
+    minimatch: "npm:10.2.5"
     picocolors: "npm:^1.1.0"
     resolve.exports: "npm:2.0.3"
     semver: "npm:^7.6.3"
     tslib: "npm:^2.3.0"
     yargs-parser: "npm:21.1.1"
-  checksum: 10c0/188f97581a6f0bce5208682300708f20177ab46f124a4af6729bd8922e27932cade9c5922a82c51bb3c15b162068ee11d6715d16bf4a0f8fed060b114988c3e9
+  checksum: 10c0/50d8350011cf307b06d9c6c3268dd1fe6ee106190694a1400cd9a6c3a208fea5fa05f3fe47a2fa58adac70a6ead34533cde7837c8aba5b87f8a747e68e151566
   languageName: node
   linkType: hard
 
-"@nx/js@npm:22.7.0, @nx/js@npm:^22.7.0":
-  version: 22.7.0
-  resolution: "@nx/js@npm:22.7.0"
+"@nx/js@npm:22.7.8, @nx/js@npm:^22.7.0":
+  version: 22.7.8
+  resolution: "@nx/js@npm:22.7.8"
   dependencies:
     "@babel/core": "npm:^7.23.2"
     "@babel/plugin-proposal-decorators": "npm:^7.22.7"
@@ -4322,16 +4322,16 @@ __metadata:
     "@babel/preset-env": "npm:^7.23.2"
     "@babel/preset-typescript": "npm:^7.22.5"
     "@babel/runtime": "npm:^7.22.6"
-    "@nx/devkit": "npm:22.7.0"
-    "@nx/workspace": "npm:22.7.0"
+    "@nx/devkit": "npm:22.7.8"
+    "@nx/workspace": "npm:22.7.8"
     "@zkochan/js-yaml": "npm:0.0.7"
     babel-plugin-const-enum: "npm:^1.0.1"
     babel-plugin-macros: "npm:^3.1.0"
     babel-plugin-transform-typescript-metadata: "npm:^0.3.1"
     chalk: "npm:^4.1.0"
     columnify: "npm:^1.6.0"
-    detect-port: "npm:^1.5.1"
-    ignore: "npm:^5.0.4"
+    detect-port: "npm:^2.1.0"
+    ignore: "npm:^7.0.5"
     js-tokens: "npm:^4.0.0"
     jsonc-parser: "npm:3.2.0"
     npm-run-path: "npm:^4.0.1"
@@ -4346,174 +4346,174 @@ __metadata:
   peerDependenciesMeta:
     verdaccio:
       optional: true
-  checksum: 10c0/80e0112f0c7206b8421bd8e72acbe6996e4e8b6f87a0f2344b69bf47f8b7fd9086c24d0cc49d89b32c53f4707a1c9dca7970ee42c13b511b49e70b5b9efa7de8
+  checksum: 10c0/89f887dfc055e18482b0e3f0ed6d100fb28fb72ca75731f680f4ac00a82608e174cba71ae7ac7cda7bcafd98d0e9edc367e64bcd40b58eee32e514ca1152c2a3
   languageName: node
   linkType: hard
 
-"@nx/module-federation@npm:22.7.0":
-  version: 22.7.0
-  resolution: "@nx/module-federation@npm:22.7.0"
+"@nx/module-federation@npm:22.7.8":
+  version: 22.7.8
+  resolution: "@nx/module-federation@npm:22.7.8"
   dependencies:
     "@module-federation/enhanced": "npm:^2.3.3"
     "@module-federation/node": "npm:^2.7.21"
     "@module-federation/sdk": "npm:^2.1.0"
-    "@nx/devkit": "npm:22.7.0"
-    "@nx/js": "npm:22.7.0"
-    "@nx/web": "npm:22.7.0"
+    "@nx/devkit": "npm:22.7.8"
+    "@nx/js": "npm:22.7.8"
+    "@nx/web": "npm:22.7.8"
     "@rspack/core": "npm:1.6.8"
     express: "npm:^4.21.2"
     http-proxy-middleware: "npm:^3.0.5"
     picocolors: "npm:^1.1.0"
     tslib: "npm:^2.3.0"
     webpack: "npm:^5.101.3"
-  checksum: 10c0/cbbcd5fcc9759d1d02779478bf6979e99f33d25acfa03e08ae6c0ec75dd8fc2cd9d9ae76df2b60b6208cc41338adac48f4394937621317933c5e369c6fdff6eb
+  checksum: 10c0/f20325b1b2fb5d0a6c2c5e44b57b5b40ef8c03630fcd6bcc9355677c6f4eefb00f63e8c4f0f4a1d11b2bb623d8970d35180cdb42d1a804973b3565531218832b
   languageName: node
   linkType: hard
 
 "@nx/next@npm:^22.7.0":
-  version: 22.7.0
-  resolution: "@nx/next@npm:22.7.0"
+  version: 22.7.8
+  resolution: "@nx/next@npm:22.7.8"
   dependencies:
     "@babel/plugin-proposal-decorators": "npm:^7.22.7"
-    "@nx/devkit": "npm:22.7.0"
-    "@nx/eslint": "npm:22.7.0"
-    "@nx/js": "npm:22.7.0"
-    "@nx/react": "npm:22.7.0"
-    "@nx/web": "npm:22.7.0"
-    "@nx/webpack": "npm:22.7.0"
-    "@phenomnomnominal/tsquery": "npm:~6.1.4"
+    "@nx/devkit": "npm:22.7.8"
+    "@nx/eslint": "npm:22.7.8"
+    "@nx/js": "npm:22.7.8"
+    "@nx/react": "npm:22.7.8"
+    "@nx/web": "npm:22.7.8"
+    "@nx/webpack": "npm:22.7.8"
+    "@phenomnomnominal/tsquery": "npm:~6.2.0"
     "@svgr/webpack": "npm:^8.1.0"
     copy-webpack-plugin: "npm:^14.0.0"
-    ignore: "npm:^5.0.4"
+    ignore: "npm:^7.0.5"
     semver: "npm:^7.6.3"
     tslib: "npm:^2.3.0"
     webpack-merge: "npm:^5.8.0"
   peerDependencies:
     next: ">=14.0.0 <17.0.0"
-  checksum: 10c0/457dc7f10537c193db6dc4f140696f72b2987584af05566f8a878f57b4cf21c4c61eb5a509af86a1125c930772bc825e0910c37417f2b52752f66fe1fcc2a803
+  checksum: 10c0/0a6a8570e3f7d4272179f8e478ab4dbe591e95a64b75599fed3b92717be439783f09f3c53fa8054e15f709b9ad571b36e24f0870e6ed28cf5dc77e5513077ff6
   languageName: node
   linkType: hard
 
-"@nx/nx-darwin-arm64@npm:22.7.0":
-  version: 22.7.0
-  resolution: "@nx/nx-darwin-arm64@npm:22.7.0"
+"@nx/nx-darwin-arm64@npm:22.7.8":
+  version: 22.7.8
+  resolution: "@nx/nx-darwin-arm64@npm:22.7.8"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@nx/nx-darwin-x64@npm:22.7.0":
-  version: 22.7.0
-  resolution: "@nx/nx-darwin-x64@npm:22.7.0"
+"@nx/nx-darwin-x64@npm:22.7.8":
+  version: 22.7.8
+  resolution: "@nx/nx-darwin-x64@npm:22.7.8"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@nx/nx-freebsd-x64@npm:22.7.0":
-  version: 22.7.0
-  resolution: "@nx/nx-freebsd-x64@npm:22.7.0"
+"@nx/nx-freebsd-x64@npm:22.7.8":
+  version: 22.7.8
+  resolution: "@nx/nx-freebsd-x64@npm:22.7.8"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@nx/nx-linux-arm-gnueabihf@npm:22.7.0":
-  version: 22.7.0
-  resolution: "@nx/nx-linux-arm-gnueabihf@npm:22.7.0"
+"@nx/nx-linux-arm-gnueabihf@npm:22.7.8":
+  version: 22.7.8
+  resolution: "@nx/nx-linux-arm-gnueabihf@npm:22.7.8"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@nx/nx-linux-arm64-gnu@npm:22.7.0":
-  version: 22.7.0
-  resolution: "@nx/nx-linux-arm64-gnu@npm:22.7.0"
+"@nx/nx-linux-arm64-gnu@npm:22.7.8":
+  version: 22.7.8
+  resolution: "@nx/nx-linux-arm64-gnu@npm:22.7.8"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@nx/nx-linux-arm64-musl@npm:22.7.0":
-  version: 22.7.0
-  resolution: "@nx/nx-linux-arm64-musl@npm:22.7.0"
+"@nx/nx-linux-arm64-musl@npm:22.7.8":
+  version: 22.7.8
+  resolution: "@nx/nx-linux-arm64-musl@npm:22.7.8"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@nx/nx-linux-x64-gnu@npm:22.7.0":
-  version: 22.7.0
-  resolution: "@nx/nx-linux-x64-gnu@npm:22.7.0"
+"@nx/nx-linux-x64-gnu@npm:22.7.8":
+  version: 22.7.8
+  resolution: "@nx/nx-linux-x64-gnu@npm:22.7.8"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@nx/nx-linux-x64-musl@npm:22.7.0":
-  version: 22.7.0
-  resolution: "@nx/nx-linux-x64-musl@npm:22.7.0"
+"@nx/nx-linux-x64-musl@npm:22.7.8":
+  version: 22.7.8
+  resolution: "@nx/nx-linux-x64-musl@npm:22.7.8"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@nx/nx-win32-arm64-msvc@npm:22.7.0":
-  version: 22.7.0
-  resolution: "@nx/nx-win32-arm64-msvc@npm:22.7.0"
+"@nx/nx-win32-arm64-msvc@npm:22.7.8":
+  version: 22.7.8
+  resolution: "@nx/nx-win32-arm64-msvc@npm:22.7.8"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@nx/nx-win32-x64-msvc@npm:22.7.0":
-  version: 22.7.0
-  resolution: "@nx/nx-win32-x64-msvc@npm:22.7.0"
+"@nx/nx-win32-x64-msvc@npm:22.7.8":
+  version: 22.7.8
+  resolution: "@nx/nx-win32-x64-msvc@npm:22.7.8"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
 "@nx/playwright@npm:^22.7.0":
-  version: 22.7.0
-  resolution: "@nx/playwright@npm:22.7.0"
+  version: 22.7.8
+  resolution: "@nx/playwright@npm:22.7.8"
   dependencies:
-    "@nx/devkit": "npm:22.7.0"
-    "@nx/eslint": "npm:22.7.0"
-    "@nx/js": "npm:22.7.0"
-    minimatch: "npm:10.2.4"
+    "@nx/devkit": "npm:22.7.8"
+    "@nx/eslint": "npm:22.7.8"
+    "@nx/js": "npm:22.7.8"
+    minimatch: "npm:10.2.5"
     tslib: "npm:^2.3.0"
   peerDependencies:
     "@playwright/test": ^1.36.0
   peerDependenciesMeta:
     "@playwright/test":
       optional: true
-  checksum: 10c0/7c99fd7fe53dbc97f0d6f8caf47bb550ffd3d0da2b62c0f8ce7e3bb6b50159705d3fa1b2183daca18b24950fb6f447fa177d71f8ba642f32b6b478a098fdfac5
+  checksum: 10c0/282dedcc0abcc9b7597c54aed6d6b8f6eff34aa9477b6c65b611febb3ce008d8f044eda29e204b5b3eb129d9b94be8b5a121e038ba49fe64bf2721db287f4801
   languageName: node
   linkType: hard
 
-"@nx/react@npm:22.7.0, @nx/react@npm:^22.7.0":
-  version: 22.7.0
-  resolution: "@nx/react@npm:22.7.0"
+"@nx/react@npm:22.7.8, @nx/react@npm:^22.7.0":
+  version: 22.7.8
+  resolution: "@nx/react@npm:22.7.8"
   dependencies:
-    "@nx/devkit": "npm:22.7.0"
-    "@nx/eslint": "npm:22.7.0"
-    "@nx/js": "npm:22.7.0"
-    "@nx/module-federation": "npm:22.7.0"
-    "@nx/rollup": "npm:22.7.0"
-    "@nx/vite": "npm:22.7.0"
-    "@nx/web": "npm:22.7.0"
-    "@phenomnomnominal/tsquery": "npm:~6.1.4"
+    "@nx/devkit": "npm:22.7.8"
+    "@nx/eslint": "npm:22.7.8"
+    "@nx/js": "npm:22.7.8"
+    "@nx/module-federation": "npm:22.7.8"
+    "@nx/rollup": "npm:22.7.8"
+    "@nx/vite": "npm:22.7.8"
+    "@nx/web": "npm:22.7.8"
+    "@phenomnomnominal/tsquery": "npm:~6.2.0"
     "@svgr/webpack": "npm:^8.0.1"
     express: "npm:^4.21.2"
     http-proxy-middleware: "npm:^3.0.5"
-    minimatch: "npm:10.2.4"
+    minimatch: "npm:10.2.5"
     picocolors: "npm:^1.1.0"
     semver: "npm:^7.6.3"
     tslib: "npm:^2.3.0"
   dependenciesMeta:
     "@nx/vite":
       optional: true
-  checksum: 10c0/2739ba9031f508373a9b971e5f9a8cc4b3af7843c3579006f1b4da1da8d05cb3608e3b7bf7bed4147afea320c2c5dc67f5ac6895c2e1dac41983fcb03f38f9a1
+  checksum: 10c0/07cba398b5d4e021e688b641422629c62c7b2e40c771711f5459f49cdac0a01ef6571786aa23ef83309655e41c72edf748bf08e65e11e5576d56091d6ec6e08e
   languageName: node
   linkType: hard
 
-"@nx/rollup@npm:22.7.0":
-  version: 22.7.0
-  resolution: "@nx/rollup@npm:22.7.0"
+"@nx/rollup@npm:22.7.8":
+  version: 22.7.8
+  resolution: "@nx/rollup@npm:22.7.8"
   dependencies:
-    "@nx/devkit": "npm:22.7.0"
-    "@nx/js": "npm:22.7.0"
+    "@nx/devkit": "npm:22.7.8"
+    "@nx/js": "npm:22.7.8"
     "@rollup/plugin-babel": "npm:^6.0.4"
     "@rollup/plugin-commonjs": "npm:^25.0.7"
     "@rollup/plugin-image": "npm:^3.0.3"
@@ -4529,39 +4529,39 @@ __metadata:
     rollup: "npm:^4.14.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
     tslib: "npm:^2.3.0"
-  checksum: 10c0/19bd36e816c97eb07c0d9efbd2464ac85e81df60708d6c87200cc8a3b05e01895965ec9a050cdeea7a44a1ec51e2dd84faf424c5c6a85b097bf5ee637dd288d2
+  checksum: 10c0/b0c28f8c9d8d3e535551d3585e00689f742330803e67a93fb35ef241e5c9a3db934b90cf2d9c32546c256df56c208649afbde9f43e5ebe060a034d812e6cc429
   languageName: node
   linkType: hard
 
 "@nx/storybook@npm:^22.7.0":
-  version: 22.7.0
-  resolution: "@nx/storybook@npm:22.7.0"
+  version: 22.7.8
+  resolution: "@nx/storybook@npm:22.7.8"
   dependencies:
-    "@nx/cypress": "npm:22.7.0"
-    "@nx/devkit": "npm:22.7.0"
-    "@nx/eslint": "npm:22.7.0"
-    "@nx/js": "npm:22.7.0"
-    "@phenomnomnominal/tsquery": "npm:~6.1.4"
+    "@nx/cypress": "npm:22.7.8"
+    "@nx/devkit": "npm:22.7.8"
+    "@nx/eslint": "npm:22.7.8"
+    "@nx/js": "npm:22.7.8"
+    "@phenomnomnominal/tsquery": "npm:~6.2.0"
     semver: "npm:^7.6.3"
     tslib: "npm:^2.3.0"
   peerDependencies:
-    "@nx/web": 22.7.0
+    "@nx/web": 22.7.8
     storybook: ">=7.0.0 <11.0.0"
   peerDependenciesMeta:
     "@nx/web":
       optional: true
-  checksum: 10c0/89589f434ef2fc445f5dd25f99b55544a877f9e958f7ed86caf7e680d9bbabc6c7e239ae561bb8ae34a7706fd2a7ca561cfef3e59069cffe3178c9be3813a3e3
+  checksum: 10c0/c8bc21fd9ab3f3003996dba733cf049c7664b890eda95d267c098ca4c8922d2763d2fd8dc4c4e96ad542d3122f3a9454bc25dd75c6dfdf197d8bdc73f27085ea
   languageName: node
   linkType: hard
 
-"@nx/vite@npm:22.7.0, @nx/vite@npm:^22.7.0":
-  version: 22.7.0
-  resolution: "@nx/vite@npm:22.7.0"
+"@nx/vite@npm:22.7.8, @nx/vite@npm:^22.7.0":
+  version: 22.7.8
+  resolution: "@nx/vite@npm:22.7.8"
   dependencies:
-    "@nx/devkit": "npm:22.7.0"
-    "@nx/js": "npm:22.7.0"
-    "@nx/vitest": "npm:22.7.0"
-    "@phenomnomnominal/tsquery": "npm:~6.1.4"
+    "@nx/devkit": "npm:22.7.8"
+    "@nx/js": "npm:22.7.8"
+    "@nx/vitest": "npm:22.7.8"
+    "@phenomnomnominal/tsquery": "npm:~6.2.0"
     ajv: "npm:^8.0.0"
     enquirer: "npm:~2.3.6"
     picomatch: "npm:4.0.4"
@@ -4571,21 +4571,21 @@ __metadata:
   peerDependencies:
     vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     vitest: ^1.3.1 || ^2.0.0 || ^3.0.0 || ^4.0.0
-  checksum: 10c0/f0b05bca0f2ecf88354d4b1550368b838e37b2e1cf537e5ff8911e23d8781ab199c1fe87897806052790e5ce9e6e45cd7d0be4caca88aa300bf2deb1fecab5f5
+  checksum: 10c0/974605a5a05e841de086ab9920930c4aab4b496d679e05b427938763044c8a8263255063da1b57a52c0383e99e76c96837a196128273661c96d5378f53c20378
   languageName: node
   linkType: hard
 
-"@nx/vitest@npm:22.7.0":
-  version: 22.7.0
-  resolution: "@nx/vitest@npm:22.7.0"
+"@nx/vitest@npm:22.7.8":
+  version: 22.7.8
+  resolution: "@nx/vitest@npm:22.7.8"
   dependencies:
-    "@nx/devkit": "npm:22.7.0"
-    "@nx/js": "npm:22.7.0"
-    "@phenomnomnominal/tsquery": "npm:~6.1.4"
+    "@nx/devkit": "npm:22.7.8"
+    "@nx/js": "npm:22.7.8"
+    "@phenomnomnominal/tsquery": "npm:~6.2.0"
     semver: "npm:^7.6.3"
     tslib: "npm:^2.3.0"
   peerDependencies:
-    "@nx/eslint": 22.7.0
+    "@nx/eslint": 22.7.8
     vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     vitest: ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
   peerDependenciesMeta:
@@ -4595,27 +4595,27 @@ __metadata:
       optional: true
     vitest:
       optional: true
-  checksum: 10c0/024f90a33fa36236de584c2d4a36be5efdca36b0a6330f6acd43aeaf1aaa58334f3752e31f814c94f6d1af50ec5a8bb75171d3a6430c4fd2724d8b1e99113f61
+  checksum: 10c0/e2a1bfce3c9cf37e6817cb70267f254c0d365ac8abafe2d512438661669864f48f798f808b61296899bcccc9bccd082340d219dd0a8813f80fb42db417a8a032
   languageName: node
   linkType: hard
 
-"@nx/web@npm:22.7.0, @nx/web@npm:^22.7.0":
-  version: 22.7.0
-  resolution: "@nx/web@npm:22.7.0"
+"@nx/web@npm:22.7.8, @nx/web@npm:^22.7.0":
+  version: 22.7.8
+  resolution: "@nx/web@npm:22.7.8"
   dependencies:
-    "@nx/devkit": "npm:22.7.0"
-    "@nx/js": "npm:22.7.0"
-    detect-port: "npm:^1.5.1"
+    "@nx/devkit": "npm:22.7.8"
+    "@nx/js": "npm:22.7.8"
+    detect-port: "npm:^2.1.0"
     http-server: "npm:^14.1.0"
     picocolors: "npm:^1.1.0"
     tslib: "npm:^2.3.0"
   peerDependencies:
-    "@nx/cypress": 22.7.0
-    "@nx/eslint": 22.7.0
-    "@nx/jest": 22.7.0
-    "@nx/playwright": 22.7.0
-    "@nx/vite": 22.7.0
-    "@nx/webpack": 22.7.0
+    "@nx/cypress": 22.7.8
+    "@nx/eslint": 22.7.8
+    "@nx/jest": 22.7.8
+    "@nx/playwright": 22.7.8
+    "@nx/vite": 22.7.8
+    "@nx/webpack": 22.7.8
   peerDependenciesMeta:
     "@nx/cypress":
       optional: true
@@ -4629,18 +4629,18 @@ __metadata:
       optional: true
     "@nx/webpack":
       optional: true
-  checksum: 10c0/9b9b7be5685ae3150d5229eca83aec9f0721a4ce65e7be5f99c6b84ef9a84e89544c002752668a10261d807ca4924cc38ee262991d2853ae9941dd9d0e839513
+  checksum: 10c0/51dfd886d1468a4e1960a0fbf8ba0cbc6cb7bc63a4f7247f000dfff4ea01ea56fd7eeef8094987856cc2c2f140cfbfb2bbfcfa5548bfe50b42f2d980ee66878c
   languageName: node
   linkType: hard
 
-"@nx/webpack@npm:22.7.0":
-  version: 22.7.0
-  resolution: "@nx/webpack@npm:22.7.0"
+"@nx/webpack@npm:22.7.8":
+  version: 22.7.8
+  resolution: "@nx/webpack@npm:22.7.8"
   dependencies:
     "@babel/core": "npm:^7.23.2"
-    "@nx/devkit": "npm:22.7.0"
-    "@nx/js": "npm:22.7.0"
-    "@phenomnomnominal/tsquery": "npm:~6.1.4"
+    "@nx/devkit": "npm:22.7.8"
+    "@nx/js": "npm:22.7.8"
+    "@phenomnomnominal/tsquery": "npm:~6.2.0"
     ajv: "npm:^8.12.0"
     autoprefixer: "npm:^10.4.9"
     babel-loader: "npm:^9.1.2"
@@ -4673,24 +4673,24 @@ __metadata:
     webpack-dev-server: "npm:^5.2.1"
     webpack-node-externals: "npm:^3.0.0"
     webpack-subresource-integrity: "npm:^5.1.0"
-  checksum: 10c0/39b79a8d7d925a96206c7dc513c58027a90245bd46462770f4c42f3e99fbf36705e34c1b6c7d8ebdadcd042ad5f7eba43151d4830c473ea1e589fd1e97617553
+  checksum: 10c0/69cbf2fb7db59c305b586dda332f15f35cbd32f8fb1153aba76f3833d6bf5da0eab4e340aa5709b7d8ea33d8301e295550b61a87f523419f92817ecc61979365
   languageName: node
   linkType: hard
 
-"@nx/workspace@npm:22.7.0, @nx/workspace@npm:^22.7.0":
-  version: 22.7.0
-  resolution: "@nx/workspace@npm:22.7.0"
+"@nx/workspace@npm:22.7.8, @nx/workspace@npm:^22.7.0":
+  version: 22.7.8
+  resolution: "@nx/workspace@npm:22.7.8"
   dependencies:
-    "@nx/devkit": "npm:22.7.0"
+    "@nx/devkit": "npm:22.7.8"
     "@zkochan/js-yaml": "npm:0.0.7"
     chalk: "npm:^4.1.0"
     enquirer: "npm:~2.3.6"
-    nx: "npm:22.7.0"
+    nx: "npm:22.7.8"
     picomatch: "npm:4.0.4"
     semver: "npm:^7.6.3"
     tslib: "npm:^2.3.0"
     yargs-parser: "npm:21.1.1"
-  checksum: 10c0/06cdd79235be9ce31800bc7485bdc6c27fb87a58b178631cf6b5fc7164a6a692094ab8fc0ae5bbdadbb2526364c61a4bd3bf1342f8b5580271b1c46495abc757
+  checksum: 10c0/c0a505ebbec1894b9e25a7129aad1e3754ae42fb4dc52b5957bb1df5b30223bb8d0b4e8acdb186432120a9b84dc04eb8282fd3ec5e0b539ef3a86e593ef19a69
   languageName: node
   linkType: hard
 
@@ -5125,15 +5125,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@phenomnomnominal/tsquery@npm:~6.1.4":
-  version: 6.1.4
-  resolution: "@phenomnomnominal/tsquery@npm:6.1.4"
+"@phenomnomnominal/tsquery@npm:~6.2.0":
+  version: 6.2.0
+  resolution: "@phenomnomnominal/tsquery@npm:6.2.0"
   dependencies:
-    "@types/esquery": "npm:^1.5.0"
-    esquery: "npm:^1.5.0"
+    "@types/esquery": "npm:^1.5.4"
+    esquery: "npm:^1.7.0"
   peerDependencies:
-    typescript: ^3 || ^4 || ^5
-  checksum: 10c0/6bff27df57d4f710c8488f31405b3ad79e5dbc41db5cf1d0ff0f116cfcff49dca364cf15586fe020d48b4e7c2a976497260894ad01a35aed5187279b620c9d74
+    typescript: ">3.0.0"
+  checksum: 10c0/9842cd208f9f2b39cd147e57983b83641bbe8b98ff7c509b05d7c9ae7fba1811e668f7bd646cdfc4c0a5408262de6462c993512eae2fad370c52032cbbeddec7
   languageName: node
   linkType: hard
 
@@ -6456,7 +6456,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/esquery@npm:^1.5.0":
+"@types/esquery@npm:^1.5.4":
   version: 1.5.4
   resolution: "@types/esquery@npm:1.5.4"
   dependencies:
@@ -7741,10 +7741,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"address@npm:^1.0.1":
-  version: 1.2.2
-  resolution: "address@npm:1.2.2"
-  checksum: 10c0/1c8056b77fb124456997b78ed682ecc19d2fd7ea8bd5850a2aa8c3e3134c913847c57bcae418622efd32ba858fa1e242a40a251ac31da0515664fc0ac03a047d
+"address@npm:^2.0.1":
+  version: 2.0.3
+  resolution: "address@npm:2.0.3"
+  checksum: 10c0/e95c8d989812a9b1cef5e167328a1dd6fd2c41b02005793b7b4631d32dbf7de30bd17685d2f17fbfb94b67f3c422f9a0399caee3c1fbfa18c8e20dc0c8c77d3b
   languageName: node
   linkType: hard
 
@@ -7755,7 +7755,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agent-base@npm:6":
+"agent-base@npm:6, agent-base@npm:6.0.2":
   version: 6.0.2
   resolution: "agent-base@npm:6.0.2"
   dependencies:
@@ -8551,6 +8551,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"brace-expansion@npm:5.0.8, brace-expansion@npm:^5.0.8":
+  version: 5.0.8
+  resolution: "brace-expansion@npm:5.0.8"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10c0/73304caafd00fdc5b0168e693ac15bf25b6357dec76d1195fcd628fe2cf99c46f9c889a7ecfa3cfe236dbd2d5ce3e27a6ccc4370b46d475d0d19081e11f86019
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^1.1.16":
   version: 1.1.16
   resolution: "brace-expansion@npm:1.1.16"
@@ -8561,21 +8570,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "brace-expansion@npm:2.1.2"
+"brace-expansion@npm:^2.1.3":
+  version: 2.1.4
+  resolution: "brace-expansion@npm:2.1.4"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
+  checksum: 10c0/6c0a0e2573eac1dc565b52b1e1bfbeba39bf1830d106ebbc61ff1eaefcf610e9111cd3baa091addd18e33292135c99e019d3184d966389d85dc958fdcdc1449f
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.8":
-  version: 5.0.8
-  resolution: "brace-expansion@npm:5.0.8"
+"brace-expansion@npm:^5.0.5":
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/73304caafd00fdc5b0168e693ac15bf25b6357dec76d1195fcd628fe2cf99c46f9c889a7ecfa3cfe236dbd2d5ce3e27a6ccc4370b46d475d0d19081e11f86019
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 
@@ -9666,7 +9675,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.6, debug@npm:^4.4.0, debug@npm:^4.4.1, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:4.4.3, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.6, debug@npm:^4.4.0, debug@npm:^4.4.1, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -9861,16 +9870,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-port@npm:^1.5.1":
-  version: 1.6.1
-  resolution: "detect-port@npm:1.6.1"
+"detect-port@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "detect-port@npm:2.1.0"
   dependencies:
-    address: "npm:^1.0.1"
-    debug: "npm:4"
+    address: "npm:^2.0.1"
   bin:
-    detect: bin/detect-port.js
-    detect-port: bin/detect-port.js
-  checksum: 10c0/4ea9eb46a637cb21220dd0a62b6074792894fc77b2cacbc9de533d1908b2eedafa7bfd7547baaa2ac1e9c7ba7c289b34b17db896dca6da142f4fc6e2060eee17
+    detect: dist/commonjs/bin/detect-port.js
+    detect-port: dist/commonjs/bin/detect-port.js
+  checksum: 10c0/06236ff1197ffea038d4a1c0ab60200ece1ac234eb00a507f93e986483c06989b9efd424cc2bbb8e9556c3984ce906e8a663799797e415626eefb26f040bd5d8
   languageName: node
   linkType: hard
 
@@ -10821,7 +10829,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esquery@npm:^1.5.0":
+"esquery@npm:^1.5.0, esquery@npm:^1.7.0":
   version: 1.7.0
   resolution: "esquery@npm:1.7.0"
   dependencies:
@@ -11833,10 +11841,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globals@npm:^15.9.0":
-  version: 15.15.0
-  resolution: "globals@npm:15.15.0"
-  checksum: 10c0/f9ae80996392ca71316495a39bec88ac43ae3525a438b5626cd9d5ce9d5500d0a98a266409605f8cd7241c7acf57c354a48111ea02a767ba4f374b806d6861fe
+"globals@npm:^17.0.0":
+  version: 17.9.0
+  resolution: "globals@npm:17.9.0"
+  checksum: 10c0/776116bffb916e462d548c26a44c9a5d8f4e551935a883991e9f5d68cbcb21b63e4c688e36bbc564f97d3025e304d8b2bb0a611ecf944825aeee164898dcfbdd
   languageName: node
   linkType: hard
 
@@ -11951,21 +11959,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hasown@npm:2.0.2, hasown@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "hasown@npm:2.0.2"
-  dependencies:
-    function-bind: "npm:^1.1.2"
-  checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
-  languageName: node
-  linkType: hard
-
-"hasown@npm:^2.0.4":
+"hasown@npm:2.0.4, hasown@npm:^2.0.4":
   version: 2.0.4
   resolution: "hasown@npm:2.0.4"
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "hasown@npm:2.0.2"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
   languageName: node
   linkType: hard
 
@@ -12226,7 +12234,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^5.0.1":
+"https-proxy-agent@npm:5.0.1, https-proxy-agent@npm:^5.0.1":
   version: 5.0.1
   resolution: "https-proxy-agent@npm:5.0.1"
   dependencies:
@@ -12319,7 +12327,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.0.4, ignore@npm:^5.2.0":
+"ignore@npm:^5.2.0":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
   checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
@@ -15398,12 +15406,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:10.2.4":
-  version: 10.2.4
-  resolution: "minimatch@npm:10.2.4"
+"minimatch@npm:10.2.5":
+  version: 10.2.5
+  resolution: "minimatch@npm:10.2.5"
   dependencies:
-    brace-expansion: "npm:^5.0.2"
-  checksum: 10c0/35f3dfb7b99b51efd46afd378486889f590e7efb10e0f6a10ba6800428cf65c9a8dedb74427d0570b318d749b543dc4e85f06d46d2858bc8cac7e1eb49a95945
+    brace-expansion: "npm:^5.0.5"
+  checksum: 10c0/6bb058bd6324104b9ec2f763476a35386d05079c1f5fe4fbf1f324a25237cd4534d6813ecd71f48208f4e635c1221899bef94c3c89f7df55698fe373aaae20fd
   languageName: node
   linkType: hard
 
@@ -15851,38 +15859,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nx@npm:22.7.0, nx@npm:^22.7.0":
-  version: 22.7.0
-  resolution: "nx@npm:22.7.0"
+"nx@npm:22.7.8, nx@npm:^22.7.0":
+  version: 22.7.8
+  resolution: "nx@npm:22.7.8"
   dependencies:
     "@emnapi/core": "npm:1.4.5"
     "@emnapi/runtime": "npm:1.4.5"
     "@emnapi/wasi-threads": "npm:1.0.4"
     "@jest/diff-sequences": "npm:30.0.1"
     "@napi-rs/wasm-runtime": "npm:0.2.4"
-    "@nx/nx-darwin-arm64": "npm:22.7.0"
-    "@nx/nx-darwin-x64": "npm:22.7.0"
-    "@nx/nx-freebsd-x64": "npm:22.7.0"
-    "@nx/nx-linux-arm-gnueabihf": "npm:22.7.0"
-    "@nx/nx-linux-arm64-gnu": "npm:22.7.0"
-    "@nx/nx-linux-arm64-musl": "npm:22.7.0"
-    "@nx/nx-linux-x64-gnu": "npm:22.7.0"
-    "@nx/nx-linux-x64-musl": "npm:22.7.0"
-    "@nx/nx-win32-arm64-msvc": "npm:22.7.0"
-    "@nx/nx-win32-x64-msvc": "npm:22.7.0"
+    "@nx/nx-darwin-arm64": "npm:22.7.8"
+    "@nx/nx-darwin-x64": "npm:22.7.8"
+    "@nx/nx-freebsd-x64": "npm:22.7.8"
+    "@nx/nx-linux-arm-gnueabihf": "npm:22.7.8"
+    "@nx/nx-linux-arm64-gnu": "npm:22.7.8"
+    "@nx/nx-linux-arm64-musl": "npm:22.7.8"
+    "@nx/nx-linux-x64-gnu": "npm:22.7.8"
+    "@nx/nx-linux-x64-musl": "npm:22.7.8"
+    "@nx/nx-win32-arm64-msvc": "npm:22.7.8"
+    "@nx/nx-win32-x64-msvc": "npm:22.7.8"
     "@tybys/wasm-util": "npm:0.9.0"
     "@yarnpkg/lockfile": "npm:1.1.0"
     "@zkochan/js-yaml": "npm:0.0.7"
+    agent-base: "npm:6.0.2"
     ansi-colors: "npm:4.1.3"
     ansi-regex: "npm:5.0.1"
     ansi-styles: "npm:4.3.0"
     argparse: "npm:2.0.1"
     asynckit: "npm:0.4.0"
-    axios: "npm:1.15.0"
+    axios: "npm:1.18.1"
     balanced-match: "npm:4.0.3"
     base64-js: "npm:1.5.1"
     bl: "npm:4.1.0"
-    brace-expansion: "npm:5.0.2"
+    brace-expansion: "npm:5.0.8"
     buffer: "npm:5.7.1"
     call-bind-apply-helpers: "npm:1.0.2"
     chalk: "npm:4.1.2"
@@ -15893,6 +15902,7 @@ __metadata:
     color-convert: "npm:2.0.1"
     color-name: "npm:1.1.4"
     combined-stream: "npm:1.0.8"
+    debug: "npm:4.4.3"
     defaults: "npm:1.0.4"
     define-lazy-prop: "npm:2.0.0"
     delayed-stream: "npm:1.0.0"
@@ -15911,8 +15921,8 @@ __metadata:
     escape-string-regexp: "npm:1.0.5"
     figures: "npm:3.2.0"
     flat: "npm:5.0.2"
-    follow-redirects: "npm:1.15.11"
-    form-data: "npm:4.0.5"
+    follow-redirects: "npm:1.16.0"
+    form-data: "npm:4.0.6"
     fs-constants: "npm:1.0.0"
     function-bind: "npm:1.1.2"
     get-caller-file: "npm:2.0.5"
@@ -15922,7 +15932,8 @@ __metadata:
     has-flag: "npm:4.0.0"
     has-symbols: "npm:1.1.0"
     has-tostringtag: "npm:1.0.2"
-    hasown: "npm:2.0.2"
+    hasown: "npm:2.0.4"
+    https-proxy-agent: "npm:5.0.1"
     ieee754: "npm:1.2.1"
     ignore: "npm:7.0.5"
     inherits: "npm:2.0.4"
@@ -15939,8 +15950,9 @@ __metadata:
     mime-db: "npm:1.52.0"
     mime-types: "npm:2.1.35"
     mimic-fn: "npm:2.1.0"
-    minimatch: "npm:10.2.4"
+    minimatch: "npm:10.2.5"
     minimist: "npm:1.2.8"
+    ms: "npm:2.1.3"
     npm-run-path: "npm:4.0.1"
     once: "npm:1.4.0"
     onetime: "npm:5.1.2"
@@ -15963,7 +15975,7 @@ __metadata:
     strip-bom: "npm:3.0.0"
     supports-color: "npm:7.2.0"
     tar-stream: "npm:2.2.0"
-    tmp: "npm:0.2.4"
+    tmp: "npm:0.2.7"
     tree-kill: "npm:1.2.2"
     tsconfig-paths: "npm:4.2.0"
     tslib: "npm:2.8.1"
@@ -15972,7 +15984,7 @@ __metadata:
     wrap-ansi: "npm:7.0.0"
     wrappy: "npm:1.0.2"
     y18n: "npm:5.0.8"
-    yaml: "npm:2.8.0"
+    yaml: "npm:2.9.0"
     yargs: "npm:17.7.2"
     yargs-parser: "npm:21.1.1"
   peerDependencies:
@@ -16005,9 +16017,9 @@ __metadata:
     "@swc/core":
       optional: true
   bin:
-    nx: dist/bin/nx.js
-    nx-cloud: dist/bin/nx-cloud.js
-  checksum: 10c0/1fb1362aa0ac48e907e447bddcc534f9eb90e32679e6b3af7717537ee32447e00371a6d95db67b4b42ce380631c1e9b8d03b233389fe5166b4f195d9ae9bb7ed
+    nx: ./dist/bin/nx.js
+    nx-cloud: ./dist/bin/nx-cloud.js
+  checksum: 10c0/f35026ba49dff1754fe7134a786237352a8908462d9a4649a8eb47814b7eb0e550cf009bddeb86e6883b146ac735dc2f8a8073824a2355cc18686b5b81f99556
   languageName: node
   linkType: hard
 
@@ -20967,12 +20979,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:2.8.3, yaml@npm:^2.8.3":
-  version: 2.8.3
-  resolution: "yaml@npm:2.8.3"
+"yaml@npm:2.9.0":
+  version: 2.9.0
+  resolution: "yaml@npm:2.9.0"
   bin:
     yaml: bin.mjs
-  checksum: 10c0/ddff0e11c1b467728d7eb4633db61c5f5de3d8e9373cf84d08fb0cdee03e1f58f02b9f1c51a4a8a865751695addbd465a77f73f1079be91fe5493b29c305fd77
+  checksum: 10c0/f340718df45e97a9551b9bf9dac61c80050bc464513b710debfb5067c380c8472e3b67809cffacb4ab5ffb5e66ef9310816c88b05f371cec60abfedd8c88e0a2
   languageName: node
   linkType: hard
 
@@ -20980,6 +20992,15 @@ __metadata:
   version: 1.10.3
   resolution: "yaml@npm:1.10.3"
   checksum: 10c0/c309ff85a0a569a981d71ab9cf0fef68672a16b9cdf40639d1c3b30034f6cd16ee428602bd6d64ecf006f8c8bee499023cac236538f79898aa99fb5db529a2ed
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.8.3":
+  version: 2.8.3
+  resolution: "yaml@npm:2.8.3"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/ddff0e11c1b467728d7eb4633db61c5f5de3d8e9373cf84d08fb0cdee03e1f58f02b9f1c51a4a8a865751695addbd465a77f73f1079be91fe5493b29c305fd77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

- Bump nx toolchain ^22.7.0 → 22.7.8 (via yarn up) — fixes #256 (nx, range <22.7.2)
- Bump brace-expansion 2.x resolution ^2.1.2 → ^2.1.3 (resolves 2.1.4) — fixes #257 (High)
- data-norge build verified