### PR TITLE
fix: bump nanoid to 3.3.18 (Dependabot #276)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "ws": "^8.21.0",
     "webpack-dev-server": "^5.2.6",
     "undici@npm:7.24.7": "^7.29.0",
-    "undici@npm:6.23.0": "^6.28.0"
+    "undici@npm:6.23.0": "^6.28.0",
+    "nanoid": "^3.3.18"
   },
   "packageManager": "yarn@4.14.1",
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15578,12 +15578,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.16":
-  version: 3.3.17
-  resolution: "nanoid@npm:3.3.17"
+"nanoid@npm:^3.3.18":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/06f7949c7cce5c92c6aea66022f29a1eae7f56e05acbfddf1e049e819b4bf234c44a765cc44da7163482b111677948514012e27acdfa56f95309295768bdae32
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds a `nanoid` resolution (`^3.3.18`) to resolve Dependabot alert **#276** (High, nanoid `< 3.3.18`).

- nanoid now resolves to **3.3.18**
- `yarn npm audit` shows no nanoid findings
- `nx run-many --target=build --all` ✓