### PR TITLE
Feat/ksk/transportportal dataset detail page

### DIFF
--- a/apps/data-norge/src/app/[lang]/datasets/[id]/[slug]/page.tsx
+++ b/apps/data-norge/src/app/[lang]/datasets/[id]/[slug]/page.tsx
@@ -27,6 +27,7 @@ import {
   searchDataServices,
   searchInformationModels,
 } from "@fdk-frontend/data-access/server";
+import { getProfile } from "@fdk-frontend/utils/server";
 
 export type DetailsPageWrapperProps = {
   params: Promise<{
@@ -209,6 +210,8 @@ const DetailsPageWrapper = async (props: DetailsPageWrapperProps) => {
     }
   }
 
+  const profile = await getProfile();
+
   return (
     <DatasetDetailsPage
       baseUri={FDK_BASE_URI as string}
@@ -227,6 +230,7 @@ const DetailsPageWrapper = async (props: DetailsPageWrapperProps) => {
       defaultActiveTab={activeTab}
       resolvedDistributionDataServices={resolvedDistributionDataServices}
       resolvedDistributionInformationModels={resolvedDistributionInformationModels}
+      profile={profile}
     />
   );
 };

--- a/apps/data-norge/src/app/components/details-page/community-tab/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/community-tab/index.tsx
@@ -2,10 +2,9 @@ import cn from "classnames";
 import { Heading, Button, Paragraph, Alert, Table } from "@digdir/designsystemet-react";
 import { Profile, type JSONValue } from "@fdk-frontend/types";
 import { type LocaleCodes, type Localization } from "@fdk-frontend/localization";
-import { Badge, ExternalLink, Hstack, VStack, ScrollShadows, PlaceholderBox } from "@fdk-frontend/ui";
+import { Badge, ExternalLink, Hstack, InternalLink, VStack, ScrollShadows, PlaceholderBox } from "@fdk-frontend/ui";
 import styles from "./community-tab.module.scss";
 import TopicRow from "./components/topic-row";
-import InternalLink from "@fdk-frontend/libs/ui/src/lib/internal-link";
 
 export type CommunityTabProps = {
   communityBaseUri: string;

--- a/apps/data-norge/src/app/components/details-page/community-tab/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/community-tab/index.tsx
@@ -12,11 +12,18 @@ export type CommunityTabProps = {
   topics?: JSONValue;
   dictionary: Localization;
   locale: LocaleCodes;
-  profile: Profile;
+  profile?: Profile;
   baseUri: string;
 };
 
-const CommunityTab = ({ communityBaseUri, topics, dictionary, locale, profile, baseUri }: CommunityTabProps) => {
+const CommunityTab = ({
+  communityBaseUri,
+  topics,
+  dictionary,
+  locale,
+  profile = "data.norge",
+  baseUri,
+}: CommunityTabProps) => {
   return (
     <section className={styles.section}>
       <Heading

--- a/apps/data-norge/src/app/components/details-page/community-tab/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/community-tab/index.tsx
@@ -1,19 +1,22 @@
 import cn from "classnames";
-import { Heading, Button, Link, Paragraph, Alert, Table } from "@digdir/designsystemet-react";
-import { type JSONValue } from "@fdk-frontend/types";
+import { Heading, Button, Paragraph, Alert, Table } from "@digdir/designsystemet-react";
+import { Profile, type JSONValue } from "@fdk-frontend/types";
 import { type LocaleCodes, type Localization } from "@fdk-frontend/localization";
 import { Badge, ExternalLink, Hstack, VStack, ScrollShadows, PlaceholderBox } from "@fdk-frontend/ui";
 import styles from "./community-tab.module.scss";
 import TopicRow from "./components/topic-row";
+import InternalLink from "@fdk-frontend/libs/ui/src/lib/internal-link";
 
 export type CommunityTabProps = {
   communityBaseUri: string;
   topics?: JSONValue;
   dictionary: Localization;
   locale: LocaleCodes;
+  profile: Profile;
+  baseUri: string;
 };
 
-const CommunityTab = ({ communityBaseUri, topics, dictionary, locale }: CommunityTabProps) => {
+const CommunityTab = ({ communityBaseUri, topics, dictionary, locale, profile, baseUri }: CommunityTabProps) => {
   return (
     <section className={styles.section}>
       <Heading
@@ -76,7 +79,13 @@ const CommunityTab = ({ communityBaseUri, topics, dictionary, locale }: Communit
               data-size="sm"
               asChild
             >
-              <Link href="/docs/community">{dictionary.community.notice.moreInfo}</Link>
+              <InternalLink
+                href="/docs/community"
+                profile={profile}
+                baseUri={baseUri}
+              >
+                {dictionary.community.notice.moreInfo}
+              </InternalLink>
             </Button>
           </Hstack>
         </VStack>

--- a/apps/data-norge/src/app/components/details-page/data-service/data-service-overview-tab.tsx
+++ b/apps/data-norge/src/app/components/details-page/data-service/data-service-overview-tab.tsx
@@ -142,6 +142,8 @@ export default function DataServiceOverviewTab({
               datasets={resolvedDatasets}
               locale={locale}
               dictionary={dictionary}
+              profile="data.norge"
+              baseUri=""
             />
           </ScrollShadows>
         </section>

--- a/apps/data-norge/src/app/components/details-page/data-service/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/data-service/index.tsx
@@ -177,6 +177,7 @@ export default function DataServiceDetailsPage({
               communityBaseUri={communityBaseUri}
               dictionary={dictionaries.detailsPage}
               locale={locale}
+              baseUri={baseUri}
             />
           </TabsPanel>
           <TabsPanel
@@ -187,6 +188,7 @@ export default function DataServiceDetailsPage({
               uri={`${baseUri}/data-services/${resource.id}`}
               dictionary={dictionaries.detailsPage}
               locale={locale}
+              baseUri={baseUri}
             />
           </TabsPanel>
         </Tabs>

--- a/apps/data-norge/src/app/components/details-page/dataset/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/dataset/index.tsx
@@ -10,7 +10,7 @@ import {
   type CommunityTopic,
   type SearchObject,
 } from "@fellesdatakatalog/types";
-import { type PopulatedDatasetReference } from "@fdk-frontend/types";
+import { type PopulatedDatasetReference, type Profile } from "@fdk-frontend/types";
 import { sumArrayLengths, printLocaleValue } from "@fdk-frontend/utils";
 import {
   Badge,
@@ -55,6 +55,7 @@ export type DatasetDetailsPageType = {
   };
   resolvedDistributionDataServices?: SearchObject[];
   resolvedDistributionInformationModels?: SearchObject[];
+  profile?: Profile;
 };
 
 export default function DatasetDetailsPage({
@@ -75,6 +76,7 @@ export default function DatasetDetailsPage({
   dictionaries,
   resolvedDistributionDataServices,
   resolvedDistributionInformationModels,
+  profile,
 }: DatasetDetailsPageType) {
   const [activeTab, setActiveTab] = useState(defaultActiveTab);
   const isAvailable = !!sumArrayLengths(resource.distribution, resource.sample, apis);
@@ -214,6 +216,7 @@ export default function DatasetDetailsPage({
                   isRelatedToTransportportal={resource?.isRelatedToTransportportal}
                   resolvedDistributionDataServices={resolvedDistributionDataServices}
                   resolvedDistributionInformationModels={resolvedDistributionInformationModels}
+                  profile={profile}
                 />
               )}
             </section>
@@ -235,6 +238,7 @@ export default function DatasetDetailsPage({
                     datasets={internalRelatedDatasets}
                     locale={locale}
                     dictionary={dictionaries.detailsPage}
+                    profile={profile}
                   />
                 </ScrollShadows>
               </section>
@@ -252,6 +256,7 @@ export default function DatasetDetailsPage({
                     datasets={similarDatasets}
                     locale={locale}
                     dictionary={dictionaries.detailsPage}
+                    profile={profile}
                   />
                 </ScrollShadows>
               </section>
@@ -278,6 +283,7 @@ export default function DatasetDetailsPage({
                 isRelatedToTransportportal={resource?.isRelatedToTransportportal}
                 resolvedDistributionDataServices={resolvedDistributionDataServices}
                 resolvedDistributionInformationModels={resolvedDistributionInformationModels}
+                profile={profile}
               />
             )}
           </TabsPanel>
@@ -293,6 +299,7 @@ export default function DatasetDetailsPage({
               locale={locale}
               metadataScore={metadataScore}
               dictionary={dictionaries.detailsPage}
+              profile={profile}
             />
           </TabsPanel>
           <TabsPanel

--- a/apps/data-norge/src/app/components/details-page/dataset/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/dataset/index.tsx
@@ -55,7 +55,7 @@ export type DatasetDetailsPageType = {
   };
   resolvedDistributionDataServices?: SearchObject[];
   resolvedDistributionInformationModels?: SearchObject[];
-  profile?: Profile;
+  profile: Profile;
 };
 
 export default function DatasetDetailsPage({
@@ -217,6 +217,7 @@ export default function DatasetDetailsPage({
                   resolvedDistributionDataServices={resolvedDistributionDataServices}
                   resolvedDistributionInformationModels={resolvedDistributionInformationModels}
                   profile={profile}
+                  baseUri={baseUri}
                 />
               )}
             </section>
@@ -239,6 +240,7 @@ export default function DatasetDetailsPage({
                     locale={locale}
                     dictionary={dictionaries.detailsPage}
                     profile={profile}
+                    baseUri={baseUri}
                   />
                 </ScrollShadows>
               </section>
@@ -257,6 +259,7 @@ export default function DatasetDetailsPage({
                     locale={locale}
                     dictionary={dictionaries.detailsPage}
                     profile={profile}
+                    baseUri={baseUri}
                   />
                 </ScrollShadows>
               </section>
@@ -284,6 +287,7 @@ export default function DatasetDetailsPage({
                 resolvedDistributionDataServices={resolvedDistributionDataServices}
                 resolvedDistributionInformationModels={resolvedDistributionInformationModels}
                 profile={profile}
+                baseUri={baseUri}
               />
             )}
           </TabsPanel>
@@ -300,6 +304,7 @@ export default function DatasetDetailsPage({
               metadataScore={metadataScore}
               dictionary={dictionaries.detailsPage}
               profile={profile}
+              baseUri={baseUri}
             />
           </TabsPanel>
           <TabsPanel

--- a/apps/data-norge/src/app/components/details-page/dataset/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/dataset/index.tsx
@@ -316,6 +316,8 @@ export default function DatasetDetailsPage({
               communityBaseUri={communityBaseUri}
               dictionary={dictionaries.detailsPage}
               locale={locale}
+              profile={profile}
+              baseUri={baseUri}
             />
           </TabsPanel>
           <TabsPanel
@@ -326,6 +328,8 @@ export default function DatasetDetailsPage({
               uri={`${baseUri}/datasets/${resource.id}`}
               dictionary={dictionaries.detailsPage}
               locale={locale}
+              profile={profile}
+              baseUri={baseUri}
             />
           </TabsPanel>
         </Tabs>

--- a/apps/data-norge/src/app/components/details-page/details-tab/components/concept-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/concept-details/index.tsx
@@ -5,7 +5,7 @@ import { DatasetDetailsProps } from "../../";
 import { printLocaleValue } from "@fdk-frontend/utils";
 import InternalLink from "@fdk-frontend/libs/ui/src/lib/internal-link";
 
-const ConceptDetails = ({ dataset, locale, dictionary, concepts, profile }: DatasetDetailsProps) => {
+const ConceptDetails = ({ dataset, locale, dictionary, concepts, profile, baseUri }: DatasetDetailsProps) => {
   return (
     <section>
       <Heading
@@ -24,6 +24,7 @@ const ConceptDetails = ({ dataset, locale, dictionary, concepts, profile }: Data
                     entity={concept}
                     href={`/concepts/${concept.id}`}
                     profile={profile}
+                    baseUri={baseUri}
                   >
                     {printLocaleValue(locale, concept.title) || concept.uri}
                   </InternalLink>

--- a/apps/data-norge/src/app/components/details-page/details-tab/components/concept-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/concept-details/index.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { Heading } from "@digdir/designsystemet-react";
-import { PlaceholderBox, Dlist } from "@fdk-frontend/ui";
+import { PlaceholderBox, Dlist, InternalLink } from "@fdk-frontend/ui";
 import { DatasetDetailsProps } from "../../";
 import { printLocaleValue } from "@fdk-frontend/utils";
-import InternalLink from "@fdk-frontend/libs/ui/src/lib/internal-link";
 
 const ConceptDetails = ({ dataset, locale, dictionary, concepts, profile, baseUri }: DatasetDetailsProps) => {
   return (

--- a/apps/data-norge/src/app/components/details-page/details-tab/components/concept-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/concept-details/index.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import { Heading, Link } from "@digdir/designsystemet-react";
+import { Heading } from "@digdir/designsystemet-react";
 import { PlaceholderBox, Dlist } from "@fdk-frontend/ui";
 import { DatasetDetailsProps } from "../../";
 import { printLocaleValue } from "@fdk-frontend/utils";
+import InternalLink from "@fdk-frontend/libs/ui/src/lib/internal-link";
 
-const ConceptDetails = ({ dataset, locale, dictionary, concepts }: DatasetDetailsProps) => {
+const ConceptDetails = ({ dataset, locale, dictionary, concepts, profile }: DatasetDetailsProps) => {
   return (
     <section>
       <Heading
@@ -19,7 +20,13 @@ const ConceptDetails = ({ dataset, locale, dictionary, concepts }: DatasetDetail
             return (
               <React.Fragment key={concept.uri}>
                 <dt>
-                  <Link href={`/concepts/${concept.id}`}>{printLocaleValue(locale, concept.title) || concept.uri}</Link>
+                  <InternalLink
+                    entity={concept}
+                    href={`/concepts/${concept.id}`}
+                    profile={profile}
+                  >
+                    {printLocaleValue(locale, concept.title) || concept.uri}
+                  </InternalLink>
                 </dt>
                 <dd>{printLocaleValue(locale, concept.description)}</dd>
               </React.Fragment>

--- a/apps/data-norge/src/app/components/details-page/details-tab/components/contact-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/contact-details/index.tsx
@@ -4,7 +4,7 @@ import { PlaceholderText, PlaceholderBox, ExternalLink, Dlist } from "@fdk-front
 import { DatasetDetailsProps, DatasetDetailsTabContext } from "../../";
 import { i18n } from "@fdk-frontend/localization";
 
-const ContactDetails = ({ dataset, locale, dictionary }: DatasetDetailsProps) => {
+const ContactDetails = ({ dataset, locale, dictionary }: Omit<DatasetDetailsProps, "baseUri" | "profile">) => {
   const { showEmptyRows } = useContext(DatasetDetailsTabContext);
 
   const printContactPointName = (contactPoint: any) => {

--- a/apps/data-norge/src/app/components/details-page/details-tab/components/content-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/content-details/index.tsx
@@ -5,7 +5,7 @@ import { DatasetDetailsProps, DatasetDetailsTabContext } from "../../";
 import { formatTemporalDate, printLocaleValue } from "@fdk-frontend/utils";
 import { HelpText } from "@fellesdatakatalog/ui";
 
-const ContentDetails = ({ dataset, locale, dictionary }: DatasetDetailsProps) => {
+const ContentDetails = ({ dataset, locale, dictionary }: Omit<DatasetDetailsProps, "baseUri" | "profile">) => {
   const { showEmptyRows } = useContext(DatasetDetailsTabContext);
 
   return (

--- a/apps/data-norge/src/app/components/details-page/details-tab/components/general-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/general-details/index.tsx
@@ -13,7 +13,7 @@ import { calculateMetadataScore, printLocaleValue } from "@fdk-frontend/utils";
 import { HelpText } from "@fellesdatakatalog/ui";
 import { DatasetDetailsProps, DatasetDetailsTabContext } from "../../";
 import { i18n } from "@fdk-frontend/localization";
-import InternalLink from "@fdk-frontend/libs/ui/src/lib/internal-link";
+import { InternalLink } from "@fdk-frontend/ui";
 
 const GeneralDetails = ({ dataset, locale, dictionary, metadataScore, profile, baseUri }: DatasetDetailsProps) => {
   const { showEmptyRows } = useContext(DatasetDetailsTabContext);

--- a/apps/data-norge/src/app/components/details-page/details-tab/components/general-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/general-details/index.tsx
@@ -66,9 +66,13 @@ const GeneralDetails = ({ dataset, locale, dictionary, metadataScore, profile, b
               <div style={{ whiteSpace: "normal" }}>
                 <Paragraph data-size="sm">{dictionary.details.general.firstHarvestedHelpText}</Paragraph>
                 <Paragraph data-size="sm">
-                  <Link href="/docs/sharing-data/publishing-data-descriptions/4-triggering-harvest">
+                  <InternalLink
+                    href="/docs/sharing-data/publishing-data-descriptions/4-triggering-harvest"
+                    profile={profile}
+                    baseUri={baseUri}
+                  >
                     {dictionary.details.general.firstHarvestedHelpTextLink}
-                  </Link>
+                  </InternalLink>
                 </Paragraph>
               </div>
             </HelpText>

--- a/apps/data-norge/src/app/components/details-page/details-tab/components/general-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/general-details/index.tsx
@@ -8,12 +8,12 @@ import {
   Dlist,
   InputWithCopyButton,
   TagLink,
+  InternalLink,
 } from "@fdk-frontend/ui";
 import { calculateMetadataScore, printLocaleValue } from "@fdk-frontend/utils";
 import { HelpText } from "@fellesdatakatalog/ui";
 import { DatasetDetailsProps, DatasetDetailsTabContext } from "../../";
 import { i18n } from "@fdk-frontend/localization";
-import { InternalLink } from "@fdk-frontend/ui";
 
 const GeneralDetails = ({ dataset, locale, dictionary, metadataScore, profile, baseUri }: DatasetDetailsProps) => {
   const { showEmptyRows } = useContext(DatasetDetailsTabContext);

--- a/apps/data-norge/src/app/components/details-page/details-tab/components/general-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/general-details/index.tsx
@@ -13,8 +13,9 @@ import { calculateMetadataScore, printLocaleValue } from "@fdk-frontend/utils";
 import { HelpText } from "@fellesdatakatalog/ui";
 import { DatasetDetailsProps, DatasetDetailsTabContext } from "../../";
 import { i18n } from "@fdk-frontend/localization";
+import InternalLink from "@fdk-frontend/libs/ui/src/lib/internal-link";
 
-const GeneralDetails = ({ dataset, locale, dictionary, metadataScore }: DatasetDetailsProps) => {
+const GeneralDetails = ({ dataset, locale, dictionary, metadataScore, profile, baseUri }: DatasetDetailsProps) => {
   const { showEmptyRows } = useContext(DatasetDetailsTabContext);
 
   // dctType may be a single object (not-yet-reparsed datasets) or a list — normalize to a list.
@@ -157,9 +158,13 @@ const GeneralDetails = ({ dataset, locale, dictionary, metadataScore }: DatasetD
               <div style={{ whiteSpace: "normal" }}>
                 <Paragraph data-size="sm">{dictionary.details.general.metadataQuality.helpText}</Paragraph>
                 <Paragraph data-size="sm">
-                  <Link href="/nb/docs/metadata-quality">
+                  <InternalLink
+                    href="/nb/docs/metadata-quality"
+                    profile={profile}
+                    baseUri={baseUri}
+                  >
                     {dictionary.details.general.metadataQuality.helpTextLink}
-                  </Link>
+                  </InternalLink>
                 </Paragraph>
               </div>
             </HelpText>

--- a/apps/data-norge/src/app/components/details-page/details-tab/components/legal-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/legal-details/index.tsx
@@ -7,7 +7,7 @@ import { printLocaleValue } from "@fdk-frontend/utils";
 export const hasLegalBasis = (dataset: any) =>
   dataset.legalBasisForAccess || dataset.legalBasisForProcessing || dataset.legalBasisForRestriction;
 
-const LegalDetails = ({ dataset, locale, dictionary }: DatasetDetailsProps) => {
+const LegalDetails = ({ dataset, locale, dictionary }: Omit<DatasetDetailsProps, "baseUri" | "profile">) => {
   const { showEmptyRows } = useContext(DatasetDetailsTabContext);
 
   const printLegalBasis = (legalBasis: any) => {

--- a/apps/data-norge/src/app/components/details-page/details-tab/components/references-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/references-details/index.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { Heading } from "@digdir/designsystemet-react";
-import { PlaceholderBox, ExternalLink, SmartList, Dlist } from "@fdk-frontend/ui";
+import { PlaceholderBox, ExternalLink, SmartList, Dlist, InternalLink } from "@fdk-frontend/ui";
 import { printLocaleValue, getSlug } from "@fdk-frontend/utils";
 import { DatasetDetailsProps } from "../../";
-import InternalLink from "@fdk-frontend/libs/ui/src/lib/internal-link";
 
 const ReferencesDetails = ({
   populatedReferences,

--- a/apps/data-norge/src/app/components/details-page/details-tab/components/references-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/references-details/index.tsx
@@ -10,6 +10,7 @@ const ReferencesDetails = ({
   locale,
   dictionary,
   profile,
+  baseUri,
 }: Omit<DatasetDetailsProps, "dataset">) => {
   const relations =
     populatedReferences?.filter((r) => r.reference.referenceType.uri !== "http://purl.org/dc/terms/relation") || [];
@@ -38,6 +39,7 @@ const ReferencesDetails = ({
                     href={`/${locale}/datasets/${r.resource?.id}/${getSlug(r.resource, locale)}`}
                     entity={r.resource}
                     profile={profile}
+                    baseUri={baseUri}
                   >
                     {printLocaleValue(locale, r.resource?.title)}
                   </InternalLink>
@@ -67,6 +69,7 @@ const ReferencesDetails = ({
                     }
                     entity={r.resource}
                     profile={profile}
+                    baseUri={baseUri}
                   >
                     {printLocaleValue(locale, r.resource?.title)}
                   </InternalLink>

--- a/apps/data-norge/src/app/components/details-page/details-tab/components/references-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/references-details/index.tsx
@@ -3,8 +3,14 @@ import { Heading, Link } from "@digdir/designsystemet-react";
 import { PlaceholderBox, ExternalLink, SmartList, Dlist } from "@fdk-frontend/ui";
 import { printLocaleValue, getSlug } from "@fdk-frontend/utils";
 import { DatasetDetailsProps } from "../../";
+import InternalLink from "@fdk-frontend/libs/ui/src/lib/internal-link";
 
-const ReferencesDetails = ({ populatedReferences, locale, dictionary }: Omit<DatasetDetailsProps, "dataset">) => {
+const ReferencesDetails = ({
+  populatedReferences,
+  locale,
+  dictionary,
+  profile,
+}: Omit<DatasetDetailsProps, "dataset">) => {
   const relations =
     populatedReferences?.filter((r) => r.reference.referenceType.uri !== "http://purl.org/dc/terms/relation") || [];
   const other = populatedReferences?.filter((r) => !relations.includes(r)) || [];
@@ -28,9 +34,13 @@ const ReferencesDetails = ({ populatedReferences, locale, dictionary }: Omit<Dat
               </dt>
               <dd>
                 {r.resource ? (
-                  <Link href={`/${locale}/datasets/${r.resource?.id}/${getSlug(r.resource, locale)}`}>
+                  <InternalLink
+                    href={`/${locale}/datasets/${r.resource?.id}/${getSlug(r.resource, locale)}`}
+                    entity={r.resource}
+                    profile={profile}
+                  >
                     {printLocaleValue(locale, r.resource?.title)}
-                  </Link>
+                  </InternalLink>
                 ) : (
                   <ExternalLink
                     href={r.reference.source?.uri}
@@ -49,15 +59,17 @@ const ReferencesDetails = ({ populatedReferences, locale, dictionary }: Omit<Dat
               items={other}
               renderItem={(r) =>
                 r.resource ? (
-                  <Link
+                  <InternalLink
                     href={
                       r.resource
                         ? `/${locale}/datasets/${r.resource.id}/${getSlug(r.resource, locale)}`
                         : r.reference.source?.uri
                     }
+                    entity={r.resource}
+                    profile={profile}
                   >
                     {printLocaleValue(locale, r.resource?.title)}
-                  </Link>
+                  </InternalLink>
                 ) : (
                   <ExternalLink
                     href={r.reference.source?.uri}

--- a/apps/data-norge/src/app/components/details-page/details-tab/components/references-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/references-details/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Heading, Link } from "@digdir/designsystemet-react";
+import { Heading } from "@digdir/designsystemet-react";
 import { PlaceholderBox, ExternalLink, SmartList, Dlist } from "@fdk-frontend/ui";
 import { printLocaleValue, getSlug } from "@fdk-frontend/utils";
 import { DatasetDetailsProps } from "../../";

--- a/apps/data-norge/src/app/components/details-page/details-tab/components/related-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/components/related-details/index.tsx
@@ -19,6 +19,8 @@ const RelatedDetails = ({ related, locale, dictionary }: Omit<DatasetDetailsProp
             datasets={related}
             locale={locale}
             dictionary={dictionary}
+            profile="data.norge"
+            baseUri=""
           />
         </ScrollShadows>
       ) : (

--- a/apps/data-norge/src/app/components/details-page/details-tab/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/index.tsx
@@ -7,7 +7,7 @@ import {
   type SearchObject,
   type ReferenceDataCode,
 } from "@fellesdatakatalog/types";
-import { type PopulatedDatasetReference } from "@fdk-frontend/types";
+import { type PopulatedDatasetReference, type Profile } from "@fdk-frontend/types";
 import { type LocaleCodes, type Localization } from "@fdk-frontend/localization";
 import { PlaceholderBox, PlaceholderText, TagList, Dlist, ExternalLink, SmartList, TagLink } from "@fdk-frontend/ui";
 import GeneralDetails from "./components/general-details";
@@ -31,6 +31,7 @@ export type DatasetDetailsProps = {
   concepts?: SearchObject[];
   populatedReferences?: PopulatedDatasetReference[];
   internalRelatedDatasets?: DatasetWithIdentifier[];
+  profile?: Profile;
 };
 
 const DatasetDetailsTab = ({
@@ -42,6 +43,7 @@ const DatasetDetailsTab = ({
   concepts,
   populatedReferences,
   internalRelatedDatasets,
+  profile,
 }: DatasetDetailsProps) => {
   const [showEmptyRows, setShowEmptyRows] = useState<boolean>(true);
 
@@ -91,6 +93,7 @@ const DatasetDetailsTab = ({
             concepts={concepts}
             locale={locale}
             dictionary={dictionary}
+            profile={profile}
           />
         )}
         {!populatedReferences?.length && !showEmptyRows ? null : (

--- a/apps/data-norge/src/app/components/details-page/details-tab/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/details-tab/index.tsx
@@ -31,7 +31,8 @@ export type DatasetDetailsProps = {
   concepts?: SearchObject[];
   populatedReferences?: PopulatedDatasetReference[];
   internalRelatedDatasets?: DatasetWithIdentifier[];
-  profile?: Profile;
+  profile: Profile;
+  baseUri: string;
 };
 
 const DatasetDetailsTab = ({
@@ -44,6 +45,7 @@ const DatasetDetailsTab = ({
   populatedReferences,
   internalRelatedDatasets,
   profile,
+  baseUri,
 }: DatasetDetailsProps) => {
   const [showEmptyRows, setShowEmptyRows] = useState<boolean>(true);
 
@@ -94,6 +96,7 @@ const DatasetDetailsTab = ({
             locale={locale}
             dictionary={dictionary}
             profile={profile}
+            baseUri={baseUri}
           />
         )}
         {!populatedReferences?.length && !showEmptyRows ? null : (
@@ -101,6 +104,8 @@ const DatasetDetailsTab = ({
             populatedReferences={populatedReferences}
             locale={locale}
             dictionary={dictionary}
+            profile={profile}
+            baseUri={baseUri}
           />
         )}
         {!dataset.costs?.length && !showEmptyRows ? null : (
@@ -171,6 +176,8 @@ const DatasetDetailsTab = ({
           locale={locale}
           dictionary={dictionary}
           metadataScore={metadataScore}
+          profile={profile}
+          baseUri={baseUri}
         />
         {!dataset.theme?.length && !showEmptyRows ? null : (
           <section>

--- a/apps/data-norge/src/app/components/details-page/distributions/components/dataset-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/distributions/components/dataset-details/index.tsx
@@ -9,6 +9,7 @@ import { DownloadButton } from "@fdk-frontend/ui";
 import styles from "../../distributions.module.scss";
 import DistributionDetails from "../distribution-details";
 import DistributionHeader from "../distribution-header";
+import { type Profile } from "@fdk-frontend/types";
 
 type DistributionListProps = {
   distribution: Distribution;
@@ -20,6 +21,7 @@ type DistributionListProps = {
   isRelatedToTransportportal: boolean;
   resolvedDistributionDataServices: SearchObject[];
   resolvedDistributionInformationModels: SearchObject[];
+  profile?: Profile;
 };
 
 const DistributionList = ({
@@ -29,6 +31,7 @@ const DistributionList = ({
   isRelatedToTransportportal,
   resolvedDistributionDataServices,
   resolvedDistributionInformationModels,
+  profile,
 }: DistributionListProps) => {
   const [hasBeenOpened, setHasBeenOpened] = useState(false);
 
@@ -60,6 +63,7 @@ const DistributionList = ({
             resolvedDistributionDataServices={resolvedDistributionDataServices}
             resolvedDistributionInformationModels={resolvedDistributionInformationModels}
             hasBeenOpened={hasBeenOpened}
+            profile={profile}
           />
         </Details.Content>
       </Details>

--- a/apps/data-norge/src/app/components/details-page/distributions/components/dataset-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/distributions/components/dataset-details/index.tsx
@@ -21,7 +21,8 @@ type DistributionListProps = {
   isRelatedToTransportportal: boolean;
   resolvedDistributionDataServices: SearchObject[];
   resolvedDistributionInformationModels: SearchObject[];
-  profile?: Profile;
+  profile: Profile;
+  baseUri: string;
 };
 
 const DistributionList = ({
@@ -32,6 +33,7 @@ const DistributionList = ({
   resolvedDistributionDataServices,
   resolvedDistributionInformationModels,
   profile,
+  baseUri,
 }: DistributionListProps) => {
   const [hasBeenOpened, setHasBeenOpened] = useState(false);
 
@@ -64,6 +66,7 @@ const DistributionList = ({
             resolvedDistributionInformationModels={resolvedDistributionInformationModels}
             hasBeenOpened={hasBeenOpened}
             profile={profile}
+            baseUri={baseUri}
           />
         </Details.Content>
       </Details>

--- a/apps/data-norge/src/app/components/details-page/distributions/components/distribution-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/distributions/components/distribution-details/index.tsx
@@ -14,9 +14,9 @@ import {
   Article,
   DownloadDistributionWidget,
   noHeadings,
+  InternalLink,
 } from "@fdk-frontend/ui";
 import distStyles from "../../distributions.module.scss";
-import InternalLink from "@fdk-frontend/libs/ui/src/lib/internal-link";
 import { type Profile } from "@fdk-frontend/types";
 
 type DistributionDetailsProps = {

--- a/apps/data-norge/src/app/components/details-page/distributions/components/distribution-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/distributions/components/distribution-details/index.tsx
@@ -30,7 +30,8 @@ type DistributionDetailsProps = {
   resolvedDistributionDataServices?: SearchObject[];
   resolvedDistributionInformationModels?: SearchObject[];
   hasBeenOpened: boolean;
-  profile?: Profile;
+  profile: Profile;
+  baseUri: string;
 };
 
 const DistributionDetails = ({
@@ -42,6 +43,7 @@ const DistributionDetails = ({
   resolvedDistributionInformationModels = [],
   hasBeenOpened,
   profile,
+  baseUri,
 }: DistributionDetailsProps) => {
   return (
     <>
@@ -142,6 +144,7 @@ const DistributionDetails = ({
                       href={`/data-services/${resolvedDataService.id}`}
                       className="fdk-box-link"
                       profile={profile}
+                      baseUri={baseUri}
                     >
                       {printLocaleValue(locale, resolvedDataService.title) || resolvedDataService.uri}
                     </InternalLink>
@@ -225,6 +228,7 @@ const DistributionDetails = ({
                       className="fdk-box-link"
                       entity={resolvedInformationModel}
                       profile={profile}
+                      baseUri={baseUri}
                     >
                       {printLocaleValue(locale, resolvedInformationModel.title) || resolvedInformationModel.uri}
                     </InternalLink>

--- a/apps/data-norge/src/app/components/details-page/distributions/components/distribution-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/distributions/components/distribution-details/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "@digdir/designsystemet-react";
 import { type LocaleCodes, type Localization } from "@fdk-frontend/localization";
 import { printLocaleValue } from "@fdk-frontend/utils";
 import { type Distribution, type SearchObject } from "@fellesdatakatalog/types";
@@ -17,6 +16,8 @@ import {
   noHeadings,
 } from "@fdk-frontend/ui";
 import distStyles from "../../distributions.module.scss";
+import InternalLink from "@fdk-frontend/libs/ui/src/lib/internal-link";
+import { type Profile } from "@fdk-frontend/types";
 
 type DistributionDetailsProps = {
   distribution: Distribution;
@@ -29,6 +30,7 @@ type DistributionDetailsProps = {
   resolvedDistributionDataServices?: SearchObject[];
   resolvedDistributionInformationModels?: SearchObject[];
   hasBeenOpened: boolean;
+  profile?: Profile;
 };
 
 const DistributionDetails = ({
@@ -39,6 +41,7 @@ const DistributionDetails = ({
   resolvedDistributionDataServices = [],
   resolvedDistributionInformationModels = [],
   hasBeenOpened,
+  profile,
 }: DistributionDetailsProps) => {
   return (
     <>
@@ -134,12 +137,14 @@ const DistributionDetails = ({
 
                 if (resolvedDataService) {
                   return (
-                    <Link
+                    <InternalLink
+                      entity={resolvedDataService}
                       href={`/data-services/${resolvedDataService.id}`}
                       className="fdk-box-link"
+                      profile={profile}
                     >
                       {printLocaleValue(locale, resolvedDataService.title) || resolvedDataService.uri}
-                    </Link>
+                    </InternalLink>
                   );
                 }
 
@@ -215,12 +220,14 @@ const DistributionDetails = ({
 
                 if (resolvedInformationModel) {
                   return (
-                    <Link
+                    <InternalLink
                       href={`/information-models/${resolvedInformationModel.id}`}
                       className="fdk-box-link"
+                      entity={resolvedInformationModel}
+                      profile={profile}
                     >
                       {printLocaleValue(locale, resolvedInformationModel.title) || resolvedInformationModel.uri}
-                    </Link>
+                    </InternalLink>
                   );
                 }
 

--- a/apps/data-norge/src/app/components/details-page/distributions/components/example-data-details/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/distributions/components/example-data-details/index.tsx
@@ -9,6 +9,7 @@ import { DownloadButton } from "@fdk-frontend/ui";
 import styles from "../../distributions.module.scss";
 import DistributionDetails from "../distribution-details";
 import DistributionHeader from "../distribution-header";
+import { Profile } from "@fdk-frontend/libs/types/src";
 
 type ExampleDataDetailsProps = {
   distribution: Distribution;
@@ -20,6 +21,8 @@ type ExampleDataDetailsProps = {
   isRelatedToTransportportal: boolean;
   resolvedDistributionDataServices: SearchObject[];
   resolvedDistributionInformationModels: SearchObject[];
+  profile: Profile;
+  baseUri: string;
 };
 
 const ExampleDataDetails = ({
@@ -29,6 +32,8 @@ const ExampleDataDetails = ({
   isRelatedToTransportportal,
   resolvedDistributionDataServices,
   resolvedDistributionInformationModels,
+  profile,
+  baseUri,
 }: ExampleDataDetailsProps) => {
   const [hasBeenOpened, setHasBeenOpened] = useState(false);
 
@@ -61,6 +66,8 @@ const ExampleDataDetails = ({
             resolvedDistributionDataServices={resolvedDistributionDataServices}
             resolvedDistributionInformationModels={resolvedDistributionInformationModels}
             hasBeenOpened={hasBeenOpened}
+            profile={profile}
+            baseUri={baseUri}
           />
         </Details.Content>
       </Details>

--- a/apps/data-norge/src/app/components/details-page/distributions/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/distributions/index.tsx
@@ -26,7 +26,8 @@ export type DistributionsProps = {
   };
   resolvedDistributionDataServices?: SearchObject[];
   resolvedDistributionInformationModels?: SearchObject[];
-  profile?: Profile;
+  profile: Profile;
+  baseUri: string;
 };
 
 const Distributions = ({
@@ -40,6 +41,7 @@ const Distributions = ({
   resolvedDistributionDataServices = [],
   resolvedDistributionInformationModels = [],
   profile,
+  baseUri,
 }: DistributionsProps) => {
   return (
     <div className={cn(styles.distributions, className)}>
@@ -65,6 +67,7 @@ const Distributions = ({
                 resolvedDistributionDataServices={resolvedDistributionDataServices}
                 resolvedDistributionInformationModels={resolvedDistributionInformationModels}
                 profile={profile}
+                baseUri={baseUri}
               />
             ))}
           {exampleData &&
@@ -77,6 +80,8 @@ const Distributions = ({
                 isRelatedToTransportportal={isRelatedToTransportportal}
                 resolvedDistributionDataServices={resolvedDistributionDataServices}
                 resolvedDistributionInformationModels={resolvedDistributionInformationModels}
+                profile={profile}
+                baseUri={baseUri}
               />
             ))}
         </Card>

--- a/apps/data-norge/src/app/components/details-page/distributions/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/distributions/index.tsx
@@ -1,17 +1,18 @@
 "use client";
 import cn from "classnames";
-import { Card, Details, Heading } from "@digdir/designsystemet-react";
+import { Button, Card, Details, Heading } from "@digdir/designsystemet-react";
 import { type LocaleCodes, type Localization } from "@fdk-frontend/localization";
 import { type JSONValue, type Profile } from "@fdk-frontend/types";
 import { sumArrayLengths } from "@fdk-frontend/utils";
 import { ArrowRightIcon } from "@navikt/aksel-icons";
 import { type SearchObject, type DataService, type Distribution } from "@fellesdatakatalog/types";
-import { Badge, Hstack, PlaceholderBox, ActionButton } from "@fdk-frontend/ui";
+import { Badge, Hstack, PlaceholderBox } from "@fdk-frontend/ui";
 import styles from "./distributions.module.scss";
 import DistributionList from "./components/dataset-details";
 import ExampleDataDetails from "./components/example-data-details";
 import ApiHeader from "./components/api-header";
 import ApiDetails from "./components/api-details";
+import InternalLink from "@fdk-frontend/libs/ui/src/lib/internal-link";
 
 export type DistributionsProps = {
   datasets?: JSONValue[];
@@ -123,16 +124,27 @@ const Distributions = ({
                   />
                 </Details.Content>
               </Details>
-              <ActionButton
-                uri={`/${locale}/data-services/${api.id}`}
+              <Button
+                asChild
+                data-size="sm"
+                variant="secondary"
+                onClick={(e) => {
+                  e.stopPropagation();
+                }}
                 className={styles.actionButton}
               >
-                {dictionaries.detailsPage.apis.header.gotoBtn}
-                <ArrowRightIcon
-                  aria-hidden
-                  fontSize="1.2em"
-                />
-              </ActionButton>
+                <InternalLink
+                  href={`/${locale}/data-services/${api.id}`}
+                  profile={profile}
+                  baseUri={baseUri}
+                >
+                  {dictionaries.detailsPage.apis.header.gotoBtn}
+                  <ArrowRightIcon
+                    aria-hidden
+                    fontSize="1.2em"
+                  />
+                </InternalLink>
+              </Button>
             </div>
           ))}
         </Card>

--- a/apps/data-norge/src/app/components/details-page/distributions/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/distributions/index.tsx
@@ -2,7 +2,7 @@
 import cn from "classnames";
 import { Card, Details, Heading } from "@digdir/designsystemet-react";
 import { type LocaleCodes, type Localization } from "@fdk-frontend/localization";
-import { type JSONValue } from "@fdk-frontend/types";
+import { type JSONValue, type Profile } from "@fdk-frontend/types";
 import { sumArrayLengths } from "@fdk-frontend/utils";
 import { ArrowRightIcon } from "@navikt/aksel-icons";
 import { type SearchObject, type DataService, type Distribution } from "@fellesdatakatalog/types";
@@ -26,6 +26,7 @@ export type DistributionsProps = {
   };
   resolvedDistributionDataServices?: SearchObject[];
   resolvedDistributionInformationModels?: SearchObject[];
+  profile?: Profile;
 };
 
 const Distributions = ({
@@ -38,6 +39,7 @@ const Distributions = ({
   dictionaries,
   resolvedDistributionDataServices = [],
   resolvedDistributionInformationModels = [],
+  profile,
 }: DistributionsProps) => {
   return (
     <div className={cn(styles.distributions, className)}>
@@ -62,6 +64,7 @@ const Distributions = ({
                 isRelatedToTransportportal={isRelatedToTransportportal}
                 resolvedDistributionDataServices={resolvedDistributionDataServices}
                 resolvedDistributionInformationModels={resolvedDistributionInformationModels}
+                profile={profile}
               />
             ))}
           {exampleData &&

--- a/apps/data-norge/src/app/components/details-page/distributions/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/distributions/index.tsx
@@ -6,13 +6,12 @@ import { type JSONValue, type Profile } from "@fdk-frontend/types";
 import { sumArrayLengths } from "@fdk-frontend/utils";
 import { ArrowRightIcon } from "@navikt/aksel-icons";
 import { type SearchObject, type DataService, type Distribution } from "@fellesdatakatalog/types";
-import { Badge, Hstack, PlaceholderBox } from "@fdk-frontend/ui";
+import { Badge, Hstack, PlaceholderBox, InternalLink } from "@fdk-frontend/ui";
 import styles from "./distributions.module.scss";
 import DistributionList from "./components/dataset-details";
 import ExampleDataDetails from "./components/example-data-details";
 import ApiHeader from "./components/api-header";
 import ApiDetails from "./components/api-details";
-import InternalLink from "@fdk-frontend/libs/ui/src/lib/internal-link";
 
 export type DistributionsProps = {
   datasets?: JSONValue[];

--- a/apps/data-norge/src/app/components/details-page/metadata-tab/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/metadata-tab/index.tsx
@@ -4,15 +4,19 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { InputWithCopyButton, Hstack } from "@fdk-frontend/ui";
 import { type Localization, type LocaleCodes } from "@fdk-frontend/localization";
-import { ToggleGroup, Heading, Spinner, Paragraph, Link } from "@digdir/designsystemet-react";
+import { ToggleGroup, Heading, Spinner, Paragraph } from "@digdir/designsystemet-react";
 import { CopyButton, HelpText } from "@fellesdatakatalog/ui";
 
 import styles from "./metadata-tab.module.scss";
+import InternalLink from "@fdk-frontend/libs/ui/src/lib/internal-link";
+import { Profile } from "@fdk-frontend/libs/types/src";
 
 export type MetadataTabProps = {
   uri: string;
   dictionary: Localization;
   locale: LocaleCodes;
+  profile: Profile;
+  baseUri: string;
 };
 
 const MetadataTab = ({
@@ -20,6 +24,8 @@ const MetadataTab = ({
   uri,
   dictionary,
   locale,
+  profile,
+  baseUri,
   ...props
 }: MetadataTabProps & React.HTMLAttributes<HTMLDivElement>) => {
   const [contentType, setContentType] = useState<string>("text/turtle");
@@ -77,7 +83,13 @@ const MetadataTab = ({
             <HelpText aria-label={dictionary.rdf.titleHelpTextTitle}>
               <Paragraph data-size="md">{dictionary.rdf.titleHelpText}</Paragraph>
               <Paragraph data-size="md">
-                <Link href={`/${locale}/docs/sharing-data/rdf`}>{dictionary.rdf.titleHelpTextLink}</Link>
+                <InternalLink
+                  href={`/${locale}/docs/sharing-data/rdf`}
+                  profile={profile}
+                  baseUri={baseUri}
+                >
+                  {dictionary.rdf.titleHelpTextLink}
+                </InternalLink>
               </Paragraph>
             </HelpText>
           </Hstack>

--- a/apps/data-norge/src/app/components/details-page/metadata-tab/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/metadata-tab/index.tsx
@@ -15,7 +15,7 @@ export type MetadataTabProps = {
   uri: string;
   dictionary: Localization;
   locale: LocaleCodes;
-  profile: Profile;
+  profile?: Profile;
   baseUri: string;
 };
 
@@ -24,7 +24,7 @@ const MetadataTab = ({
   uri,
   dictionary,
   locale,
-  profile,
+  profile = "data.norge",
   baseUri,
   ...props
 }: MetadataTabProps & React.HTMLAttributes<HTMLDivElement>) => {

--- a/apps/data-norge/src/app/components/details-page/metadata-tab/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/metadata-tab/index.tsx
@@ -2,14 +2,13 @@ import React, { useState, useEffect } from "react";
 import cn from "classnames";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
-import { InputWithCopyButton, Hstack } from "@fdk-frontend/ui";
+import { InputWithCopyButton, Hstack, InternalLink } from "@fdk-frontend/ui";
 import { type Localization, type LocaleCodes } from "@fdk-frontend/localization";
 import { ToggleGroup, Heading, Spinner, Paragraph } from "@digdir/designsystemet-react";
 import { CopyButton, HelpText } from "@fellesdatakatalog/ui";
 
 import styles from "./metadata-tab.module.scss";
-import InternalLink from "@fdk-frontend/libs/ui/src/lib/internal-link";
-import { Profile } from "@fdk-frontend/libs/types/src";
+import { Profile } from "@fdk-frontend/types";
 
 export type MetadataTabProps = {
   uri: string;

--- a/apps/data-norge/src/app/components/details-page/service/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/service/index.tsx
@@ -709,6 +709,8 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
               communityBaseUri={communityBaseUri}
               dictionary={dictionaries.detailsPage}
               locale={locale}
+              profile="data.norge"
+              baseUri=""
             />
           </TabsPanel>
           <TabsPanel
@@ -719,6 +721,8 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
               uri={`${baseUri}/services/${service.id}`}
               dictionary={dictionaries.detailsPage}
               locale={locale}
+              profile="data.norge"
+              baseUri=""
             />
           </TabsPanel>
         </Tabs>

--- a/apps/data-norge/src/app/components/details-page/service/index.tsx
+++ b/apps/data-norge/src/app/components/details-page/service/index.tsx
@@ -709,8 +709,7 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
               communityBaseUri={communityBaseUri}
               dictionary={dictionaries.detailsPage}
               locale={locale}
-              profile="data.norge"
-              baseUri=""
+              baseUri={baseUri}
             />
           </TabsPanel>
           <TabsPanel
@@ -721,8 +720,7 @@ export default function ServiceDetailsPage(props: ServiceDetailsPageType) {
               uri={`${baseUri}/services/${service.id}`}
               dictionary={dictionaries.detailsPage}
               locale={locale}
-              profile="data.norge"
-              baseUri=""
+              baseUri={baseUri}
             />
           </TabsPanel>
         </Tabs>

--- a/apps/data-norge/src/app/components/frontpage/frontpage-banner/index.tsx
+++ b/apps/data-norge/src/app/components/frontpage/frontpage-banner/index.tsx
@@ -9,7 +9,7 @@ import Norgeskart from "./components/norgeskart";
 import ScrollButton from "./components/scroll-button";
 
 import styles from "./frontpage-banner.module.scss";
-import { Profile } from "@fdk-frontend/libs/types/src";
+import { Profile } from "@fdk-frontend/types";
 
 type FrontpageBannerProps = {
   dictionary: Localization;

--- a/apps/data-norge/src/app/components/frontpage/frontpage-banner/index.tsx
+++ b/apps/data-norge/src/app/components/frontpage/frontpage-banner/index.tsx
@@ -18,7 +18,7 @@ type FrontpageBannerProps = {
   profile?: Profile;
 };
 
-const FrontpageBanner = ({ dictionary, locale, endpoint, profile = "default" }: FrontpageBannerProps) => (
+const FrontpageBanner = ({ dictionary, locale, endpoint, profile = "data.norge" }: FrontpageBannerProps) => (
   <div
     className={cn(styles.outer, { [styles.transportportal]: profile === "transportportal" })}
     id="frontpage-banner"

--- a/apps/data-norge/src/app/components/frontpage/frontpage-banner/index.tsx
+++ b/apps/data-norge/src/app/components/frontpage/frontpage-banner/index.tsx
@@ -9,12 +9,13 @@ import Norgeskart from "./components/norgeskart";
 import ScrollButton from "./components/scroll-button";
 
 import styles from "./frontpage-banner.module.scss";
+import { Profile } from "@fdk-frontend/libs/types/src";
 
 type FrontpageBannerProps = {
   dictionary: Localization;
   locale: LocaleCodes;
   endpoint: string;
-  profile?: "default" | "transportportal";
+  profile?: Profile;
 };
 
 const FrontpageBanner = ({ dictionary, locale, endpoint, profile = "default" }: FrontpageBannerProps) => (

--- a/apps/data-norge/src/app/components/search-page/search-page-client.tsx
+++ b/apps/data-norge/src/app/components/search-page/search-page-client.tsx
@@ -12,7 +12,7 @@ import { Profile } from "@fdk-frontend/types";
 
 export type SearchPageClientProps = Pick<SearchPageProps, "lang"> & { profile?: Profile };
 
-const SearchPageClient = function ({ lang, profile = "default" }: SearchPageClientProps) {
+const SearchPageClient = function ({ lang, profile = "data.norge" }: SearchPageClientProps) {
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();

--- a/apps/data-norge/src/app/components/search-page/search-page-client.tsx
+++ b/apps/data-norge/src/app/components/search-page/search-page-client.tsx
@@ -3,12 +3,12 @@
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useReducer } from "react";
 import { type LocaleCodes } from "@fdk-frontend/localization";
-import { type Profile } from "@fdk-frontend/utils/server";
 import { parseSearchPageParam, parseSearchPageSizeParam } from "@fdk-frontend/ui/search-form";
 import { deriveActiveEntityTabFromPathname, deriveLangFromPathname } from "../../[lang]/search/search-route";
 import SearchPage, { type SearchPageProps } from "./index";
 import { loadEntitySearchState, loadLlmDocsSearchState } from "./search-fetch";
 import { initialSearchPageState, searchPageReducer } from "./search-page-state";
+import { Profile } from "@fdk-frontend/libs/types/src";
 
 export type SearchPageClientProps = Pick<SearchPageProps, "lang"> & { profile?: Profile };
 

--- a/apps/data-norge/src/app/components/search-page/search-page-client.tsx
+++ b/apps/data-norge/src/app/components/search-page/search-page-client.tsx
@@ -8,7 +8,7 @@ import { deriveActiveEntityTabFromPathname, deriveLangFromPathname } from "../..
 import SearchPage, { type SearchPageProps } from "./index";
 import { loadEntitySearchState, loadLlmDocsSearchState } from "./search-fetch";
 import { initialSearchPageState, searchPageReducer } from "./search-page-state";
-import { Profile } from "@fdk-frontend/libs/types/src";
+import { Profile } from "@fdk-frontend/types";
 
 export type SearchPageClientProps = Pick<SearchPageProps, "lang"> & { profile?: Profile };
 

--- a/libs/types/src/lib/common/index.ts
+++ b/libs/types/src/lib/common/index.ts
@@ -31,4 +31,4 @@ export interface PopulatedDatasetReference {
   resource: Dataset;
 }
 
-export type Profile = "data.norge" | "transportportal" | "default";
+export type Profile = "data.norge" | "transportportal";

--- a/libs/types/src/lib/common/index.ts
+++ b/libs/types/src/lib/common/index.ts
@@ -30,3 +30,5 @@ export interface PopulatedDatasetReference {
   reference: DatasetReference;
   resource: Dataset;
 }
+
+export type Profile = "data.norge" | "transportportal" | "default";

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -80,6 +80,7 @@ export { default as IconBadge } from "./lib/icon-badge";
 export * from "./lib/icon-badge";
 export { default as InputWithCopyButton } from "./lib/input-with-copy-button";
 export * from "./lib/input-with-copy-button";
+export * from "./lib/internal-link";
 export * from "./lib/label-with-tag";
 export { default as LanguageSwitcher } from "./lib/language-switcher";
 export * from "./lib/language-switcher";

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -80,6 +80,7 @@ export { default as IconBadge } from "./lib/icon-badge";
 export * from "./lib/icon-badge";
 export { default as InputWithCopyButton } from "./lib/input-with-copy-button";
 export * from "./lib/input-with-copy-button";
+export { default as InternalLink } from "./lib/internal-link";
 export * from "./lib/internal-link";
 export * from "./lib/label-with-tag";
 export { default as LanguageSwitcher } from "./lib/language-switcher";

--- a/libs/ui/src/lib/dataset-table/index.tsx
+++ b/libs/ui/src/lib/dataset-table/index.tsx
@@ -1,17 +1,20 @@
 import React from "react";
 import cn from "classnames";
-import { Link, Table } from "@digdir/designsystemet-react";
+import { Table } from "@digdir/designsystemet-react";
 import AccessLevelTag from "../access-level-tag";
 import HStack from "../hstack";
 import { printLocaleValue } from "@fdk-frontend/utils";
 import { type Localization, type LocaleCodes } from "@fdk-frontend/localization";
 import { AccessRightsCodes } from "@fellesdatakatalog/types";
 import styles from "./dataset-table.module.scss";
+import InternalLink from "../internal-link";
+import { type Profile } from "@fdk-frontend/types";
 
 type DatasetTableProps = {
   locale: LocaleCodes;
   dictionary: Localization;
   datasets: any[];
+  profile?: Profile;
 };
 
 const DatasetTable = ({
@@ -19,6 +22,7 @@ const DatasetTable = ({
   datasets,
   locale,
   dictionary,
+  profile,
   ...props
 }: DatasetTableProps & React.HTMLAttributes<HTMLDivElement>) => {
   return (
@@ -33,12 +37,14 @@ const DatasetTable = ({
           datasets.map((dataset: any, index: number) => (
             <tr key={`${dataset.id}-${index}`}>
               <td>
-                <Link
+                <InternalLink
                   href={`/${locale}/datasets/${dataset.id}`}
                   className={styles.datasetLink}
+                  profile={profile}
+                  entity={dataset}
                 >
                   {printLocaleValue(locale, dataset.title) || dictionary.header.namelessDataset}
-                </Link>
+                </InternalLink>
               </td>
               <td>
                 <span className={styles.relatedPublisher}>

--- a/libs/ui/src/lib/dataset-table/index.tsx
+++ b/libs/ui/src/lib/dataset-table/index.tsx
@@ -14,7 +14,8 @@ type DatasetTableProps = {
   locale: LocaleCodes;
   dictionary: Localization;
   datasets: any[];
-  profile?: Profile;
+  profile: Profile;
+  baseUri: string;
 };
 
 const DatasetTable = ({
@@ -23,6 +24,7 @@ const DatasetTable = ({
   locale,
   dictionary,
   profile,
+  baseUri,
   ...props
 }: DatasetTableProps & React.HTMLAttributes<HTMLDivElement>) => {
   return (
@@ -42,6 +44,7 @@ const DatasetTable = ({
                   className={styles.datasetLink}
                   profile={profile}
                   entity={dataset}
+                  baseUri={baseUri}
                 >
                   {printLocaleValue(locale, dataset.title) || dictionary.header.namelessDataset}
                 </InternalLink>

--- a/libs/ui/src/lib/footer/index.tsx
+++ b/libs/ui/src/lib/footer/index.tsx
@@ -5,7 +5,7 @@ import MainMenu from "../main-menu";
 import TransportportalFooter from "./transportportal-footer";
 import styles from "./footer.module.scss";
 import { HStack } from "@fellesdatakatalog/ui";
-import { Profile } from "@fdk-frontend/libs/types/src";
+import { Profile } from "@fdk-frontend/types";
 
 export type FooterProps = {
   locale: LocaleCodes;

--- a/libs/ui/src/lib/footer/index.tsx
+++ b/libs/ui/src/lib/footer/index.tsx
@@ -5,12 +5,11 @@ import MainMenu from "../main-menu";
 import TransportportalFooter from "./transportportal-footer";
 import styles from "./footer.module.scss";
 import { HStack } from "@fellesdatakatalog/ui";
-
-export type FooterProfile = "default" | "transportportal";
+import { Profile } from "@fdk-frontend/libs/types/src";
 
 export type FooterProps = {
   locale: LocaleCodes;
-  profile?: FooterProfile;
+  profile?: Profile;
 };
 
 const Footer = ({ locale, profile = "default" }: FooterProps) => {

--- a/libs/ui/src/lib/footer/index.tsx
+++ b/libs/ui/src/lib/footer/index.tsx
@@ -12,7 +12,7 @@ export type FooterProps = {
   profile?: Profile;
 };
 
-const Footer = ({ locale, profile = "default" }: FooterProps) => {
+const Footer = ({ locale, profile = "data.norge" }: FooterProps) => {
   const dictionary = getLocalization(locale).common;
 
   if (profile === "transportportal") {

--- a/libs/ui/src/lib/header/index.tsx
+++ b/libs/ui/src/lib/header/index.tsx
@@ -9,14 +9,13 @@ import { LogoLink } from "../logo";
 import MainMenu from "../main-menu";
 import SearchInput from "../search-input";
 import styles from "./header.module.scss";
-
-export type HeaderProfile = "default" | "transportportal";
+import { Profile } from "@fdk-frontend/libs/types/src";
 
 export type HeaderProps = {
   locale: LocaleCodes;
   frontpage?: boolean;
   showSearchInput?: boolean;
-  profile?: HeaderProfile;
+  profile?: Profile;
 };
 
 const MotionDiv: ForwardRefComponent<any, any> = motion.div;

--- a/libs/ui/src/lib/header/index.tsx
+++ b/libs/ui/src/lib/header/index.tsx
@@ -20,7 +20,7 @@ export type HeaderProps = {
 
 const MotionDiv: ForwardRefComponent<any, any> = motion.div;
 
-const Header = ({ locale, frontpage, showSearchInput, profile = "default" }: HeaderProps) => {
+const Header = ({ locale, frontpage, showSearchInput, profile = "data.norge" }: HeaderProps) => {
   const dictionary = getLocalization(locale).common;
   const headerRef = useRef<HTMLDivElement>(null);
   const [sticky, setSticky] = useState(false);

--- a/libs/ui/src/lib/header/index.tsx
+++ b/libs/ui/src/lib/header/index.tsx
@@ -9,7 +9,7 @@ import { LogoLink } from "../logo";
 import MainMenu from "../main-menu";
 import SearchInput from "../search-input";
 import styles from "./header.module.scss";
-import { Profile } from "@fdk-frontend/libs/types/src";
+import { Profile } from "@fdk-frontend/types";
 
 export type HeaderProps = {
   locale: LocaleCodes;

--- a/libs/ui/src/lib/internal-link/index.tsx
+++ b/libs/ui/src/lib/internal-link/index.tsx
@@ -15,7 +15,8 @@ export type InternalLinkProps = Omit<LinkProps, "children"> &
   PropsWithChildren & {
     entity?: SearchObject | Dataset;
     locale?: LocaleCodes;
-    profile?: Profile;
+    profile: Profile;
+    baseUri: string;
   };
 
 const InternalLink = ({
@@ -23,6 +24,7 @@ const InternalLink = ({
   entity,
   locale = i18n.defaultLocale,
   profile = "default",
+  baseUri,
   ...props
 }: InternalLinkProps) => {
   const dataset = entity as TransportDataset;
@@ -30,11 +32,10 @@ const InternalLink = ({
     return <Link {...props}>{children} </Link>;
   }
 
-  const defaultBaseUrl = "https://staging.fellesdatakatalog.digdir.no"; // TODO: actual method for this
   return (
     <ExternalLink
       {...props}
-      href={defaultBaseUrl + props.href}
+      href={baseUri + props.href}
       gateway
     >
       {children}

--- a/libs/ui/src/lib/internal-link/index.tsx
+++ b/libs/ui/src/lib/internal-link/index.tsx
@@ -23,12 +23,12 @@ const InternalLink = ({
   children,
   entity,
   locale = i18n.defaultLocale,
-  profile = "default",
+  profile = "data.norge",
   baseUri,
   ...props
 }: InternalLinkProps) => {
   const dataset = entity as TransportDataset;
-  if (!(profile === "transportportal") || (profile === "transportportal" && dataset?.isRelatedToTransportportal)) {
+  if (profile !== "transportportal" || dataset?.isRelatedToTransportportal) {
     return <Link {...props}>{children}</Link>;
   }
 

--- a/libs/ui/src/lib/internal-link/index.tsx
+++ b/libs/ui/src/lib/internal-link/index.tsx
@@ -3,7 +3,7 @@
 import { type PropsWithChildren } from "react";
 import { Link, type LinkProps } from "@digdir/designsystemet-react";
 import { i18n, type LocaleCodes } from "@fdk-frontend/localization";
-import { Dataset, EntityType, type SearchObject } from "@fellesdatakatalog/types";
+import { Dataset, type SearchObject } from "@fellesdatakatalog/types";
 import ExternalLink from "../external-link";
 import { type Profile } from "@fdk-frontend/types";
 

--- a/libs/ui/src/lib/internal-link/index.tsx
+++ b/libs/ui/src/lib/internal-link/index.tsx
@@ -29,7 +29,7 @@ const InternalLink = ({
 }: InternalLinkProps) => {
   const dataset = entity as TransportDataset;
   if (!(profile === "transportportal") || (profile === "transportportal" && dataset?.isRelatedToTransportportal)) {
-    return <Link {...props}>{children} </Link>;
+    return <Link {...props}>{children}</Link>;
   }
 
   return (

--- a/libs/ui/src/lib/internal-link/index.tsx
+++ b/libs/ui/src/lib/internal-link/index.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { type PropsWithChildren } from "react";
+import { Link, type LinkProps } from "@digdir/designsystemet-react";
+import { i18n, type LocaleCodes } from "@fdk-frontend/localization";
+import { Dataset, EntityType, type SearchObject } from "@fellesdatakatalog/types";
+import ExternalLink from "../external-link";
+import { type Profile } from "@fdk-frontend/types";
+
+interface TransportDataset extends SearchObject {
+  isRelatedToTransportportal?: boolean;
+}
+
+export type InternalLinkProps = Omit<LinkProps, "children"> &
+  PropsWithChildren & {
+    entity?: SearchObject | Dataset;
+    locale?: LocaleCodes;
+    profile?: Profile;
+  };
+
+const InternalLink = ({
+  children,
+  entity,
+  locale = i18n.defaultLocale,
+  profile = "default",
+  ...props
+}: InternalLinkProps) => {
+  const dataset = entity as TransportDataset;
+  if (!(profile === "transportportal") || (profile === "transportportal" && dataset?.isRelatedToTransportportal)) {
+    return <Link {...props}>{children} </Link>;
+  }
+
+  const defaultBaseUrl = "https://staging.fellesdatakatalog.digdir.no"; // TODO: actual method for this
+  return (
+    <ExternalLink
+      {...props}
+      href={defaultBaseUrl + props.href}
+      gateway
+    >
+      {children}
+    </ExternalLink>
+  );
+};
+
+export default InternalLink;

--- a/libs/ui/src/lib/layouts/normal-layout/index.tsx
+++ b/libs/ui/src/lib/layouts/normal-layout/index.tsx
@@ -3,7 +3,7 @@ import { type RootLayoutProps } from "../root-layout";
 import HeaderLayout from "../header-layout";
 import FooterLayout from "../footer-layout";
 import FeedbackBanner from "../../feedback-banner";
-import { Profile } from "@fdk-frontend/libs/types/src";
+import { Profile } from "@fdk-frontend/types";
 
 type NormalLayoutProps = RootLayoutProps & {
   profile?: Profile;

--- a/libs/ui/src/lib/layouts/normal-layout/index.tsx
+++ b/libs/ui/src/lib/layouts/normal-layout/index.tsx
@@ -3,10 +3,10 @@ import { type RootLayoutProps } from "../root-layout";
 import HeaderLayout from "../header-layout";
 import FooterLayout from "../footer-layout";
 import FeedbackBanner from "../../feedback-banner";
-import { type HeaderProfile } from "../../header";
+import { Profile } from "@fdk-frontend/libs/types/src";
 
 type NormalLayoutProps = RootLayoutProps & {
-  profile?: HeaderProfile;
+  profile?: Profile;
 };
 
 const NormalLayout = async ({ children, params, profile }: PropsWithChildren & NormalLayoutProps) => {

--- a/libs/ui/src/lib/logo/index.tsx
+++ b/libs/ui/src/lib/logo/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import cn from "classnames";
 import { Link, type LinkProps } from "@digdir/designsystemet-react";
 
@@ -7,11 +6,10 @@ import DigdirLogo from "../core/svg/digdir-logo";
 import DpgBadge from "../core/svg/dpg-badge";
 
 import styles from "./logo.module.scss";
-
-export type LogoProfile = "default" | "transportportal";
+import { Profile } from "@fdk-frontend/libs/types/src";
 
 export type LogoProps = {
-  profile?: LogoProfile;
+  profile?: Profile;
   tagline?: string;
 };
 

--- a/libs/ui/src/lib/logo/index.tsx
+++ b/libs/ui/src/lib/logo/index.tsx
@@ -6,7 +6,7 @@ import DigdirLogo from "../core/svg/digdir-logo";
 import DpgBadge from "../core/svg/dpg-badge";
 
 import styles from "./logo.module.scss";
-import { Profile } from "@fdk-frontend/libs/types/src";
+import { Profile } from "@fdk-frontend/types";
 
 export type LogoProps = {
   profile?: Profile;

--- a/libs/ui/src/lib/logo/index.tsx
+++ b/libs/ui/src/lib/logo/index.tsx
@@ -13,7 +13,7 @@ export type LogoProps = {
   tagline?: string;
 };
 
-const Logo = ({ profile = "default", tagline }: LogoProps) =>
+const Logo = ({ profile = "data.norge", tagline }: LogoProps) =>
   profile === "transportportal" ? (
     <div className={styles.transportportalLogo}>
       <span className={styles.transportportalWordmark}>Transportportal.no</span>

--- a/libs/ui/src/lib/main-menu/index.tsx
+++ b/libs/ui/src/lib/main-menu/index.tsx
@@ -10,10 +10,11 @@ import ConsentReopenButton from "../consent/consent-reopen-button";
 import styles from "./main-menu.module.scss";
 import GithubLogo from "./images/github-logo";
 import getMainMenuData from "./data";
+import { Profile } from "@fdk-frontend/libs/types/src";
 
 type MainMenuProps = React.HTMLAttributes<HTMLDivElement> & {
   locale: LocaleCodes;
-  profile?: "default" | "transportportal";
+  profile?: Profile;
   motionProps?: any;
 };
 
@@ -156,105 +157,105 @@ const MainMenu = ({ className, locale, profile = "default", motionProps = {}, ..
               variants={animations.section}
               aria-labelledby="mainMenu.catalogs.heading"
             >
-          <Heading
-            className={styles.linkSectionHeader}
-            level={2}
-            data-size="sm"
-            id="mainMenu.catalogs.heading"
-          >
-            {dictionary.mainMenu.catalogs.heading}
-          </Heading>
-          <ul>
-            {data.catalogs.map((item) => (
-              <li key={item.key}>
-                <Link
-                  className={styles.iconLink}
-                  href={item.href}
-                >
-                  {item.title}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </MotionNav>
-        <MotionNav
-          className={styles.linkSection}
-          variants={animations.section}
-          aria-labelledby="mainMenu.help.heading"
-        >
-          <Heading
-            className={styles.linkSectionHeader}
-            level={2}
-            data-size="sm"
-            id="mainMenu.help.heading"
-          >
-            {dictionary.mainMenu.help.heading}
-          </Heading>
-          <ul>
-            {data.help.map((item) => (
-              <li key={item.href}>
-                <Link href={item.href}>{item.title}</Link>
-              </li>
-            ))}
-          </ul>
-        </MotionNav>
-        <MotionNav
-          className={styles.linkSection}
-          variants={animations.section}
-          aria-labelledby="mainMenu.tools.heading"
-        >
-          <Heading
-            className={styles.linkSectionHeader}
-            level={2}
-            data-size="sm"
-            id="mainMenu.tools.heading"
-          >
-            {dictionary.mainMenu.tools.heading}
-          </Heading>
-          <ul>
-            {data.tools.map((item) => (
-              <li key={item.href}>
-                <Link href={item.href}>{item.title}</Link>
-              </li>
-            ))}
-          </ul>
-        </MotionNav>
-        <MotionNav
-          className={styles.linkSection}
-          variants={animations.section}
-          aria-labelledby="mainMenu.about.heading"
-        >
-          <Heading
-            className={styles.linkSectionHeader}
-            level={2}
-            data-size="sm"
-            id="mainMenu.about.heading"
-          >
-            {dictionary.mainMenu.about.heading}
-          </Heading>
-          <ul>
-            {data.about.map((item) => (
-              <li key={item.href ?? item.title}>
-                {item.consent ? (
-                  <ConsentReopenButton
-                    locale={locale}
-                    label={item.title}
-                  />
-                ) : item.external ? (
-                  <ExternalLink
-                    href={item.href}
-                    locale={locale}
-                  >
-                    {item.href && isGithubUrl(item.href) && <GithubLogo style={{ marginRight: "0.125em" }} />}
-                    {item.title}
-                  </ExternalLink>
-                ) : (
-                  <Link href={item.href}>{item.title}</Link>
-                )}
-              </li>
-            ))}
-          </ul>
-        </MotionNav>
+              <Heading
+                className={styles.linkSectionHeader}
+                level={2}
+                data-size="sm"
+                id="mainMenu.catalogs.heading"
+              >
+                {dictionary.mainMenu.catalogs.heading}
+              </Heading>
+              <ul>
+                {data.catalogs.map((item) => (
+                  <li key={item.key}>
+                    <Link
+                      className={styles.iconLink}
+                      href={item.href}
+                    >
+                      {item.title}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </MotionNav>
+            <MotionNav
+              className={styles.linkSection}
+              variants={animations.section}
+              aria-labelledby="mainMenu.help.heading"
+            >
+              <Heading
+                className={styles.linkSectionHeader}
+                level={2}
+                data-size="sm"
+                id="mainMenu.help.heading"
+              >
+                {dictionary.mainMenu.help.heading}
+              </Heading>
+              <ul>
+                {data.help.map((item) => (
+                  <li key={item.href}>
+                    <Link href={item.href}>{item.title}</Link>
+                  </li>
+                ))}
+              </ul>
+            </MotionNav>
+            <MotionNav
+              className={styles.linkSection}
+              variants={animations.section}
+              aria-labelledby="mainMenu.tools.heading"
+            >
+              <Heading
+                className={styles.linkSectionHeader}
+                level={2}
+                data-size="sm"
+                id="mainMenu.tools.heading"
+              >
+                {dictionary.mainMenu.tools.heading}
+              </Heading>
+              <ul>
+                {data.tools.map((item) => (
+                  <li key={item.href}>
+                    <Link href={item.href}>{item.title}</Link>
+                  </li>
+                ))}
+              </ul>
+            </MotionNav>
+            <MotionNav
+              className={styles.linkSection}
+              variants={animations.section}
+              aria-labelledby="mainMenu.about.heading"
+            >
+              <Heading
+                className={styles.linkSectionHeader}
+                level={2}
+                data-size="sm"
+                id="mainMenu.about.heading"
+              >
+                {dictionary.mainMenu.about.heading}
+              </Heading>
+              <ul>
+                {data.about.map((item) => (
+                  <li key={item.href ?? item.title}>
+                    {item.consent ? (
+                      <ConsentReopenButton
+                        locale={locale}
+                        label={item.title}
+                      />
+                    ) : item.external ? (
+                      <ExternalLink
+                        href={item.href}
+                        locale={locale}
+                      >
+                        {item.href && isGithubUrl(item.href) && <GithubLogo style={{ marginRight: "0.125em" }} />}
+                        {item.title}
+                      </ExternalLink>
+                    ) : (
+                      <Link href={item.href}>{item.title}</Link>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </MotionNav>
           </>
         )}
       </div>

--- a/libs/ui/src/lib/main-menu/index.tsx
+++ b/libs/ui/src/lib/main-menu/index.tsx
@@ -20,7 +20,7 @@ type MainMenuProps = React.HTMLAttributes<HTMLDivElement> & {
 
 const MotionNav: ForwardRefComponent<any, any> = motion.nav;
 
-const MainMenu = ({ className, locale, profile = "default", motionProps = {}, ...rest }: MainMenuProps) => {
+const MainMenu = ({ className, locale, profile = "data.norge", motionProps = {}, ...rest }: MainMenuProps) => {
   const dictionary = getLocalization(locale).common;
   const data = getMainMenuData(dictionary, locale);
 

--- a/libs/ui/src/lib/main-menu/index.tsx
+++ b/libs/ui/src/lib/main-menu/index.tsx
@@ -10,7 +10,7 @@ import ConsentReopenButton from "../consent/consent-reopen-button";
 import styles from "./main-menu.module.scss";
 import GithubLogo from "./images/github-logo";
 import getMainMenuData from "./data";
-import { Profile } from "@fdk-frontend/libs/types/src";
+import { Profile } from "@fdk-frontend/types";
 
 type MainMenuProps = React.HTMLAttributes<HTMLDivElement> & {
   locale: LocaleCodes;

--- a/libs/utils/src/lib/profile.ts
+++ b/libs/utils/src/lib/profile.ts
@@ -1,6 +1,5 @@
 import { headers } from "next/headers";
-
-export type Profile = "default" | "transportportal";
+import { type Profile } from "@fdk-frontend/types";
 
 const transportportalHosts = (process.env.TRANSPORTPORTAL_HOSTS ?? "data.transportportal.no,transportportal.no")
   .split(",")
@@ -16,5 +15,5 @@ export const getProfile = async (): Promise<Profile> => {
 
   const host = (headerList.get("x-forwarded-host") ?? headerList.get("host") ?? "").split(":")[0];
 
-  return transportportalHosts.includes(host) ? "transportportal" : "default";
+  return transportportalHosts.includes(host) ? "transportportal" : "data.norge";
 };


### PR DESCRIPTION
fixes https://github.com/Informasjonsforvaltning/fdk-frontend/issues/987

- add InternalLink component. Component provides correct links based on if profile is set to transportportal or not. If profile is transportportal, links leading to data.norge pages will go through the leaving gateway, like external links