### PR TITLE
fix: bump js-yaml to 4.3.1 (Dependabot #275)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "adm-zip": "^0.6.0",
     "immutable": "^5.1.8",
     "sharp": "^0.35.0",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "esbuild": "^0.28.1",
     "shell-quote": "^1.9.0",
     "glob": "^10.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13923,14 +13923,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "js-yaml@npm:4.3.0"
+"js-yaml@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "js-yaml@npm:4.3.1"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
+  checksum: 10c0/13c500ca322e0c3f8c81686e6ecda96d2ea37b45247a420c17c7db36932d6965cc27391abc2d1a104501600e7f0d947a5f8b7be6db619c4fefa87901b3512807
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps the `js-yaml` resolution from `^4.3.0` to `^4.3.1` to resolve Dependabot alert **#275** (High, js-yaml `>= 4.0.0, < 4.3.1`).

- js-yaml now resolves to **4.3.1** (the unrelated `0.0.7` line is untouched)
- `yarn npm audit` shows no js-yaml findings
- `nx run-many --target=build --all` ✓